### PR TITLE
Fixes ZEN-16834

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/browser/resources/js/global.js
+++ b/ZenPacks/zenoss/Microsoft/Windows/browser/resources/js/global.js
@@ -77,6 +77,7 @@ Zenoss.form.WinRSStrategy = Ext.extend(Ext.Panel, {
             },{
                 xtype: 'textarea',
                 width: 300,
+                height: 200,
                 fieldLabel: _t('Script'),
                 name: 'script',
                 ref: 'ScriptTextarea',


### PR DESCRIPTION
When entering powershell script, variables are denoted using a single '$'.  We'll log error message and send event that script may be malformed.  Also, when creating the pscommand, we were formatting the string twice, resulting in a KeyError if there was an assignment operator('=') in the script.  Fixed the event message to make more sense.