### PR TITLE
Fixes ZEN-21029

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1064,6 +1064,9 @@ Installing this ZenPack will add the following items to your Zenoss system.
 
 == Changes ==
 
+;2.5.2
+* Fix IIS Site Failed connection when monitoring Windows Server 2012 with IIS 8.5 (ZEN-21029)
+
 ;2.5.1
 * Fix MicrosoftWindows - Unbound Cluster Error when modeling cluster (ZEN-20931)
 * Fix MicrosoftWindows - list index out of range when modeling processes (ZEN-20932)

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/IISSiteDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/IISSiteDataSource.py
@@ -166,7 +166,7 @@ class IISSiteDataSourcePlugin(PythonDataSourcePlugin):
             # 7 and above use the same namespace/query
             try:
                 iis_version = re.match('Version (\d).*', version.stdout[0]).group(1)
-            except IndexError:
+            except (IndexError, AttributeError):
                 if version.stdout:
                     log.error("Malformed version information: {}".format(version.stdout[0]))
                 if version.stderr:

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/IISSiteDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/IISSiteDataSource.py
@@ -12,6 +12,7 @@ A datasource that uses WinRM to collect Windows IIS Site Status
 
 """
 import logging
+import re
 
 from zope.component import adapts
 from zope.interface import implements
@@ -65,8 +66,7 @@ class IISCommander(object):
 
     IIS_COMMAND= '''
         $iisversion = get-itemproperty HKLM:\SOFTWARE\Microsoft\InetStp\ | select versionstring;
-        If($iisversion -like '*Version 6*'){ Write-Host 6 };
-        If($iisversion -like '*Version 7*'){ Write-Host 7 };
+        Write-Host $iisversion.versionstring;
     '''
 
     def get_iis_version(self):
@@ -162,7 +162,16 @@ class IISSiteDataSourcePlugin(PythonDataSourcePlugin):
         if not iis_version:
             winrs = IISCommander(conn_info)
             version = yield winrs.get_iis_version()
-            iis_version = version.stdout[0]
+            # version should be in 'Version x.x' format
+            # 7 and above use the same namespace/query
+            try:
+                iis_version = re.match('Version (\d).*', version.stdout[0]).group(1)
+            except IndexError:
+                if version.stdout:
+                    log.error("Malformed version information: {}".format(version.stdout[0]))
+                if version.stderr:
+                    log.error("Error retrieving IIS Version: {}".format(version.stderr[0]))
+                defer.returnValue(None)
 
         if iis_version == 6:
             WinRMQueries = [create_enum_info(wql=wql_iis6, resource_uri=resource_uri_iis6),]


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-21029

Version 7 and up of IIS uses same namespace and wmi class.  Better to check the version in the ZenPack.  This also helps with debugging