### PR TITLE
Only monkeypatch IPv6 support when possible.

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/patches/platform.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/patches/platform.py
@@ -25,64 +25,66 @@ if not hasattr(OSProcess, 'getMaxProcessCount'):
         return None
 
 
-@monkeypatch(twisted.web.client._AgentBase)
-def _computeHostValue(self, scheme, host, port):
-    """
-    Compute the string to use for the value of the I{Host} header, based on
-    the given scheme, host name, and port number.
+if hasattr(twisted.web.client, '_AgentBase'):
+    @monkeypatch(twisted.web.client._AgentBase)
+    def _computeHostValue(self, scheme, host, port):
+        """
+        Compute the string to use for the value of the I{Host} header, based on
+        the given scheme, host name, and port number.
 
-    Monkeypatched by ZenPacks.zenoss.Microsoft.Windows to be tolerant of IPv6
-    host addresses.
-    """
-    if ':' in host:
-        # HTTP host header must be surrounded by brackets if it's an IPv6
-        # address literal.
-        host = '[{}]'.format(host)
+        Monkeypatched by ZenPacks.zenoss.Microsoft.Windows to be tolerant of IPv6
+        host addresses.
+        """
+        if ':' in host:
+            # HTTP host header must be surrounded by brackets if it's an IPv6
+            # address literal.
+            host = '[{}]'.format(host)
 
-    return original(self, scheme, host, port)  # NOQA: original injected
+        return original(self, scheme, host, port)  # NOQA: original injected
 
 
-@classmethod
-def fromBytes(cls, uri, defaultPort=None):
-    """
-    Parse the given URI into a L{_URI}.
+if hasattr(twisted.web.client, '_URI'):
+    @classmethod
+    def fromBytes(cls, uri, defaultPort=None):
+        """
+        Parse the given URI into a L{_URI}.
 
-    Monkeypatched by ZenPacks.zenoss.Microsoft.Windows to be tolerant of IPv6
-    host addresses.
+        Monkeypatched by ZenPacks.zenoss.Microsoft.Windows to be tolerant of IPv6
+        host addresses.
 
-    @type uri: C{bytes}
-    @param uri: URI to parse.
+        @type uri: C{bytes}
+        @param uri: URI to parse.
 
-    @type defaultPort: C{int} or C{None}
-    @param defaultPort: An alternate value to use as the port if the URI
-        does not include one.
+        @type defaultPort: C{int} or C{None}
+        @param defaultPort: An alternate value to use as the port if the URI
+            does not include one.
 
-    @rtype: L{_URI}
-    @return: Parsed URI instance.
-    """
-    uri = uri.strip()
-    scheme, netloc, path, params, query, fragment = twisted.web.http.urlparse(uri)
+        @rtype: L{_URI}
+        @return: Parsed URI instance.
+        """
+        uri = uri.strip()
+        scheme, netloc, path, params, query, fragment = twisted.web.http.urlparse(uri)
 
-    if defaultPort is None:
-        if scheme == b'https':
-            defaultPort = 443
-        else:
-            defaultPort = 80
+        if defaultPort is None:
+            if scheme == b'https':
+                defaultPort = 443
+            else:
+                defaultPort = 80
 
-    host, port = netloc, defaultPort
-    if b':' in host:
-        # This is the only line changed from the original method. It had been
-        # the following, which resulted in an unpacking error on IPv6 addresses
-        # because they can contain many colons.
-        #
-        #     host, port = host.split(b':')
-        host, port = host.rsplit(b':', 1)
-        try:
-            port = int(port)
-        except ValueError:
-            port = defaultPort
+        host, port = netloc, defaultPort
+        if b':' in host:
+            # This is the only line changed from the original method. It had been
+            # the following, which resulted in an unpacking error on IPv6 addresses
+            # because they can contain many colons.
+            #
+            #     host, port = host.split(b':')
+            host, port = host.rsplit(b':', 1)
+            try:
+                port = int(port)
+            except ValueError:
+                port = defaultPort
 
-    return cls(scheme, netloc, host, port, path, params, query, fragment)
+        return cls(scheme, netloc, host, port, path, params, query, fragment)
 
-# Must monkeypatch by hand because it's a classmethod.
-twisted.web.client._URI.fromBytes = fromBytes
+    # Must monkeypatch by hand because it's a classmethod.
+    twisted.web.client._URI.fromBytes = fromBytes


### PR DESCRIPTION
Fixes the following error on Zenoss 4:

    AttributeError: 'module' object has no attribute '_AgentBase'

Fixes ZEN-20474.