### PR TITLE
fixes ZEN-21928

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
@@ -298,6 +298,9 @@ class CustomCommandStrategy(object):
         cmd.device = dsconf.params['servername']
         cmd.component = dsconf.params['contextcompname']
 
+        # Pass the severity from the datasource to the command parsers
+        cmd.severity = dsconf.severity
+
         # Add the device id to the config for compatibility with parsers
         config.device = config.id
         cmd.deviceConfig = config


### PR DESCRIPTION
Send severity to cmd parser so that it can use datasource severity

Tested by creating custom parser and setting severity to something other than 3(Warning)

https://jira.zenoss.com/browse/ZEN-21928