### PR TITLE
Feature/service udpate

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -628,7 +628,7 @@ See the following examples:
 ;Enable/Disable monitoring by default for the WinRM service for a select group of servers.
 # Create a new device class somewhere under ''/Server/Microsoft/Windows'' for the select group of servers.
 # Move the servers to the new device class.
-# Follow steps 1-5 from the previous section.
+# Follow steps 1-5 from the previous section to create a copy of the WinService template.
 # Choose your new device class as the target then click submit.
 # Expand the ''WinService'' tree then select the copy in your device class.
 # Choose ''View and Edit Details'' from the gear menu at the bottom left of the page.
@@ -644,13 +644,29 @@ See the following examples:
 # In the Data Sources pane, click the + button to add a new data source, give it a name, and choose Windows Service as the type.
 # Choose ''View and Edit Details'' from the Data Sources gear menu.
 # Tick the ''Auto'' checkbox under ''Service Options'' and click save.
-# You can optionally exclude certain services to be monitored when selecting the ''Auto'', ''Manual'', and/or ''Disabled'' start mode(s) by entering a comma separated list of services.  These must be the service names and are case insensitive.
+
+;Enable monitoring of all services with a start mode of 'Auto' and begin with MSSQLSERVER.
+# Navigate to Advanced -> Monitoring Templates.
+# Verify the list of templates is grouped by template.
+# Expand the ''WinService'' tree.
+# Select ''/Server/Microsoft''.
+# In the Data Sources pane, click the + button to add a new data source, give it a name, and choose Windows Service as the type.
+# Choose ''View and Edit Details'' from the Data Sources gear menu.
+# Tick the ''Auto'' checkbox under ''Service Options''.
+# Enter ''+MSSQLSERVER.*'' into the "Inclusions(+)/Exclusions(-)" text box and click save.
+
+The order of precedence for monitoring a service is:
+# User manually sets monitoring
+# 'DefaultService' datasource from default WinService template or copy of default template
+# Datasource other than the DefaultService in default WinService template or copy of default template
+
+You can optionally include or exclude certain services to be monitored when selecting the ''Auto'', ''Manual'', and/or ''Disabled'' start mode(s) by entering a comma separated list of services.  These can be the service names or a valid regular expression and are case sensitive.  To exclude services, you must specify a '-' at the beginning of the name or regular expression.  To include services, specify a '+' at the beginning of the name or regular expression.  Exclusions will take precedence over inclusions.
 
 {{note}} To enable monitoring by default of a service or services, you must choose a start mode by ticking the appropriate box.  Unticking all three boxes disables monitoring by default.
 
 {{note}} When saving changes to a service template, the changes may take several minutes to propogate to all of your devices.
 
-{{note}} The WinService datasource no longer depends on the 'DefaultService' data source name.
+{{note}} The Windows Service datasource no longer depends on the 'DefaultService' data source name.  User defined datasources are now honored.
 
 <br clear=all>
 

--- a/ZenPacks/zenoss/Microsoft/Windows/WinService.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/WinService.py
@@ -9,6 +9,7 @@
 
 import re
 import logging
+import string
 from Globals import InitializeClass
 
 from Products.ZenModel.OSComponent import OSComponent
@@ -60,6 +61,10 @@ class WinService(OSComponent):
         return 'WinService'
 
     def is_match(self, service_regex):
+        # can be actual name of service or a regex
+        allowed_chars = set(string.ascii_letters + string.digits + '_-')
+        if not set(service_regex) - allowed_chars:
+            return service_regex == self.servicename
         try:
             regx = re.compile(service_regex)
         except re.error as e:

--- a/ZenPacks/zenoss/Microsoft/Windows/WinService.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/WinService.py
@@ -7,11 +7,14 @@
 #
 ##############################################################################
 
+import re
+import logging
 from Globals import InitializeClass
 
 from Products.ZenModel.OSComponent import OSComponent
 from Products.ZenRelations.RelSchema import ToOne, ToManyCont
 
