### PR TITLE
Fixes ZEN-21270

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1080,6 +1080,14 @@ Installing this ZenPack will add the following items to your Zenoss system.
 
 == Changes ==
 
+;2.5.4
+* Fix Windows Service monitoring improvements
+* Fix WinRM Ping DataSource marks ping up devices down and stops all collection (ZEN-21270)
+* Fix WinCommand notification fails to run on WinRM ZP 2.5.1, 2.5.3 (ZEN-21272)
+
+;2.5.3
+* Fix Microsoft Windows - modeling cluster results in traceback error (ZEN-21242)
+
 ;2.5.2
 * Fix IIS Site Failed connection when monitoring Windows Server 2012 with IIS 8.5 (ZEN-21029)
 

--- a/ZenPacks/zenoss/Microsoft/Windows/Device.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/Device.py
@@ -40,8 +40,11 @@ class Device(BaseDevice):
         {'id': 'sqlhostname', 'label': 'SQL Host Name', 'type': 'string', 'mode': 'w'},
         {'id': 'msexchangeversion', 'label': 'MS Exchange Version', 'type': 'string', 'mode': 'w'},
         {'id': 'ip_and_hostname', 'type': 'string'},
-        {'id': 'domain_controller', 'label': 'Domain Controller','type': 'boolean'},
+        {'id': 'domain_controller', 'label': 'Domain Controller', 'type': 'boolean'},
     )
+
+    def getPingStatus(self):
+        return self.getStatus('/Status/WinRM')
 
     def setClusterMachines(self, clusterdnsnames):
         '''

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/WinRMPingDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/WinRMPingDataSource.py
@@ -138,7 +138,7 @@ class WinRMPingDataSourcePlugin(PythonDataSourcePlugin):
     def onSuccess(self, results, config):
         data = self.new_data()
         data['events'].append({
-            'eventClass': '/Status/Ping',
+            'eventClass': '/Status/WinRM',
             'severity': ZenEventClasses.Clear,
             'summary': 'Device is UP!',
             'device': config.id})
@@ -147,7 +147,7 @@ class WinRMPingDataSourcePlugin(PythonDataSourcePlugin):
     def onError(self, results, config):
         data = self.new_data()
         data['events'].append({
-            'eventClass': '/Status/Ping',
+            'eventClass': '/Status/WinRM',
             'severity': ZenEventClasses.Critical,
             'summary': 'Device is DOWN!',
             'device': config.id})


### PR DESCRIPTION
put winrm ping status in /Status/WinRM then use that for device status.  this way it will still collect on zenpython and not go into pause status