### PR TITLE
Feature/zen 16224

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/Software.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/Software.py
@@ -17,7 +17,6 @@ possibly causing other problems to appear.
 import re
 from DateTime import DateTime
 from Products.DataCollector.plugins.DataMaps import MultiArgs
-from Products.ZenModel.ZenDate import ZenDate
 
 from ZenPacks.zenoss.Microsoft.Windows.modeler.WinRMPlugin import WinRMPlugin
 

--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/Software.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/Software.py
@@ -15,7 +15,9 @@ Querying Win32_Product causes Windows installer to run a consistency check,
 possibly causing other problems to appear.
 '''
 import re
+from DateTime import DateTime
 from Products.DataCollector.plugins.DataMaps import MultiArgs
+from Products.ZenModel.ZenDate import ZenDate
 
 from ZenPacks.zenoss.Microsoft.Windows.modeler.WinRMPlugin import WinRMPlugin
 
@@ -68,18 +70,12 @@ class Software(WinRMPlugin):
                     om.setProductKey = MultiArgs(softwareDict['DisplayName'], softwareDict['Vendor'])
 
                     if softwareDict['InstallDate'] is not '':
-                        installdate = softwareDict['InstallDate']
-                        datematch = re.match('(\d{2}/\d{2}/\d{4})', installdate)
-                        if datematch:
-                            om.setInstallDate = '{0}/{1}/{2} 00:00:00'.format(
-                               softwareDict['InstallDate'][6:10],
-                               softwareDict['InstallDate'][3:5],
-                               softwareDict['InstallDate'][0:2])
-                        else:
-                            om.setInstallDate = '{0}/{1}/{2} 00:00:00'.format(
-                               softwareDict['InstallDate'][0:4],
-                               softwareDict['InstallDate'][4:6],
-                               softwareDict['InstallDate'][6:8])
+                        try:
+                            installDate = DateTime(softwareDict['InstallDate'])
+                            om.setInstallDate = '{0} 00:00:00'.format(installDate.Date())
+                        except:
+                            # Date is unreadable, leave blank
+                            pass
                     rm.append(om)
                     
                 except (KeyError, ValueError):


### PR DESCRIPTION
Fix traceback when date is in different format.  Use DateTime to format date correctly.  Ignore unreadable date.