### PR TITLE
Fixes ZEN-18757

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/EventLogDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/EventLogDataSource.py
@@ -403,7 +403,7 @@ class EventLogQuery(object):
                     `"TimeGenerated`": `"$(sstring($_.TimeCreated))`",
                     `"Source`": `"$(sstring($_.ProviderName))`",
                     `"InstanceId`": `"$(sstring($_.Id))`",
-                    `"Message`": `"$(if ($_.Message){{$(sstring($_.Message))}}else{{$(sstring($_.Properties.Value))}})`",
+                    `"Message`": `"$(if ($_.Message){{$(sstring($_.Message))}}else{{$(sstring($_.FormatDescription()))}})`",
                     `"UserName`": `"$(sstring($_.UserId))`",
                     `"MachineName`": `"$(sstring($_.MachineName))`",
                     `"EventID`": `"$(sstring($_.Id))`"


### PR DESCRIPTION
from Zendesk #105674, user reported that using `$_.FormatDescription()` will return the correct message if the Message property is empty.