### PR TITLE
Fixes ZEN-17308

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/info.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/info.py
@@ -156,7 +156,7 @@ class WinServiceInfo(WinComponentInfo):
             self._object.description)
 
     def getMonitor(self):
-        monitorstatus = self._object.getMonitor()
+        monitorstatus = self._object.monitored()
         return monitorstatus
 
     def setMonitor(self, value):


### PR DESCRIPTION
should be calling WinService.monitored() instead of getMonitor()