### PR TITLE
Feature/zen 20375

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1080,6 +1080,9 @@ Installing this ZenPack will add the following items to your Zenoss system.
 
 == Changes ==
 
+; 2.5.5
+* Fix WinRM Modeling Software Breaks if Installed Software Ends in Underscores(ZEN-20375)
+
 ;2.5.4
 * Fix Windows Service monitoring improvements
 * Fix WinRM Ping DataSource marks ping up devices down and stops all collection (ZEN-21270)

--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/Software.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/Software.py
@@ -73,13 +73,8 @@ class Software(WinRMPlugin):
                 softwareDict[key] = value
 
             keys = ['DisplayName', 'Vendor', 'InstallDate']
-            for k in softwareDict.keys():
-                try:
-                    keys.remove(k)
-                except ValueError:
-                    continue
             # malformed data line
-            if keys:
+            if set(keys).difference(set(softwareDict.keys())):
                 continue
             # skip over empty entries
             if softwareDict['DisplayName'] == '':

--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/Software.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/Software.py
@@ -11,11 +11,13 @@
 Windows Installed Software
 
 Models list of installed software by querying registry.
-Querying Win32_Product causes Windows installer to run a consistency check, 
+Querying Win32_Product causes Windows installer to run a consistency check,
 possibly causing other problems to appear.
 """
 
 from DateTime import DateTime
+from DateTime.interfaces import SyntaxError, TimeError
+
 from Products.DataCollector.plugins.DataMaps import MultiArgs
 
 from OFS.ObjectManager import checkValidId, BadRequest
@@ -88,13 +90,12 @@ class Software(WinRMPlugin):
 
             om.setProductKey = MultiArgs(om.id, vendor)
 
-            if softwareDict['InstallDate'] is not '':
-                try:
-                    installDate = DateTime(softwareDict['InstallDate'])
-                    om.setInstallDate = '{0} 00:00:00'.format(installDate.Date())
-                except:
-                    # Date is unreadable, leave blank
-                    pass
+            try:
+                installDate = DateTime(softwareDict['InstallDate'])
+                om.setInstallDate = '{0} 00:00:00'.format(installDate.Date())
+            except (SyntaxError, TimeError):
+                # Date is unreadable or empty, ok to leave blank
+                pass
             rm.append(om)
 
         return rm

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testSoftware.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testSoftware.py
@@ -1,4 +1,7 @@
+#!/usr/bin/env python
 # coding=utf-8
+
+##############################################################################
 #
 # Copyright (C) Zenoss, Inc. 2014, all rights reserved.
 #
@@ -19,19 +22,42 @@ class TestProcesses(BaseTestCase):
     def setUp(self):
         self.plugin = Software()
         self.results = dict(software=Mock(stdout=['DisplayName=;InstallDate=;Vendor=|',
+                                                  'DisplayName=?????????? Microsoft Report Viewer ??? Visual Studio 2013;'
+                                                  'InstallDate=20150710;Vendor=Microsoft Corporation |',
+                                                  'DisplayName=Visual Studio 2013? Microsoft Report Viewer ?? ??;'
+                                                  'InstallDate=20150710;Vendor=Microsoft Corporation |',
                                                   'DisplayName=Soft x86 - 1.0.0;'
                                                   'InstallDate=19700101;'
                                                   'Vendor=Sunway Systems|',
-                                                  'DisplayName=Soft x86 - 1.0.0;',
-                                                  'InstallDate=19700101;',
+                                                  'DisplayName=Soft x86 - 1.0.0;'
+                                                  'InstallDate=19700101;'
                                                   'Vendor=Вендор|',
+                                                  'DisplayName=;xxx;yyy|'
                                                   ]))
 
         self.device = StringAttributeObject()
 
     def test_process(self):
         data = self.plugin.process(self.device, self.results, Mock())
-        self.assertEquals(data.maps[0].id, 'Soft x86 - 1.0.0')
-        self.assertEquals(data.maps[0].setInstallDate, '1970/01/01 00:00:00')
-        self.assertTupleEqual(data.maps[0].setProductKey.args, ('Soft x86 - 1.0.0', 'Sunway Systems'))
-        self.assertTupleEqual(data.maps[1].setProductKey.args, ('Soft x86 - 1.0.0', 'Unknown'))
+        self.assertEquals(data.maps[0].id, 'Microsoft Report Viewer _ Visual Studio 2013')
+        self.assertEquals(data.maps[0].setProductKey.args, ('Microsoft Report Viewer _ Visual Studio 2013', 'Microsoft Corporation'))
+        self.assertEquals(data.maps[1].id, 'Visual Studio 2013_ Microsoft Report Viewer')
+        self.assertEquals(data.maps[1].setProductKey.args, ('Visual Studio 2013_ Microsoft Report Viewer', 'Microsoft Corporation'))
+        self.assertEquals(data.maps[2].id, 'Soft x86 - 1.0.0')
+        self.assertEquals(data.maps[2].setInstallDate, '1970/01/01 00:00:00')
+        self.assertTupleEqual(data.maps[2].setProductKey.args, ('Soft x86 - 1.0.0', 'Sunway Systems'))
+        self.assertTupleEqual(data.maps[3].setProductKey.args, ('Soft x86 - 1.0.0', 'Unknown'))
+        self.assertEquals(len(data.maps), 4)
+
+
+def test_suite():
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    suite.addTest(makeSuite(TestProcesses))
+    return suite
+
+
+if __name__ == "__main__":
+    from zope.testrunner.runner import Runner
+    runner = Runner(found_suites=[test_suite()])
+    runner.run()

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testSoftware.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testSoftware.py
@@ -32,7 +32,8 @@ class TestProcesses(BaseTestCase):
                                                   'DisplayName=Soft x86 - 1.0.0;'
                                                   'InstallDate=19700101;'
                                                   'Vendor=Вендор|',
-                                                  'DisplayName=;xxx;yyy|'
+                                                  'DisplayName=;xxx;yyy|',
+                                                  'DisplayName=Software;InstallDate=;Vendor=SoftCorp'
                                                   ]))
 
         self.device = StringAttributeObject()
@@ -47,7 +48,8 @@ class TestProcesses(BaseTestCase):
         self.assertEquals(data.maps[2].setInstallDate, '1970/01/01 00:00:00')
         self.assertTupleEqual(data.maps[2].setProductKey.args, ('Soft x86 - 1.0.0', 'Sunway Systems'))
         self.assertTupleEqual(data.maps[3].setProductKey.args, ('Soft x86 - 1.0.0', 'Unknown'))
-        self.assertEquals(len(data.maps), 4)
+        self.assertFalse(hasattr(data.maps[4], 'setInstallDate'))
+        self.assertEquals(len(data.maps), 5)
 
 
 def test_suite():


### PR DESCRIPTION
We were never removing underscores from name when we were creating the productkey.  This goes way back to previous versions.  Added more results to unit tests.  Make code cleaner

https://jira.zenoss.com/browse/ZEN-20375