### PR TITLE
Fix for ZEN-10572

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinCluster.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinCluster.py
@@ -44,10 +44,8 @@ class WinCluster(WinRMPlugin):
         pscommand = "powershell -NoLogo -NonInteractive -NoProfile " \
             "-OutputFormat TEXT -Command "
 
-        psHostCommands = []
-        psHostCommands.append("$Host.UI.RawUI.BufferSize = New-Object Management.Automation.Host.Size (512, 512);")
-
         psClusterCommands = []
+        psClusterCommands.append("$Host.UI.RawUI.BufferSize = New-Object Management.Automation.Host.Size (512, 512);")
         psClusterCommands.append("import-module failoverclusters;")
 
         psClusterHosts = []
@@ -56,7 +54,7 @@ class WinCluster(WinRMPlugin):
 
         command = "{0} \"& {{{1}}}\"".format(
             pscommand,
-            ''.join(psHostCommands + psClusterCommands + psClusterHosts))
+            ''.join(psClusterCommands + psClusterHosts))
 
         clusternodes = winrs.run_command(command)
         clusternode = yield clusternodes


### PR DESCRIPTION
The powershell command was putting a carriage return in returned data which caused
the results to shift. The end result was index errors and corrupted data.
