### PR TITLE
Fixes ZEN-15793

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
@@ -606,7 +606,7 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
                 False,
                 logging.WARN,
                 "receive failure on {}: {}"
-                .format(self.config.id, failure))
+                .format(self.config.id, e))
 
         if self.data_deferred and not self.data_deferred.called:
             self.data_deferred.errback(failure)


### PR DESCRIPTION
when formatting 'failure' it prints out the entire traceback.  leads to confusion so we'll just print out e which will only show the error.