### PR TITLE
Feature/services updates

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -559,7 +559,7 @@ See the following examples:
 # Select the ''/Server/Microsoft'' copy.
 # Choose ''View and Edit Details'' from the gear menu.
 # Change the template's name to ''WinRM''.
-# Change ''Start mode of service to monitor'' from 'None' to 'Auto' then click save.
+# Tick the ''Auto'' checkbox under ''Service Options'' and click save.
 
 ;Enable/Disable monitoring by default for the WinRM service for a select group of servers.
 # Create a new device class somewhere under ''/Server/Microsoft/Windows'' for the select group of servers.
@@ -570,19 +570,21 @@ See the following examples:
 # Choose ''View and Edit Details'' from the gear menu.
 # Change the template's name to ''WinRM'' then click submit.
 # Double-click to edit the ''DefaultService' datasource.
-# Change ''Start mode of service to monitor'' from 'None' to 'Auto' to enable or leave it as 'None' to disable monitoring by default then click save.
+# Tick/Untick the ''Auto'' checkbox under ''Service Options'' and click save.
 
 ;Enable monitoring of all services with a start mode of 'Auto'.
 # Navigate to Advanced -> Monitoring Templates.
 # Verify the list of templates is grouped by template.
 # Expand the ''WinService'' tree.
 # Select ''/Server/Microsoft''.
+# In the Data Sources pane, click the + button to add a new data source, give it a name, and choose Windows Service as the type.
 # Choose ''View and Edit Details'' from the Data Sources gear menu.
-# Change ''Start mode of service to monitor'' from 'None' to 'Auto' then click save.
+# Tick the ''Auto'' checkbox under ''Service Options'' and click save.
+# You can optionally exclude certain services to be monitored when selecting the ''Auto'', ''Manual'', and/or ''Disabled'' start mode(s) by entering a comma separated list of services.  These must be the service names and are case insensitive.
 
-{{note}} To enable monitoring by default of a service or services, you must choose a start mode other than 'None'.  Choosing 'None' disables monitoring by default.
+{{note}} To enable monitoring by default of a service or services, you must choose a start mode by ticking the appropriate box.  Unticking all three boxes disables monitoring by default.
 {{note}} When saving changes to a service template, the changes may take several minutes to propogate to all of your devices.
-{{note}} Do not change the datasource name of 'DefaultService'.  The WinService datasource depends on this name.
+{{note}} The WinService datasource no longer depends on the 'DefaultService' data source name.
 
 <br clear=all>
 

--- a/ZenPacks/zenoss/Microsoft/Windows/WinService.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/WinService.py
@@ -56,6 +56,12 @@ class WinService(OSComponent):
             pass
         return 'WinService'
 
+    def getMonitored(self, datasource):
+        for startmode in datasource.startmode.split(','):
+            if startmode in self.startmode.split(',') and \
+               self.servicename.lower() not in [service.strip() for service in datasource.exclusions.split(',')]:
+                return True
+
     def monitored(self):
         """Return True if this service should be monitored. False otherwise."""
 
@@ -68,11 +74,14 @@ class WinService(OSComponent):
         if template:
             datasource = template.datasources._getOb('DefaultService', None)
             if datasource:
-                for startmode in datasource.startmode.split(','):
-                    if startmode in self.startmode.split(','):
+                if self.getMonitored(datasource):
+                    return True
+            # 3 - Allow for other datasources to be specified.
+            for datasource in template.getRRDDataSources():
+                if datasource.id != 'DefaultService':
+                    if self.getMonitored(datasource):
                         return True
 
         return False
-
 
 InitializeClass(WinService)

