### PR TITLE
Update for ZEN-17059

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/Device.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/Device.py
@@ -160,8 +160,6 @@ class Device(BaseDevice):
                     continue
             templates.append(template)
 
-        self.zDeviceTemplates = [template.id for template in templates]
-
         return templates
 
 


### PR DESCRIPTION
Do not need to update zDeviceTemplates as this creates a local template.  There is some confusion around getRRDTemplates and the bind templates dialog.