### PR TITLE
ZEN-19993: Microsoft windows cluster failing to model

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/ClusterDevice.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/ClusterDevice.py
@@ -68,8 +68,8 @@ class ClusterDevice(BaseDevice):
                     log.warning('Unable to resolve hostname {0}'.format(clusterhostdnsname))
                     continue
 
-            device = deviceRoot.findDeviceByIdOrIp(clusterhostip)
-            if device:
+            if deviceRoot.findDeviceByIdOrIp(clusterhostip) or \
+                    deviceRoot.findDeviceByIdExact(clusterhostdnsname):
                 # Server device in cluster already exists
                 self.clusterhostdevices = clusterhostdnsnames.keys()
                 self.clusterhostdevicesdict = clusterhostdnsnames


### PR DESCRIPTION
Fixes https://jira.zenoss.com/browse/ZEN-19993

If you have already added cluster node by FQDN and this FQDN resolves in IP different from known and reported by cluster, then possible no devices would be found by 'clusterhostip', so the second one check might handle this case.
