### PR TITLE
Fixes ZEN-15493

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/Interface.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/Interface.py
@@ -21,6 +21,11 @@ class Interface(IpInterface):
             'teaminterfaces')),
         )
 
+    def __init__(self, *args, **kwargs):
+        super(IpInterface, self).__init__(*args, **kwargs)
+        # Default to False for monitoring
+        self.monitor = False
+
     def monitored(self):
         '''
         Return the monitored status of this component.
@@ -28,7 +33,7 @@ class Interface(IpInterface):
         Overridden from IpInterface to prevent monitoring
         administratively down interfaces.
         '''
-        return self.monitor and self.adminStatus == 1
+        return self.monitor
 
     def getIconPath(self):
         '''

--- a/ZenPacks/zenoss/Microsoft/Windows/browser/resources/js/device.js
+++ b/ZenPacks/zenoss/Microsoft/Windows/browser/resources/js/device.js
@@ -842,8 +842,6 @@ ZC.WinTeamInterfacePanel = Ext.extend(ZC.WINComponentGridPanel, {
                 {name: 'network'},//, mapping:'network.uid'},
                 {name: 'macaddress'},
                 {name: 'usesMonitorAttribute'},
-                {name: 'operStatus'},
-                {name: 'adminStatus'},
                 {name: 'nic_count'},
                 {name: 'status'},
                 {name: 'monitor'},
@@ -900,18 +898,8 @@ ZC.WinTeamInterfacePanel = Ext.extend(ZC.WINComponentGridPanel, {
             },{
                 id: 'status',
                 dataIndex: 'status',
-                header: _t('Monitored'),
+                header: _t('Status'),
                 renderer: Zenoss.render.pingStatus,
-                width: 80
-            },{
-                id: 'operStatus',
-                dataIndex: 'operStatus',
-                header: _t('Operational Status'),
-                width: 110
-            },{
-                id: 'adminStatus',
-                dataIndex: 'adminStatus',
-                header: _t('Admin Status'),
                 width: 80
             },{
                 id: 'monitored',
@@ -950,8 +938,6 @@ ZC.WindowsInterfacePanel = Ext.extend(ZC.WINComponentGridPanel, {
                 {name: 'network'},//, mapping:'network.uid'},
                 {name: 'macaddress'},
                 {name: 'usesMonitorAttribute'},
-                {name: 'operStatus'},
-                {name: 'adminStatus'},
                 {name: 'status'},
                 {name: 'monitor'},
                 {name: 'monitored'},
@@ -1002,18 +988,8 @@ ZC.WindowsInterfacePanel = Ext.extend(ZC.WINComponentGridPanel, {
             },{
                 id: 'status',
                 dataIndex: 'status',
-                header: _t('Monitored'),
+                header: _t('Status'),
                 renderer: Zenoss.render.pingStatus,
-                width: 80
-            },{
-                id: 'operStatus',
-                dataIndex: 'operStatus',
-                header: _t('Operational Status'),
-                width: 110
-            },{
-                id: 'adminStatus',
-                dataIndex: 'adminStatus',
-                header: _t('Admin Status'),
                 width: 80
             },{
                 id: 'monitored',

--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/Interfaces.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/Interfaces.py
@@ -272,16 +272,6 @@ class Interfaces(WinRMPlugin):
             int_om.type = inter.AdapterType
 
             try:
-                int_om.adminStatus = int(lookup_operstatus(inter.NetEnabled))
-            except (AttributeError):
-                int_om.adminStatus = 0
-                # Workaround for 2003 / XP
-                if inter.NetConnectionStatus in ENABLED_NC_STATUSES:
-                    int_om.adminStatus = 1
-
-            int_om.operStatus = AVAILABILITY.get(inter.Availability, 0)
-
-            try:
                 int_om.ifindex = inter.InterfaceIndex
             except (AttributeError, TypeError):
                 int_om.ifindex = inter.Index
@@ -443,17 +433,6 @@ def standardizeInstance(rawInstance):
     unfriendly characters with one that Windows expects.
     """
     return rawInstance.translate(_transTable)
-
-
-def lookup_operstatus(value):
-    """
-    Check operational status.  If None, assume LPU and ok to monitor
-    """
-    if value == 'true' or value == None:
-        return 1
-    else:
-        return 2
-
 
 def filter_maps(objectmaps, device, log):
     '''


### PR DESCRIPTION
Admin status and Oper status don't really translate to Windows world, so we're removing them.  netEnabled is inaccessible to LPU so we couldn't use it.  Default monitoring to False so a user can choose which interfaces to monitor.  The 'Monitored' column was mislabeled, should be 'Status'.
