### PR TITLE
Fixes ZEN-21351

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1083,6 +1083,7 @@ Installing this ZenPack will add the following items to your Zenoss system.
 ; 2.5.5
 * Fix WinRM Modeling Software Breaks if Installed Software Ends in Underscores(ZEN-20375)
 * Fix Microsoft Windows - monitoring cluster disks results in powershell error (ZEN-21325)
+* Fix Problem while executing plugin zenoss.winrm.FileSystems (ZEN-21351)
 
 ;2.5.4
 * Fix Windows Service monitoring improvements

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/utils.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/utils.py
@@ -27,3 +27,11 @@ def load_pickle(self, filename):
             self.__class__.__name__,
             '{}.pkl.gz'.format(filename)), 'rb') as f:
         return pickle.load(f)
+
+
+def test_suite(testnames):
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    for testname in testnames:
+        suite.addTest(makeSuite(testname))
+    return suite

--- a/ZenPacks/zenoss/Microsoft/Windows/utils.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/utils.py
@@ -270,10 +270,13 @@ def check_low_disk_utilization(size, freespace):
     Checks disk utilization
     Return True if disk use less than 1 percent of disk space
     '''
-    size, freespace = int(size), int(freespace)
+    try:
+        size, freespace = int(size), int(freespace)
+    except (TypeError, ValueError):
+        return True
     if size:
         percent = float(size - freespace) / size * 100
-        return True if round(percent, 1) < 1.0  else False
+        return True if round(percent, 1) < 1.0 else False
     else:
         return False
 


### PR DESCRIPTION
Fixes https://jira.zenoss.com/browse/ZEN-21351.  If the size and/or freespace is missing, then we should return True to stay in line with the change implemented in https://jira.zenoss.com/browse/ZEN-19213.  Updated unit test to check for this as well.