### PR TITLE
Fixes ZEN-17535

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -522,7 +522,7 @@ The [[#Adding a Windows Device]] steps shown above are for the simplest case of 
 : This property is currently used and reserved for future use when keytab files are supported.
 
 ;zDBInstances
-: This setting is only relevant when the ''zenoss.winrm.WinMSSQL'' modeler plugin is enabled. Multiple instances can be specified to monitor multiple SQL Server instances per server. The default instance is ''MSSQLSERVER''. Fill in the user and password to use SQL authentication. Leave the user and password blank to use Windows authentication.
+: This setting is only relevant when the ''zenoss.winrm.WinMSSQL'' modeler plugin is enabled. Multiple instances can be specified to monitor multiple SQL Server instances per server using different credentials. The default instance is ''MSSQLSERVER''. Fill in the user and password to use SQL authentication. Leave the user and password blank to use Windows authentication.  The default ''MSSQLSERVER'' credentials will be used for all instances not specified.
 
 {{note}} HyperV and MicrosoftWindows ZenPacks share krb5.conf file as well as tools for sending/receiving data. Therefore if either HyperV or Windows device has a correct zWinKDC setting, it will be used for another device as well.
 
@@ -603,10 +603,12 @@ SQL Server failover cluster instances can be modeled/monitored within cluster de
 
 : Use the following steps to model/monitor SQL Server instances:
 # Create a device in ''Server/Microsoft/Windows'' device class if you intend to model local SQL instances, or in ''Server/Microsoft/Cluster'' device class if you intend to model failover cluster instances.
-# Specify the instance names to be modeled in ''zDBInstances'' zProperty. Provide user names and passwords if SQL Server Authentication is to be used.
+# Optionally specify the instance names to be modeled in ''zDBInstances'' zProperty. Provide user names and passwords if SQL Server Authentication is to be used.
 # Enable ''zenoss.winrm.WinMSSQL'' modeler plugin.
 # Remodel device.
 
+{{note}} For best performance with large numbers of databases, limit the number of instances specified in the zDBInstances property.  The ZenPack will poll data for each item listed in zDBInstances.
+ 
 === Working with WinCommand Notification Action ===
 
 This ZenPack adds a new event notification action that can be used by the zenactiond daemon to allow an arbitrary command to be executed on the remote windows machine.
@@ -968,6 +970,9 @@ Installing this ZenPack will add the following items to your Zenoss system.
 * ClusterResource (in /Server/Microsoft/Cluster)
 
 == Changes ==
+
+;2.4.2
+* Fix poor performance of SQL Server monitoring of large number of databases. (ZEN-17535)
 
 ;2.4.1
 * Fixed Data from MS Exchange monitoring template is written to MSExchangeIS service component (ZEN-17566)


### PR DESCRIPTION
Allow individual zDBInstances to work, but they are no longer required.  Also, build valuemap correctly so we return the correct values for specific databases in a specific instance