### PR TITLE
ZEN-20149: Friendly message if EventLog datasource is not valid.

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/EventLogDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/EventLogDataSource.py
@@ -250,6 +250,9 @@ class EventLogPlugin(PythonDataSourcePlugin):
                     or "does not exist" in str_err:
                     err_msg = "Event Log '%s' does not exist in %s" % (eventlog, ds0.device)
                     raise MissedEventLogException(err_msg)
+                elif str_err.startswith('Where-Object : Cannot bind parameter \'FilterScript\'. Cannot convert the'):
+                    err_msg = "EventQuery value provided in datasource '{}' is not valid".format(ds0.params['eventid'])
+                    raise InvalidEventQueryValue(err_msg)
                 else:
                     raise EventLogException(str_err)
             output = '\n'.join(res.stdout)
@@ -315,7 +318,7 @@ class EventLogPlugin(PythonDataSourcePlugin):
         msg = 'WindowsEventLog: failed collection {0} {1}'.format(result, config)
         if isinstance(result.value, EventLogException):
             msg = "WindowsEventLog: failed collection. " + result.value.message
-        if isinstance(result.value, MissedEventLogException):
+        if isinstance(result.value, (MissedEventLogException, InvalidEventQueryValue)):
             msg = "WindowsEventLog: " + result.value.message
         log.error(msg)
         data = self.new_data()
@@ -515,8 +518,14 @@ class EventLogQuery(object):
         )
         return self.winrs.run_command(command)
 
+
 class EventLogException(Exception):
     pass
 
+
 class MissedEventLogException(Exception):
+    pass
+
+
+class InvalidEventQueryValue(Exception):
     pass


### PR DESCRIPTION
Fixes https://jira.zenoss.com/browse/ZEN-20149