### PR TITLE
Fixes ZEN-18811

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinMSSQL.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinMSSQL.py
@@ -221,7 +221,10 @@ class WinMSSQL(WinRMPlugin):
                 sqlserver = '{0}\{1}'.format(sqlhostname, instance)
 
             if isCluster:
-                sqlserver = '{0}\{1}'.format(sql_server.strip(), instance)
+                if instance == 'MSSQLSERVER':
+                    sqlserver = sql_server.strip()
+                else:
+                    sqlserver = '{0}\{1}'.format(sql_server.strip(), instance)
 
             # Look for specific instance creds first
             try:

--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinMSSQL.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinMSSQL.py
@@ -509,8 +509,7 @@ class WinMSSQL(WinRMPlugin):
 def check_username(databases, instance, log):
     stderr = ''.join(databases.stderr)
     stdout = ' '.join(databases.stdout)
-    if not databases.stdout and\
-        (('Exception calling "Connect" with "0" argument(s): '
+    if (('Exception calling "Connect" with "0" argument(s): '
             '"Failed to connect to server'
             in stderr) or (
             'The following exception was thrown when trying to enumerate the '


### PR DESCRIPTION
when using the default MSSQLSERVER instance we need only supply the server name.  also, stdout will never be empty so we need always check stderr