### PR TITLE
Feature/zen 19813

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -498,6 +498,10 @@ To monitor ports on a Windows server that is not a domain controller, simply cre
 
 See https://technet.microsoft.com/en-us/library/dd772723(v=ws.10).aspx for more information on Active Directory port usage.
 
+== WinRM Ping ==
+
+Device status relies on ping status, but if a target's IP has been reassigned to a non-Windows device, it is still pingable and will show as Up.  WinRM Ping is a simple datasource that will attempt to retrieve data over winrm.  If it fails, then we will send a Device Down message to '/Status/Ping', which will set the device status to down.
+
 == Requirements ==
 
 This ZenPack has the following requirements.
@@ -1069,6 +1073,7 @@ Installing this ZenPack will add the following items to your Zenoss system.
 * Fix Microsoft Windows - an event " WinRS: get-clusterservice : The term 'get-clusterservice' is not recognized..." (ZEN-20138)
 * Fix Microsoft Windows - 'RecoveryModel' property is not displayed for SQL Enterprise 2005 (ZEN-20094)
 * Fix error when modeling hosts with IPv6 addresses. (ZEN-20474)
+* Fix WinRM for Windows server - Device Status should not use /Status/Ping (ZEN-19813)
 
 ;2.4.9
 * Fix Windows ZenPack - Cluster device does not add cluster nodes as devices on model (ZEN-19085)

--- a/ZenPacks/zenoss/Microsoft/Windows/configure.zcml
+++ b/ZenPacks/zenoss/Microsoft/Windows/configure.zcml
@@ -144,6 +144,12 @@
         />
 
     <adapter
