### PR TITLE
Fixes ZEN-17318

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -989,6 +989,7 @@ Installing this ZenPack will add the following items to your Zenoss system.
 * Fix No event generated for failed modeling of Windows Device (ZEN-16195)
 * Fix WinRM ZenPack missing thresholds which should be available out-of-box (ZEN-16024)
 * Fix Microsoft.Windows - link is absent on Owner Node for Cluster/Services and Resources components (ZEN-15784)
+* Fix New Windows ZenPack - Working with templates throws 'NoneType' exception (ZEN-17318)
 
 ;2.3.2
 * Fix traceback during Software modeling (ZEN-16224)

--- a/README.mediawiki
+++ b/README.mediawiki
@@ -289,6 +289,40 @@ The following metrics are collected directly via WMI.
 {{note}} IIS 6 Management compatibility role no longer needs to be installed on the server side in order to use the IIS Sites component.
 {{note}} IIS Management Scripts and Tools role needs to be installed on the server side in order to use the IIS Sites component.
 
+=== SQL Server ===
+The following performance counters are monitored via Powershell script per database:
+
+\SQLServer:Databases(<dbname>)\Active Transactions
+\SQLServer:Databases(<dbname>)\Backup/Restore Throughput/sec
+\SQLServer:Databases(<dbname>)\Bulk Copy Rows/sec
+\SQLServer:Databases(<dbname>)\Bulk Copy Throughput/sec
+\SQLServer:Databases(<dbname>)\Cache Entries Count
+\SQLServer:Databases(<dbname>)\Cache Entries Pinned Count
+\SQLServer:Databases(<dbname>)\Cache Hit Ratio
+\SQLServer:Databases(<dbname>)\Cache Hit Ratio Base
+\SQLServer:Databases(<dbname>)\DBCC Logical Scan Bytes/sec
+\SQLServer:Databases(<dbname>)\Data File(s) Size (KB)
+\SQLServer:Databases(<dbname>)\Log Bytes Flushed/sec
+\SQLServer:Databases(<dbname>)\Log Cache Hit Ratio
+\SQLServer:Databases(<dbname>)\Log Cache Hit Ratio Base
+\SQLServer:Databases(<dbname>)\Log Cache Reads/sec
+\SQLServer:Databases(<dbname>)\Log File(s) Size (KB)
+\SQLServer:Databases(<dbname>)\Log File(s) Used Size (KB)
+\SQLServer:Databases(<dbname>)\Log Flush Wait Time
+\SQLServer:Databases(<dbname>)\Log Flush Waits/sec
+\SQLServer:Databases(<dbname>)\Log Flushes/sec
+\SQLServer:Databases(<dbname>)\Log Growths
+\SQLServer:Databases(<dbname>)\Percent Log Used
+\SQLServer:Databases(<dbname>)\Log Shrinks
+\SQLServer:Databases(<dbname>)\Log Truncations
+\SQLServer:Databases(<dbname>)\Percent Log Used
+\SQLServer:Databases(<dbname>)\Repl. Pending Xacts
+\SQLServer:Databases(<dbname>)\Repl. Trans. Rate
+\SQLServer:Databases(<dbname>)\Shrink Data Movement Bytes/sec
+\SQLServer:Databases(<dbname>)\Transactions/sec
+
+You can enable/disable any of these or change the cycle time by editing the WinDatabase monitoring template.
+
 === Event Management ===
 Events could be collected from the Windows event log using a WinRM subscription. Events collected through this mechanism will be timestamped based on the time they occurred within the Windows event log. Not by the time at which they were collected.
 

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ServiceDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ServiceDataSource.py
@@ -84,14 +84,14 @@ class ServiceDataSource(PythonDataSource):
     def getAffectedServices(self):
         """Generate WinService instances to which this datasource is bound."""
         template = self.rrdTemplate().primaryAq()
-        deviceclass = template.deviceClass().primaryAq()
+        deviceclass = template.deviceClass()
         # Template is local to a specific service.
         if deviceclass is None:
             yield template.getPrimaryParent()
 
         # Template is in a device class.
         else:
-            results = ICatalogTool(deviceclass).search(WinService)
+            results = ICatalogTool(deviceclass.primaryAq()).search(WinService)
             for result in results:
                 try:
                     service = result.getObject()


### PR DESCRIPTION
When editing a local copy of service template, there is no deviceclass.

also update the readme