### PR TITLE
Fixes ZEN-21325

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1082,6 +1082,7 @@ Installing this ZenPack will add the following items to your Zenoss system.
 
 ; 2.5.5
 * Fix WinRM Modeling Software Breaks if Installed Software Ends in Underscores(ZEN-20375)
+* Fix Microsoft Windows - monitoring cluster disks results in powershell error (ZEN-21325)
 
 ;2.5.4
 * Fix Windows Service monitoring improvements

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
@@ -747,53 +747,54 @@ class PowershellClusterDiskStrategy(object):
             '$_.PartitionNumber $_.Size $_.FreeSpace $_.State')
 
         psClusterCommands.append(
-            "$clsSharedVolume = Get-ClusterSharedVolume -errorvariable volumeerr -erroraction 'silentlycontinue'|" \
-            "where{$_.Name -eq '%s'};" \
-            "if( -Not $volumeerr){" \
-            "foreach ($volume in $clsSharedVolume) {" \
-            "$volumeowner = $volume.OwnerNode.Name;" \
-            "$csvVolume = $volume.SharedVolumeInfo.Partition.Name;" \
-            "$volumeInfo = Get-Disk | Get-Partition | Select DiskNumber, @{" \
-            "Name='Volume';Expression={Get-Volume -Partition $_ | Select -ExpandProperty ObjectId;}};"\
-            "$csvdisknumber = ($volumeinfo | where { $_.Volume -eq $csvVolume}).Disknumber;" \
-            "$csvtophysicaldisk = New-Object -TypeName PSObject -Property @{" \
-                "Id = $csvVolume.substring(11, $csvVolume.length-13);" \
-                "Name = $volume.Name;" \
-                "VolumePath = $volume.SharedVolumeInfo.FriendlyVolumeName;" \
-                "OwnerNode = $volumeowner;" \
-                "DiskNumber = $csvdisknumber;" \
-                "PartitionNumber = $volume.SharedVolumeInfo.PartitionNumber;" \
-                "Size = $volume.SharedVolumeInfo.Partition.Size;" \
-                "FreeSpace = $volume.SharedVolumeInfo.Partition.Freespace;" \
-                "State = $volume.State;" \
+            "$volumeInfo = Get-Disk | Get-Partition | Select DiskNumber, @{"
+            "Name='Volume';Expression={Get-Volume -Partition $_ | Select -ExpandProperty ObjectId;}};"
+            "$clsSharedVolume = Get-ClusterSharedVolume -errorvariable volumeerr -erroraction 'silentlycontinue'|"
+            "where{$_.Name -eq '%s'};"
+            "if( -Not $volumeerr){"
+            "foreach ($volume in $clsSharedVolume) {"
+            "$volumeowner = $volume.OwnerNode.Name;"
+            "$csvVolume = $volume.SharedVolumeInfo.Partition.Name;"
+            "$csvdisknumber = ($volumeinfo | where { $_.Volume -eq $csvVolume}).Disknumber;"
+            "$csvtophysicaldisk = New-Object -TypeName PSObject -Property @{"
+                "Id = $csvVolume.substring(11, $csvVolume.length-13);"
+                "Name = $volume.Name;"
+                "VolumePath = $volume.SharedVolumeInfo.FriendlyVolumeName;"
+                "OwnerNode = $volumeowner;"
+                "DiskNumber = $csvdisknumber;"
+                "PartitionNumber = $volume.SharedVolumeInfo.PartitionNumber;"
+                "Size = $volume.SharedVolumeInfo.Partition.Size;"
+                "FreeSpace = $volume.SharedVolumeInfo.Partition.Freespace;"
+                "State = $volume.State;"
             "}; $csvtophysicaldisk | foreach { %s };};}" % (resource, clusterdiskitems)
             )
 
         psClusterCommands.append(
-            "$clsDisk = get-clusterresource -errorvariable diskerr -erroraction 'silentlycontinue'|" \
-            "where{$_.Name -eq '%s'}| where { $_.ResourceType -eq 'Physical Disk'};" \
-            "if( -Not $diskerr){" \
-            "foreach ($disk in $clsDisk) {" \
-            "$diskowner = $disk.OwnerNode.Name;" \
-            "$diskVolume = $disk.Name;" \
-            "$diskInfo = Get-Disk | Get-Partition | Select DiskNumber, PartitionNumber," \
-            "@{Name='Volume';Expression={Get-Volume -Partition $_ | Select -ExpandProperty ObjectId};}," \
-            "@{Name='DriveLetter';Expression={Get-Volume -Partition $_ | Select -ExpandProperty DriveLetter};}," \
-            "@{Name='FileSystemLabel';Expression={Get-Volume -Partition $_ | Select -ExpandProperty FileSystemLabel};}," \
-            "@{Name='Size';Expression={Get-Volume -Partition $_ | Select -ExpandProperty Size};}," \
-            "@{Name='SizeRemaining';Expression={Get-Volume -Partition $_ | Select -ExpandProperty SizeRemaining};};" \
-            "$disknumber = ($diskInfo | where { $_.FileSystemLabel -eq $diskVolume}).DiskNumber;" \
-            "$diskpartition = ($diskInfo | where { $_.FileSystemLabel -eq $diskVolume}).PartitionNumber;" \
-            "$disksize = ($diskInfo | where { $_.FileSystemLabel -eq $diskVolume}).Size;" \
-            "$disksizeremain = ($diskInfo | where { $_.FileSystemLabel -eq $diskVolume}).SizeRemaining;" \
-            "$diskvolume = ($diskInfo | where { $_.FileSystemLabel -eq $diskVolume}).Volume.substring(3);" \
-            "$physicaldisk = New-Object -TypeName PSObject -Property @{" \
-            "Id = $diskvolume.substring(8, $diskvolume.length-10);" \
-            "Name = $disk.Name;VolumePath = $diskvolume;" \
-            "OwnerNode = $diskowner;DiskNumber = $disknumber;" \
-            "PartitionNumber = $diskpartition;Size = $disksize;" \
-            "FreeSpace = $disksizeremain;State = $disk.State;};" \
-            "$physicaldisk | foreach { %s };};}" % (resource, clusterdiskitems)
+            "$diskInfo = Get-Disk | Get-Partition | Select DiskNumber, PartitionNumber,"
+            "@{Name='Volume';Expression={Get-Volume -Partition $_ | Select -ExpandProperty ObjectId};},"
+            "@{Name='DriveLetter';Expression={Get-Volume -Partition $_ | Select -ExpandProperty DriveLetter};},"
+            "@{Name='FileSystemLabel';Expression={Get-Volume -Partition $_ | Select -ExpandProperty FileSystemLabel};},"
+            "@{Name='Size';Expression={Get-Volume -Partition $_ | Select -ExpandProperty Size};},"
+            "@{Name='SizeRemaining';Expression={Get-Volume -Partition $_ | Select -ExpandProperty SizeRemaining};};"
+            "$clsDisk = get-clusterresource -errorvariable diskerr -erroraction 'silentlycontinue'|"
+            "where{$_.Name -eq '%s'}| where { $_.ResourceType -eq 'Physical Disk'};"
+            "if( -Not $diskerr){"
+            "foreach ($disk in $clsDisk) {"
+            "$founddisk = $diskInfo | where { $_.FileSystemLabel -eq $disk.Name};"
+            "if ($founddisk -ne $null) {"
+            "$diskowner = $disk.OwnerNode.Name;"
+            "$disknumber = $founddisk.DiskNumber;"
+            "$diskpartition = $founddisk.PartitionNumber;"
+            "$disksize = $founddisk.Size;"
+            "$disksizeremain = $founddisk.SizeRemaining;"
+            "$diskvolume = $founddisk.Volume.substring(3);"
+            "$physicaldisk = New-Object -TypeName PSObject -Property @{"
+            "Id = $diskvolume.substring(8, $diskvolume.length-10);"
+            "Name = $disk.Name;VolumePath = $diskvolume;"
+            "OwnerNode = $diskowner;DiskNumber = $disknumber;"
+            "PartitionNumber = $diskpartition;Size = $disksize;"
+            "FreeSpace = $disksizeremain;State = $disk.State;};"
+            "$physicaldisk | foreach { %s };};};}" % (resource, clusterdiskitems)
             )
 
         command = "{0} \"& {{{1}}}\"".format(


### PR DESCRIPTION
Similar fix as in https://jira.zenoss.com/browse/ZEN-21242.  Problem is that not all cluster disks are local to the node and some information may not be found when looping through results of call to get-clusterresource.  Also moved $diskinfo outside of the loop as this only needs to be done once.