### PR TITLE
Fixes ZEN-18757

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/EventLogDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/EventLogDataSource.py
@@ -329,6 +329,9 @@ class EventLogQuery(object):
             
             [DateTime]$last_read = get-date;
             Set-Itemproperty -Path HKLM:\SOFTWARE\zenoss\logs -Name $eventid -Value ([String]$last_read);
+            if ($events -eq $null) {
+                return;
+            };
             if($events) {
 				[Array]::Reverse($events);
             };
@@ -346,7 +349,7 @@ class EventLogQuery(object):
             Invoke-Command $script;
             [System.Threading.Thread]::CurrentThread.CurrentCulture = $CurrentCulture;
         };
-        Use-en-US {get_new_recent_entries -logname %s -selector %s -max_age %s -eventid "%s"};
+        Use-en-US {get_new_recent_entries -logname "%s" -selector %s -max_age %s -eventid "%s"};
     '''
 
     def run(self, eventlog, selector, max_age, eventid):


### PR DESCRIPTION
check for empty events array before building json.  Also add quotes around logname in case of two or more word log names, such as "DNS Server"