### PR TITLE
ZEN-13447

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
@@ -518,6 +518,9 @@ class ShellDataSourcePlugin(PythonDataSourcePlugin):
         contexttitle = context.title
 
         servername = context.device().title
+        if contexttitle == servername and resource == 'get-clustergroup':
+            contexttitle = ''
+
         if len(servername) == 0:
             servername = ''
 


### PR DESCRIPTION
get-clustergroup -name clusterservername is not valid.  We can skip this call if we set contexttitle to "
