### PR TITLE
Fixes ZEN-18757

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/EventLogDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/EventLogDataSource.py
@@ -396,7 +396,7 @@ class EventLogQuery(object):
                     `"TimeGenerated`": `"$(sstring($_.TimeCreated))`",
                     `"Source`": `"$(sstring($_.ProviderName))`",
                     `"InstanceId`": `"$(sstring($_.Id))`",
-                    `"Message`": `"$(sstring($_.Message))`",
+                    `"Message`": `"$(if ($_.Message){{$(sstring($_.Message))}}else{{$(sstring($_.Properties.Value))}})`",
                     `"UserName`": `"$(sstring($_.UserId))`",
                     `"MachineName`": `"$(sstring($_.MachineName))`",
                     `"EventID`": `"$(sstring($_.Id))`"


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-18757

If Message property is empty, get whatever is in the Properties.value property.  This will be the Event Data.  sometimes the message is written here and not to the Message.