### PR TITLE
Fixes ZEN-15911

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/EventLogDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/EventLogDataSource.py
@@ -238,8 +238,9 @@ class EventLogQuery(object):
             };
             
             <# Remove control characters #>
-            $s = $s.replace("`r`n"," ");
+            $s = $s.replace("`r","").replace("`n"," ");
             $s = $s.replace('"', '\"').replace("\'","'");
+            $s = $s.replace("`t", " ");
             <# Hope remaining escapes are the actual slash char #>
             return "$($s)".replace('\','\\').trim();
         };


### PR DESCRIPTION
Fix replacement of newline/carriage return +newlines.  Add tabs to be replaced.  There are other escape characters in powershell, but do not see any of the others being used.  Things like alert bell, backspace, vertical tab wouldn't be used in an event message.

https://jira.zenoss.com/browse/ZEN-15911