+log = logging.getLogger('zen.MicrosoftWindows')
 
 class WinService(OSComponent):
     '''
@@ -45,7 +48,7 @@ class WinService(OSComponent):
     _relations = OSComponent._relations + (
         ("os", ToOne(ToManyCont,
          "ZenPacks.zenoss.Microsoft.Windows.OperatingSystem",
-         "winrmservices")),
+                     "winrmservices")),
     )
 
     def getRRDTemplateName(self):
@@ -56,11 +59,29 @@ class WinService(OSComponent):
             pass
         return 'WinService'
 
+    def is_match(self, service_regex):
+        try:
+            regx = re.compile(service_regex)
+        except re.error as e:
+            log.warn(e)
+            return False
+        if regx.match(self.servicename):
+            return True
+        return False
+
     def getMonitored(self, datasource):
+        # match on start mode and include/exclude list of regex/service names
+        # exclusion will override an inclusion
+        rtn = False
         for startmode in datasource.startmode.split(','):
-            if startmode in self.startmode.split(',') and \
-               self.servicename.lower() not in [service.strip() for service in datasource.exclusions.split(',')]:
-                return True
+            if startmode in self.startmode.split(','):
+                for service in datasource.in_exclusions.split(','):
+                    service_regex = service.strip()
+                    if service_regex.startswith('+') and self.is_match(service_regex[1:]):
+                        rtn = True
+                    elif service_regex.startswith('-') and self.is_match(service_regex[1:]):
+                        return False
+        return rtn
 
     def monitored(self):
         """Return True if this service should be monitored. False otherwise."""

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ServiceDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ServiceDataSource.py
@@ -49,6 +49,7 @@ MODE_DISABLED = 'Disabled'
 MODE_MANUAL = 'Manual'
 MODE_ANY = 'Any'
 
+
 def string_to_lines(string):
     if isinstance(string, (list, tuple)):
         return string
@@ -71,7 +72,7 @@ class ServiceDataSource(PythonDataSource):
     servicename = '${here/id}'
     alertifnot = 'Running'
     startmode = ''
-    exclusions = ''
+    in_exclusions = '+.*'
 
     plugin_classname = ZENPACKID + \
         '.datasources.ServiceDataSource.ServicePlugin'
@@ -80,7 +81,7 @@ class ServiceDataSource(PythonDataSource):
         {'id': 'servicename', 'type': 'string'},
         {'id': 'alertifnot', 'type': 'string'},
         {'id': 'startmode', 'type': 'string'},
-        {'id': 'exclusions', 'type': 'string'},
+        {'id': 'in_exclusions', 'type': 'string'},
     )
 
     def getAffectedServices(self):
@@ -126,9 +127,9 @@ class IServiceDataSourceInfo(IRRDDataSourceInfo):
         group=_t('Service Options'),
         xtype='startmodegroup')
 
-    exclusions = schema.TextLine(
+    in_exclusions = schema.TextLine(
         group=_t('Service Options'),
-        title=_t('Exclusions separated by commas'))
+        title=_t('Inclusions(+)/Exclusions(-) separated by commas.  Regex accepted'))
 
 
 class ServiceDataSourceInfo(RRDDataSourceInfo):
@@ -143,7 +144,7 @@ class ServiceDataSourceInfo(RRDDataSourceInfo):
     cycletime = ProxyProperty('cycletime')
     servicename = ProxyProperty('servicename')
     alertifnot = ProxyProperty('alertifnot')
-    exclusions = ProxyProperty('exclusions')
+    in_exclusions = ProxyProperty('in_exclusions')
 
     def get_startmode(self):
         return self._object.startmode

--- a/ZenPacks/zenoss/Microsoft/Windows/objects/objects.xml
+++ b/ZenPacks/zenoss/Microsoft/Windows/objects/objects.xml
@@ -15874,6 +15874,9 @@ Running
 <property type="string" id="startmode" >
 None
 </property>
+<property type="string" id="in_exclusions" >
++.*
+</property>
 </object>
 </tomanycont>
 </object>


### PR DESCRIPTION
Updated instructions in the wiki for service monitoring.

Allow for both including and excluding service monitoring by regex or specifically by name.  Regex must be valid or we'll emit warning.