### PR TITLE
Fixes ZEN-15726

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinMSSQL.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinMSSQL.py
@@ -67,7 +67,6 @@ class SQLCommander(object):
                     $local_instances += $_;
                 };
             };
-            break;
         };
         $local_instances | % {write-host \"instances:\"$_};
     '''


### PR DESCRIPTION
We may have a need to check in both of the registry subkeys.  'SOFTWARE\Microsoft\Microsoft SQL Server' may exist and not have the instances listed so we'll need to look in the wow6432node as well.
