### PR TITLE
Fixes ZEN-18533

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinMSSQL.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinMSSQL.py
@@ -171,6 +171,8 @@ class WinMSSQL(WinRMPlugin):
         for serverconfig in instances.stdout:
             key, value = serverconfig.split(':', 1)
             serverlist = []
+            if not value:
+                continue
             if key in server_config:
                 serverlist = server_config[key]
                 serverlist.append(value.strip())


### PR DESCRIPTION
instances.stdout should contain something like this:

{ instances: 'SQL1', hostname: 'server.name.loc' }

if sql server is not installed, we'll see:

{ instances: , hostname: 'server.name.loc' }

need to skip instances so that we can log no sql server installed and return without further processing.