### PR TITLE
Update WinMSSQL.py to handle default zDBInstances of "MSSQLSERVER;"

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinMSSQL.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinMSSQL.py
@@ -56,9 +56,10 @@ class WinMSSQL(WinRMPlugin):
                 arrPassword = dbinstancepassword.split(';')
                 i = 0
                 for instance in arrInstance:
-                    dbuser, dbpass = arrPassword[i].split(':', 1)
-                    i = i + 1
-                    dblogins[instance] = {'username': dbuser, 'password': dbpass}
+                    if instance and len(arrPassword) > i:
+                        dbuser, dbpass = arrPassword[i].split(':', 1)
+                        i = i + 1
+                        dblogins[instance] = {'username': dbuser, 'password': dbpass}
             else:
                 arrInstance = dbinstance.split(';')
                 for instance in arrInstance:

--- a/ZenPacks/zenoss/Microsoft/Windows/utils.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/utils.py
@@ -86,9 +86,10 @@ def parseDBUserNamePass(dbinstances='', dbinstancespassword=''):
         arrPassword = dbinstancespassword.split(';')
         i = 0
         for instance in arrInstance:
-            dbuser, dbpass = arrPassword[i].split(':')
-            i = i + 1
-            dblogins[instance] = {'username': dbuser, 'password': dbpass}
+            if instance and len(arrPassword) > i:
+                dbuser, dbpass = arrPassword[i].split(':')
+                i = i + 1
+                dblogins[instance] = {'username': dbuser, 'password': dbpass}
     else:
         dblogins['MSSQLSERVER'] = {'username': 'sa', 'password': ''}
 


### PR DESCRIPTION
Cheap fix for the default value of zDBInstances (MSSQLSERVER;) causing the "Error parsing..." message to be thrown.  2nd iteration of instance throws the exception since arrPassword at index 1 is also an empty string.  Actually, now that I think about it, might want to change "if instance:" to "if instance and arrPassword[i]" although that is checked in the parent if statement to some degree.  Anyway, up to you guys :)

``` python
>>> dbinstance = 'MSSQLSERVER;'
>>> arrInstance = dbinstance.split(';')
>>> print arrInstance
['MSSQLSERVER', '']
>>> arrPassword = 'sa:test;'
>>> dbuser, dbpass = arrPassword[1].split(':', 1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: need more than 1 value to unpack
```

LOVE the new editor in GitHub!!!!
