### PR TITLE
Fixes ZEN-21899

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/WinService.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/WinService.py
@@ -104,7 +104,7 @@ class WinService(OSComponent):
                     return True
             # 3 - Allow for other datasources to be specified.
             for datasource in template.getRRDDataSources():
-                if datasource.id != 'DefaultService':
+                if datasource.id != 'DefaultService' and hasattr(datasource, 'startmode'):
                     if self.getMonitored(datasource):
                         return True
 


### PR DESCRIPTION
We need to check to make sure that someone hasn't added a non-ServiceDataSource to a Windows service monitoring template