--- a/ZenPacks/zenoss/Microsoft/Windows/browser/resources/js/global.js
+++ b/ZenPacks/zenoss/Microsoft/Windows/browser/resources/js/global.js
@@ -293,6 +293,7 @@ if (Ext.version === undefined) {
 
 Zenoss.form.StartModeGroup = Ext.extend(Ext.panel.Panel, {
          constructor: function(config) {
+             width = 300;
              var auto = false;
              if (config.record.startmode.indexOf('Auto') > -1) {
                  auto = true;
@@ -309,7 +310,9 @@ Zenoss.form.StartModeGroup = Ext.extend(Ext.panel.Panel, {
                  layout: 'fit',
                    listeners: {
                         afterrender: function() {
-                            this.setValue(config.record.startmode.split(','));
+                            if (config.record.startmode){
+                                this.setValue(config.record.startmode.split(','));
+                            }
                         },
                         scope: this
                  },
@@ -389,6 +392,42 @@ Zenoss.form.StartModeGroup = Ext.extend(Ext.panel.Panel, {
     }
 })();
 
+Ext.ComponentMgr.onAvailable('monitoredStartModes', function(){
+    var message = _t('This page has been deprecated in ZenPacks.zenoss.Microsoft.Windows.  Please use the WinService monitoring template.')
+    var dlg = new Zenoss.FormDialog({
+        title: _t('Windows Services'),
+        modal: true,
+        items: [ {
+                    xtype: 'label',
+                    text: message,
+                    ref: 'messagelabel'
+                },
+                {
+                    xtype: 'checkboxfield',
+                    boxLabel  : 'Check if you no longer want to see this message.',
+                    name      : 'hidemessage',
+                    inputValue: '1',
+                    id        : 'checkbox1',
+                    stateful: true,
+                    stateEvents: ['change'],
+                    getState: function() {
+                        return {checked: this.getValue()}
+                    },
+                    applyState: function(state){
+                        this.setValue(state.checked);
+                    }
+                }],
+        buttons: [
+                    {
+                        xtype: 'HideDialogButton',
+                        text: _t('OK'),
+                    }
+                ],
+    });
+    if (dlg.down('checkboxfield').getValue() == false){
+        dlg.show();
+    }
+});
 
 
 var DEVICE_SUMMARY_PANEL = 'deviceoverviewpanel_summary';

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ServiceDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ServiceDataSource.py
@@ -71,6 +71,7 @@ class ServiceDataSource(PythonDataSource):
     servicename = '${here/id}'
     alertifnot = 'Running'
     startmode = ''
+    exclusions = ''
 
     plugin_classname = ZENPACKID + \
         '.datasources.ServiceDataSource.ServicePlugin'
@@ -79,6 +80,7 @@ class ServiceDataSource(PythonDataSource):
         {'id': 'servicename', 'type': 'string'},
         {'id': 'alertifnot', 'type': 'string'},
         {'id': 'startmode', 'type': 'string'},
+        {'id': 'exclusions', 'type': 'string'},
     )
 
     def getAffectedServices(self):
@@ -121,8 +123,12 @@ class IServiceDataSourceInfo(IRRDDataSourceInfo):
             [STATE_RUNNING, STATE_STOPPED]),)
 
     startmode = schema.Text(
-        group=_t('Start Modes'),
+        group=_t('Service Options'),
         xtype='startmodegroup')
+
+    exclusions = schema.TextLine(
+        group=_t('Service Options'),
+        title=_t('Exclusions separated by commas'))
 
 
 class ServiceDataSourceInfo(RRDDataSourceInfo):
@@ -137,6 +143,7 @@ class ServiceDataSourceInfo(RRDDataSourceInfo):
     cycletime = ProxyProperty('cycletime')
     servicename = ProxyProperty('servicename')
     alertifnot = ProxyProperty('alertifnot')
+    exclusions = ProxyProperty('exclusions')
 
     def get_startmode(self):
         return self._object.startmode

--- a/ZenPacks/zenoss/Microsoft/Windows/migrate/MigrateServices.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/migrate/MigrateServices.py
@@ -1,0 +1,26 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2015, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+from Products.ZenModel.ZenPack import ZenPackMigration
+from Products.ZenModel.migrate.Migrate import Version
+from ZenPacks.zenoss.Microsoft.Windows.datasources.ServiceDataSource import ServiceDataSource
+
+class RemoveObjects(ZenPackMigration):
+    # Main class that contains the migrate() method.
+    # Note version setting.
+    version = Version(2, 4, 6)
+
+    def migrate(self, dmd):
+        organizer = dmd.Devices.getOrganizer('/Server/Microsoft')
+        if organizer:
+            for template in organizer.getRRDTemplates():
+                for ds in template.getRRDDataSources():
+                    if isinstance(ds, ServiceDataSource):
+                        if ds.startmode == 'Any':
+                            ds.startmode = 'Auto,Manual,Disabled'


### PR DESCRIPTION
User experience improvements for Windows Services monitoring.

- To avoid confusion, display a message box on the Infrastructure->Windows Services page informing the user the page has been deprecated and to use the WinService template.
- Added a text box for users to enter comma separated list of services to ignore even if they do have the checked start mode.  case insensitive.
- Allow for more data sources within one template.  This will give the user more flexibility to monitor multiple services using a single datasource definition.
- Migrate any existing templates that specified "Any" to use comma separated string of all start modes