### PR TITLE
Feature/zen 21396

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -969,6 +969,8 @@ If you experience OperationTimeout errors, it may be a solution to decrease valu
 
 Other timeout issues on a domain could involve having a large Kerberos token.  This could be caused by the user belonging to a large number of groups.  See https://support.microsoft.com/en-us/kb/970875 for more information on the cause and resolution.  Possible side effects of a large token include high CPU usage on the Windows server.
 
+If you see a corrupt counters error event, this indicates that the specified counters have been corrupted on the Windows device.  No data will be collected for the specified counters until the counters have been repaired on the device and zenpython has been restarted.
+
 == Zenoss Analytics ==
 
 This ZenPack provides additional support for Zenoss Analytics. Perform the
@@ -1084,6 +1086,7 @@ Installing this ZenPack will add the following items to your Zenoss system.
 * Fix WinRM Modeling Software Breaks if Installed Software Ends in Underscores(ZEN-20375)
 * Fix Microsoft Windows - monitoring cluster disks results in powershell error (ZEN-21325)
 * Fix Problem while executing plugin zenoss.winrm.FileSystems (ZEN-21351)
+* Fix Microsoft Windows - corrupt counters are not removed from collection (ZEN-21396)
 
 ;2.5.4
 * Fix Windows Service monitoring improvements

--- a/ZenPacks/zenoss/Microsoft/Windows/Device.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/Device.py
@@ -44,7 +44,7 @@ class Device(BaseDevice):
     )
 
     def getPingStatus(self):
-        return self.getStatus('/Status/WinRM')
+        return self.getStatus('/Status/WinRM/Ping')
 
     def setClusterMachines(self, clusterdnsnames):
         '''

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
@@ -341,7 +341,7 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
         '''
         Start the continuous command.
         '''
-        if self.state != PluginStates.STOPPED:
+        if self.state != PluginStates.STOPPED or not self.ps_counter_map.keys():
             defer.returnValue(None)
 
         LOG.debug("starting Get-Counter on %s", self.config.id)
@@ -571,10 +571,13 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
         elif not results and not failures and self.cycling:
             try:
                 yield self.remove_corrupt_counters()
-            except Exception, ex:
+            except Exception:
                 pass
             yield self.restart()
-
+            # Report corrupt counters
+            dsconf0 = self.config.datasources[0]
+            if CORRUPT_COUNTERS[dsconf0.device]:
+                self.reportCorruptCounters(self.counter_map)
         else:
             if self.cycling:
                 LOG.debug('Result: {0}'.format(result))
@@ -631,7 +634,7 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
         '''
         command = lambda counters: (
             "powershell -NoLogo -NonInteractive -NoProfile -Command "
-            "\"get-counter -ea silentlycontinue -counter @({0})\" ".format(
+            "\"get-counter -counter @({0})\" ".format(
                 ', '.join("('{0}')".format(c) for c in counters))
         )
 
@@ -657,8 +660,7 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
     @defer.inlineCallbacks
     def remove_corrupt_counters(self):
         '''
-        Remove counters which are not ignored by Error Action parameter
-        and crash the whole command.
+        Remove counters which return an error.
         '''
         LOG.debug('Performing check for corrupt counters')
         dsconf0 = self.config.datasources[0]
@@ -683,6 +685,49 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
 
         defer.returnValue(None)
 
+    def reportCorruptCounters(self, requested):
+        '''
+        Emit event for corrupt counters
+        '''
+        default_eventClass = '/Status/WinRM'
+        dsconf0 = self.config.datasources[0]
+
+        events = {}
+        for req_counter in requested:
+            if req_counter in CORRUPT_COUNTERS[dsconf0.device]:
+                component, datasource, event_class = requested.get(req_counter, (None, None, None))
+                if event_class and event_class != default_eventClass:
+                    if event_class not in events:
+                        events[event_class] = []
+                    events[event_class].append(req_counter)
+                else:
+                    if default_eventClass not in events:
+                        events[default_eventClass] = []
+                    events[default_eventClass].append(req_counter)
+
+        if events:
+            for event in events:
+                PERSISTER.add_event(self.config.id, {
+                    'device': self.config.id,
+                    'severity': ZenEventClasses.Error,
+                    'eventClass': event,
+                    'eventKey': 'Windows Perfmon Corrupt Counters',
+                    'summary': self.missing_counters_summary(len(events[event])),
+                    'corrupt_counters': self.missing_counters_str(events[event]).decode('UTF-8'),
+                })
+
+        for req_counter in requested:
+            component, datasource, event_class = requested.get(req_counter, (None, None, None))
+            event_class = event_class or default_eventClass
+            if event_class not in events:
+                PERSISTER.add_event(self.config.id, {
+                    'device': self.config.id,
+                    'severity': ZenEventClasses.Clear,
+                    'eventClass': event_class or default_eventClass,
+                    'eventKey': 'Windows Perfmon Corrupt Counters',
+                    'summary': '0 counters corrupt in collection',
+                })
+
     def reportMissingCounters(self, requested, returned):
         '''
         Emit logs and events for counters requested but not returned.
@@ -695,11 +740,11 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
             if req_counter in missing_counters:
                 component, datasource, event_class = requested.get(req_counter, (None, None, None))
                 if event_class and event_class != default_eventClass:
-                    if not event_class in events:
+                    if event_class not in events:
                         events[event_class] = []
                     events[event_class].append(req_counter)
                 else:
-                    if not default_eventClass in events:
+                    if default_eventClass not in events:
                         events[default_eventClass] = []
                     events[default_eventClass].append(req_counter)
 

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/WinRMPingDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/WinRMPingDataSource.py
@@ -138,17 +138,19 @@ class WinRMPingDataSourcePlugin(PythonDataSourcePlugin):
     def onSuccess(self, results, config):
         data = self.new_data()
         data['events'].append({
-            'eventClass': '/Status/WinRM',
+            'eventClass': '/Status/WinRM/Ping',
             'severity': ZenEventClasses.Clear,
             'summary': 'Device is UP!',
+            'ipAddress': config.manageIp,
             'device': config.id})
         return data
 
     def onError(self, results, config):
         data = self.new_data()
         data['events'].append({
-            'eventClass': '/Status/WinRM',
+            'eventClass': '/Status/WinRM/Ping',
             'severity': ZenEventClasses.Critical,
             'summary': 'Device is DOWN!',
+            'ipAddress': config.manageIp,
             'device': config.id})
         return data


### PR DESCRIPTION
We should be reporting which counters are corrupted so users know to fix their devices.  Also, need to put winrmping events in /status/winrm/ping because other events may go into /status/winrm.  removed silentlycontinue from corrupt counter removal because we need to show which counters really are corrupt, not just the ones that blow up the get-counter command.  couple of minor pep8 fixes too.