+        provides=".datasources.WinRMPingDataSource.IWinRMPingDataSourceInfo"
+        for=".datasources.WinRMPingDataSource.WinRMPingDataSource"
+        factory=".datasources.WinRMPingDataSource.WinRMPingDataSourceInfo"
+        />
+
+    <adapter
         provides=".datasources.IISSiteDataSource.IIISSiteDataSourceInfo"
         for=".datasources.IISSiteDataSource.IISSiteDataSource"
         factory=".datasources.IISSiteDataSource.IISSiteDataSourceInfo"

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
@@ -15,13 +15,11 @@ via WinRS.
 '''
 
 import logging
-LOG = logging.getLogger('zen.windows')
-
 import collections
 import time
 
 from twisted.internet import defer, reactor
-from twisted.internet.error import ConnectError, TimeoutError, ConnectionRefusedError
+from twisted.internet.error import ConnectError, TimeoutError
 from twisted.internet.task import LoopingCall
 
 from zope.component import adapts, queryUtility
@@ -47,6 +45,7 @@ from ..txwinrm_utils import ConnectionInfoProperties, createConnectionInfo
 from txwinrm.shell import create_long_running_command, create_single_shot_command
 import codecs
 
+LOG = logging.getLogger('zen.windows')
 
 ZENPACKID = 'ZenPacks.zenoss.Microsoft.Windows'
 SOURCETYPE = 'Windows Perfmon'

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
@@ -352,22 +352,9 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
                 self.config.id,
                 e.message or "timeout")
 
-            if isinstance(e, ConnectionRefusedError):
-                PERSISTER.add_event(self.config.id, {
-                    'device': self.config.id,
-                    'severity': ZenEventClasses.Critical,
-                    'eventClass': '/Status/Ping',
-                    'summary': 'Device is DOWN!'
-                    })
             self.state = PluginStates.STOPPED
             defer.returnValue(None)
 
-        PERSISTER.add_event(self.config.id, {
-            'device': self.config.id,
-            'severity': ZenEventClasses.Clear,
-            'eventClass': '/Status/Ping',
-            'summary': 'Device is UP!'
-            })
         self.state = PluginStates.STARTED
         self.collected_samples = 0
         self.collected_counters = set()

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/WinRMPingDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/WinRMPingDataSource.py
@@ -1,0 +1,154 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2013, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+"""
+A datasource that uses WinRS to collect Windows Service Status
+
+"""
+import logging
+
+from zope.component import adapts
+from zope.interface import implements
+from ZenPacks.zenoss.PythonCollector.datasources.PythonDataSource \
+    import PythonDataSource, PythonDataSourcePlugin
+from Products.Zuul.infos.template import InfoBase
+from Products.Zuul.interfaces import IInfo
+from Products.Zuul.form import schema
+from Products.Zuul.utils import ZuulMessageFactory as _t
+from Products.Zuul.infos import ProxyProperty
+from Products.ZenEvents import ZenEventClasses
+
+from twisted.internet import defer
+
+from ..txwinrm_utils import ConnectionInfoProperties, createConnectionInfo
+
+# Requires that txwinrm_utils is already imported.
+from txwinrm.collect import WinrmCollectClient, create_enum_info
+
+log = logging.getLogger('zen.MicrosoftWindows')
+ZENPACKID = 'ZenPacks.zenoss.Microsoft.Windows'
+
+
+class WinRMPingDataSource(PythonDataSource):
+    ZENPACKID = ZENPACKID
+    cycletime = '${here/zWinPerfmonInterval}'
+    sourcetypes = ('WinRM Ping',)
+    sourcetype = sourcetypes[0]
+    enabled = True
+
+    plugin_classname = ZENPACKID + \
+        '.datasources.WinRMPingDataSource.WinRMPingDataSourcePlugin'
+
+    _properties = PythonDataSource._properties
+
+
+class IWinRMPingDataSourceInfo(IInfo):
+    """
+    Provide the UI information for the WinRS Service datasource.
+    """
+
+    newId = schema.TextLine(
+        title=_t(u'Name'),
+        xtype="idfield",
+        description=_t(u'The name of this datasource')
+    )
+    type = schema.TextLine(
+        title=_t(u'Type'),
+        readonly=True
+    )
+    enabled = schema.Bool(
+        title=_t(u'Enabled')
+    )
+    cycletime = schema.TextLine(
+        title=_t(u'Cycle Time (seconds)'))
+
+
+class WinRMPingDataSourceInfo(InfoBase):
+    """
+    Pull in proxy values so they can be utilized
+    within the WinRS Service plugin.
+    """
+    implements(IWinRMPingDataSourceInfo)
+    adapts(WinRMPingDataSource)
+
+    cycletime = ProxyProperty('cycletime')
+    enabled = ProxyProperty('enabled')
+
+    @property
+    def id(self):
+        return '/'.join(self._object.getPrimaryPath())
+
+    @property
+    def type(self):
+        return self._object.sourcetype
+
+    @property
+    def newId(self):
+        return self._object.id
+
+    @property
+    def source(self):
+        return self._object.getDescription()
+
+
+class WinRMPingDataSourcePlugin(PythonDataSourcePlugin):
+    proxy_attributes = ConnectionInfoProperties
+
+    @classmethod
+    def config_key(cls, datasource, context):
+        return(
+            context.device().id,
+            datasource.getCycleTime(context),
+            datasource.id,
+            datasource.plugin_classname,
+        )
+
+    @classmethod
+    def params(cls, datasource, context):
+        params = {}
+
+        return params
+
+    @defer.inlineCallbacks
+    def collect(self, config):
+
+        ds0 = config.datasources[0]
+
+        log.debug('{0}:Start WinRM connection test.'.format(config.id))
+
+        conn_info = createConnectionInfo(ds0)
+
+        WinRMQueries = [
+            create_enum_info(
+                'select * from Win32_OperatingSystem'
+            )
+        ]
+
+        winrm = WinrmCollectClient()
+        results = yield winrm.do_collect(conn_info, WinRMQueries)
+
+        defer.returnValue(results)
+
+    def onSuccess(self, results, config):
+        data = self.new_data()
+        data['events'].append({
+            'eventClass': '/Status/Ping',
+            'severity': ZenEventClasses.Clear,
+            'summary': 'Device is UP!',
+            'device': config.id})
+        return data
+
+    def onError(self, results, config):
+        data = self.new_data()
+        data['events'].append({
+            'eventClass': '/Status/Ping',
+            'severity': ZenEventClasses.Critical,
+            'summary': 'Device is DOWN!',
+            'device': config.id})
+        return data

--- a/ZenPacks/zenoss/Microsoft/Windows/objects/objects.xml
+++ b/ZenPacks/zenoss/Microsoft/Windows/objects/objects.xml
@@ -5546,6 +5546,23 @@ True
 </object>
 </tomanycont>
 </object>
+<object id='WinRMPing' module='ZenPacks.zenoss.Microsoft.Windows.datasources.WinRMPingDataSource' class='WinRMPingDataSource'>
+<property select_variable="sourcetypes" type="selection" id="sourcetype" mode="w" >
+WinRM Ping
+</property>
+<property type="boolean" id="enabled" mode="w" >
+True
+</property>
+<property type="int" id="severity" mode="w" >
+3
+</property>
+<property type="string" id="cycletime" mode="w" >
+${here/zWinPerfmonInterval}
+</property>
+<property type="string" id="plugin_classname" mode="w" >
+ZenPacks.zenoss.Microsoft.Windows.datasources.WinRMPingDataSource.WinRMPingDataSourcePlugin
+</property>
+</object>
 <object id='sysUpTime' module='ZenPacks.zenoss.Microsoft.Windows.datasources.PerfmonDataSource' class='PerfmonDataSource'>
 <property select_variable="sourcetypes" type="selection" id="sourcetype" mode="w" >
 Windows Perfmon


### PR DESCRIPTION
Remove previous change.  Create new WinRM Ping datasource to test if device is up/down.  More reliable than simple ping.  Add default datasource to Device template.  update readme