### PR TITLE
ZEN-19637: Missing Software Information for some Windows Devices

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testSoftware.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testSoftware.py
@@ -1,4 +1,4 @@
-##############################################################################
+# coding=utf-8
 #
 # Copyright (C) Zenoss, Inc. 2014, all rights reserved.
 #
@@ -22,6 +22,9 @@ class TestProcesses(BaseTestCase):
                                                   'DisplayName=Soft x86 - 1.0.0;'
                                                   'InstallDate=19700101;'
                                                   'Vendor=Sunway Systems|',
+                                                  'DisplayName=Soft x86 - 1.0.0;',
+                                                  'InstallDate=19700101;',
+                                                  'Vendor=Вендор|',
                                                   ]))
 
         self.device = StringAttributeObject()
@@ -31,3 +34,4 @@ class TestProcesses(BaseTestCase):
         self.assertEquals(data.maps[0].id, 'Soft x86 - 1.0.0')
         self.assertEquals(data.maps[0].setInstallDate, '1970/01/01 00:00:00')
         self.assertTupleEqual(data.maps[0].setProductKey.args, ('Soft x86 - 1.0.0', 'Sunway Systems'))
+        self.assertTupleEqual(data.maps[1].setProductKey.args, ('Soft x86 - 1.0.0', 'Unknown'))


### PR DESCRIPTION
Fixes https://jira.zenoss.com/browse/ZEN-19637

Make manufacturer ID "Unknown" if Vendor value would not be valid Zope ID.