### PR TITLE
Feature/zen 21603

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ServiceDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ServiceDataSource.py
@@ -152,8 +152,8 @@ class ServiceDataSourceInfo(RRDDataSourceInfo):
     def set_startmode(self, value):
         if self._object.startmode != value:
             self._object.startmode = value
-            for service in self._object.getAffectedServices():
-                service.index_object()
+        for service in self._object.getAffectedServices():
+            service.index_object()
 
     startmode = property(get_startmode, set_startmode)
 
@@ -188,6 +188,10 @@ class ServicePlugin(PythonDataSourcePlugin):
     def collect(self, config):
 
         ds0 = config.datasources[0]
+
+        if ds0.params['startmode'] == 'None':
+            log.debug('No startmodes defined in {}.  Terminating datasource collection.'.format(ds0.datasource))
+            defer.returnValue(None)
 
         log.debug('{0}:Start Collection of Services'.format(config.id))
 
@@ -227,6 +231,10 @@ class ServicePlugin(PythonDataSourcePlugin):
                 'Status': 'OK'}
         '''
         data = self.new_data()
+        if config.datasources[0].params['startmode'] == 'None':
+            log.debug('No startmodes defined in {}.  No collection occurred.'
+                      .format(config.datasources[0].datasource))
+            return data
         services = self.buildServicesDict(config.datasources)
         log.debug('Windows services query results: {}'.format(results))
         try:

--- a/ZenPacks/zenoss/Microsoft/Windows/migrate/ReindexWinService.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/migrate/ReindexWinService.py
@@ -1,0 +1,54 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2015, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+"""Reindex Windows services.
+
+ZEN-21603
+services need to be reindexed to update stale datasources.
+
+"""
+
+# Logging
+import logging
+
+# Zenoss Imports
+from zope.event import notify
+from Products.ZenModel.migrate.Migrate import Version
+from Products.ZenModel.ZenPack import ZenPackMigration
+from Products.Zuul.catalog.events import IndexingEvent
+from Products.Zuul.interfaces import ICatalogTool
+
+# ZenPack Imports
+from ZenPacks.zenoss.Microsoft.Windows.WinService import WinService
+
+LOG = logging.getLogger('zen.MicrosoftWindows')
+
+
+class ReindexWinService(ZenPackMigration):
+    version = Version(2, 5, 6)
+
+    def migrate(self, pack):
+        catalog = ICatalogTool(pack.getDmdRoot('Devices'))
+        results = catalog.search(WinService)
+
+        if not results.total:
+            return
+
+        LOG.info(
+            "Indexing %s Windows Services.",
+            results.total)
+
+        for result in results:
+            try:
+                epg = result.getObject()
+            except Exception:
+                continue
+
+            epg.index_object()
+            notify(IndexingEvent(epg))


### PR DESCRIPTION
We need to reindex services on install to refresh stale components for datasources.

We also need to always reindex when a user saves the datasource by clicking Save button dialog because other items may have changed which will affect which services are monitored.

If a datasource does not have any startmodes checked to monitor, then there is no need to collect or process datasource results.