### PR TITLE
Fixes ZEN-21242

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testWinCluster.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testWinCluster.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 ##############################################################################
 #
 # Copyright (C) Zenoss, Inc. 2014, all rights reserved.
@@ -25,7 +27,8 @@ class TestProcesses(BaseTestCase):
         self.results['nodes'] = ['node0', 'node1']
         self.results['nodes_data'] = ['node0|1|1|2|state0']
         self.results['clusterdisk'] = [
-            '2beb|disk1|Vol{2beb}|node0|1|1|2147199|1937045|Online|service'
+            '2beb|disk1|Vol{2beb}|node0|1|1|2147199|1937045|Online|service',
+            'b10c641b-29df-4aff-ab26-53769e793770|CSV Disk|C:\ClusterStorage\Volume1|node0|2|1|2147199||Online|Cluster Shared Volume',
         ]
         self.results['clusternetworks'] = [
             'e4a2|Network1||Up|3',
@@ -58,3 +61,19 @@ class TestProcesses(BaseTestCase):
         self.assertEquals(data[4].maps[0].volumepath, 'Vol{2beb}')
         self.assertEquals(data[4].maps[0].state, 'Online')
         self.assertEquals(data[4].maps[0].assignedto, 'service')
+
+        # Test for missing freespace ZEN-21242
+        self.assertEquals(data[4].maps[1].freespace, 'N/A')
+
+
+def test_suite():
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    suite.addTest(makeSuite(TestProcesses))
+    return suite
+
+
+if __name__ == "__main__":
+    from zope.testrunner.runner import Runner
+    runner = Runner(found_suites=[test_suite()])
+    runner.run()

--- a/ZenPacks/zenoss/Microsoft/Windows/utils.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/utils.py
@@ -279,11 +279,14 @@ def check_low_disk_utilization(size, freespace):
 
 
 def sizeof_fmt(byte=0):
-    byte = int(byte)
-    for unit in ['B','KB','MB','GB','TB','PB','EB','ZB']:
-        if abs(byte) < 1024.0:
-            return "%3.2f%s" % (byte, unit)
-        byte /= 1024.0
+    try:
+        byte = int(byte)
+        for unit in ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB']:
+            if abs(byte) < 1024.0:
+                return "%3.2f%s" % (byte, unit)
+            byte /= 1024.0
+    except ValueError:
+        return "N/A"
 
 
 def pipejoin(items):

--- a/ZenPacks/zenoss/Microsoft/Windows/utils.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/utils.py
@@ -281,12 +281,12 @@ def check_low_disk_utilization(size, freespace):
 def sizeof_fmt(byte=0):
     try:
         byte = int(byte)
-        for unit in ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB']:
-            if abs(byte) < 1024.0:
-                return "%3.2f%s" % (byte, unit)
-            byte /= 1024.0
     except ValueError:
         return "N/A"
+    for unit in ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB']:
+        if abs(byte) < 1024.0:
+            return "%3.2f%s" % (byte, unit)
+        byte /= 1024.0
 
 
 def pipejoin(items):


### PR DESCRIPTION
Traceback occurs when we pass in empty string to sizeof_fmt.  int('') returns ValueError.  If the data is empty, we should show 'N/A' since it's not available.  This func is called in WinCluster modeler plugin and ShellDataSource