### PR TITLE
Fixes ZEN-22345

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/ClusterDisk.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/ClusterDisk.py
@@ -15,6 +15,8 @@ from Products.ZenModel.OSComponent import OSComponent
 from Products.ZenRelations.RelSchema import ToOne, ToManyCont
 from Products.ZenUtils.IpUtil import getHostByName
 
+from utils import cluster_state_string
+
 log = logging.getLogger("zen.MicrosoftWindows")
 
 
@@ -69,5 +71,13 @@ class ClusterDisk(OSComponent):
         Return the path to an icon for this component.
         '''
         return '/++resource++mswindows/img/FileSystem.png'
+
+    def getState(self):
+        try:
+            state = int(self.cacheRRDValue('state', None))
+        except Exception:
+            return 'Unknown'
+
+        return cluster_state_string(state)
 
 InitializeClass(ClusterDisk)

--- a/ZenPacks/zenoss/Microsoft/Windows/ClusterInterface.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/ClusterInterface.py
@@ -8,12 +8,10 @@
 ##############################################################################
 
 from Globals import InitializeClass
-from socket import gaierror
 import logging
 
 from Products.ZenModel.OSComponent import OSComponent
 from Products.ZenRelations.RelSchema import ToOne, ToManyCont
-from Products.ZenUtils.IpUtil import getHostByName
 
 log = logging.getLogger("zen.MicrosoftWindows")
 
@@ -42,8 +40,7 @@ class ClusterInterface(OSComponent):
 
     _relations = OSComponent._relations + (
         ("clusternode", ToOne(ToManyCont,
-            "ZenPacks.zenoss.Microsoft.Windows.ClusterNode",
-            "clusterinterfaces")),
+         "ZenPacks.zenoss.Microsoft.Windows.ClusterNode", "clusterinterfaces")),
     )
 
     def getRRDTemplateName(self):
@@ -54,5 +51,13 @@ class ClusterInterface(OSComponent):
         Return the path to an icon for this component.
         '''
         return '/++resource++mswindows/img/Interface.png'
+
+    def getState(self):
+        try:
+            state = int(self.cacheRRDValue('state', None))
+        except Exception:
+            return 'Unknown'
+
+        return state
 
 InitializeClass(ClusterInterface)

--- a/ZenPacks/zenoss/Microsoft/Windows/ClusterNetwork.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/ClusterNetwork.py
@@ -8,12 +8,10 @@
 ##############################################################################
 
 from Globals import InitializeClass
-from socket import gaierror
 import logging
 
 from Products.ZenModel.OSComponent import OSComponent
 from Products.ZenRelations.RelSchema import ToOne, ToManyCont
-from Products.ZenUtils.IpUtil import getHostByName
 
 log = logging.getLogger("zen.MicrosoftWindows")
 
@@ -38,11 +36,18 @@ class ClusterNetwork(OSComponent):
 
     _relations = OSComponent._relations + (
         ('os', ToOne(ToManyCont,
-            'ZenPacks.zenoss.Microsoft.Windows.OperatingSystem',
-            'clusternetworks')),
+         'ZenPacks.zenoss.Microsoft.Windows.OperatingSystem', 'clusternetworks')),
     )
 
     def getRRDTemplateName(self):
         return 'ClusterNetwork'
+
+    def getState(self):
+        try:
+            state = int(self.cacheRRDValue('state', None))
+        except Exception:
+            return 'Unknown'
+
+        return state
 
 InitializeClass(ClusterNetwork)

--- a/ZenPacks/zenoss/Microsoft/Windows/ClusterNode.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/ClusterNode.py
@@ -15,6 +15,8 @@ from Products.ZenModel.OSComponent import OSComponent
 from Products.ZenRelations.RelSchema import ToOne, ToManyCont
 from Products.ZenUtils.IpUtil import getHostByName
 
+from utils import cluster_state_string
+
 log = logging.getLogger("zen.MicrosoftWindows")
 
 
@@ -38,14 +40,11 @@ class ClusterNode(OSComponent):
 
     _relations = OSComponent._relations + (
         ('os', ToOne(ToManyCont,
-            'ZenPacks.zenoss.Microsoft.Windows.OperatingSystem',
-            'clusternodes')),
+         'ZenPacks.zenoss.Microsoft.Windows.OperatingSystem', 'clusternodes')),
         ('clusterdisks', ToManyCont(ToOne,
-            'ZenPacks.zenoss.Microsoft.Windows.ClusterDisk',
-            'clusternode')),
+         'ZenPacks.zenoss.Microsoft.Windows.ClusterDisk', 'clusternode')),
         ('clusterinterfaces', ToManyCont(ToOne,
-            'ZenPacks.zenoss.Microsoft.Windows.ClusterInterface',
-            'clusternode')),
+         'ZenPacks.zenoss.Microsoft.Windows.ClusterInterface', 'clusternode')),
     )
 
     def ownernodeentity(self):
@@ -65,6 +64,14 @@ class ClusterNode(OSComponent):
         Return the path to an icon for this component.
         '''
         return '/++resource++mswindows/img/server-windows.png'
+
+    def getState(self):
+        try:
+            state = int(self.cacheRRDValue('state', None))
+        except Exception:
+            return 'Unknown'
+
+        return cluster_state_string(state)
 
 
 InitializeClass(ClusterNode)

--- a/ZenPacks/zenoss/Microsoft/Windows/ClusterResource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/ClusterResource.py
@@ -11,11 +11,12 @@ from Globals import InitializeClass
 from socket import gaierror
 import logging
 
-log = logging.getLogger("zen.MicrosoftWindows")
-
 from Products.ZenModel.OSComponent import OSComponent
 from Products.ZenRelations.RelSchema import ToOne, ToManyCont
 from Products.ZenUtils.IpUtil import getHostByName
+from utils import cluster_state_string
+
+log = logging.getLogger("zen.MicrosoftWindows")
 
 
 class ClusterResource(OSComponent):
@@ -40,8 +41,7 @@ class ClusterResource(OSComponent):
 
     _relations = OSComponent._relations + (
         ("clusterservice", ToOne(ToManyCont,
-            "ZenPacks.zenoss.Microsoft.Windows.ClusterService",
-            "clusterresources")),
+         "ZenPacks.zenoss.Microsoft.Windows.ClusterService", "clusterresources")),
     )
 
     def ownernodeentity(self):
@@ -55,5 +55,14 @@ class ClusterResource(OSComponent):
 
     def getRRDTemplateName(self):
         return 'ClusterResource'
+
+    def getState(self):
+        try:
+            state = int(self.cacheRRDValue('state', None))
+        except Exception:
+            return 'Unknown'
+
+        return cluster_state_string(state)
+
 
 InitializeClass(ClusterResource)

--- a/ZenPacks/zenoss/Microsoft/Windows/ClusterService.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/ClusterService.py
@@ -11,10 +11,13 @@ from Globals import InitializeClass
 from socket import gaierror
 import logging
 
-log = logging.getLogger("zen.MicrosoftWindows")
 from Products.ZenModel.OSComponent import OSComponent
 from Products.ZenRelations.RelSchema import ToOne, ToManyCont
 from Products.ZenUtils.IpUtil import getHostByName
+
+from utils import cluster_state_string
+
+log = logging.getLogger("zen.MicrosoftWindows")
 
 
 class ClusterService(OSComponent):
@@ -41,11 +44,9 @@ class ClusterService(OSComponent):
 
     _relations = OSComponent._relations + (
         ('os', ToOne(ToManyCont,
-            'ZenPacks.zenoss.Microsoft.Windows.OperatingSystem',
-            'clusterservices')),
+         'ZenPacks.zenoss.Microsoft.Windows.OperatingSystem', 'clusterservices')),
         ('clusterresources', ToManyCont(ToOne,
-            'ZenPacks.zenoss.Microsoft.Windows.ClusterResource',
-            'clusterservice')),
+         'ZenPacks.zenoss.Microsoft.Windows.ClusterResource', 'clusterservice')),
     )
 
     def ownernodeentity(self):
@@ -65,5 +66,14 @@ class ClusterService(OSComponent):
         Return the path to an icon for this component.
         '''
         return '/++resource++mswindows/img/ClusterService.png'
+
+    def getState(self):
+        try:
+            state = int(self.cacheRRDValue('state', None))
+        except Exception:
+            return 'Unknown'
+
+        return cluster_state_string(state)
+
 
 InitializeClass(ClusterService)

--- a/ZenPacks/zenoss/Microsoft/Windows/browser/resources/js/device.js
+++ b/ZenPacks/zenoss/Microsoft/Windows/browser/resources/js/device.js
@@ -929,7 +929,8 @@ ZC.MSClusterNodePanel = Ext.extend(ZC.WINComponentGridPanel, {
                 dataIndex: 'state',
                 header: _t('State'),
                 sortable: true,
-                width: 100
+                width: 100,
+                renderer: Zenoss.render.pingStatus
             },{
                 id: 'monitored',
                 dataIndex: 'monitored',
@@ -1102,7 +1103,8 @@ ZC.MSClusterNetworkPanel = Ext.extend(ZC.WINComponentGridPanel, {
                 dataIndex: 'state',
                 header: _t('State'),
                 sortable: true,
-                width: 100
+                width: 100,
+                renderer: Zenoss.render.pingStatus
             },{
                 id: 'monitored',
                 dataIndex: 'monitored',
@@ -1192,7 +1194,8 @@ ZC.MSClusterInterfacePanel = Ext.extend(ZC.WINComponentGridPanel, {
                 dataIndex: 'state',
                 header: _t('State'),
                 sortable: true,
-                width: 100
+                width: 100,
+                renderer: Zenoss.render.pingStatus
             },{
                 id: 'monitored',
                 dataIndex: 'monitored',

--- a/ZenPacks/zenoss/Microsoft/Windows/info.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/info.py
@@ -242,7 +242,11 @@ class ClusterServiceInfo(WinComponentInfo):
     description = ProxyProperty('description')
     coregroup = ProxyProperty('coregroup')
     priority = ProxyProperty('priority')
-    state = ProxyProperty('state')
+
+    @property
+    @info
+    def state(self):
+        return self._object.getState()
 
     @property
     @info
@@ -259,7 +263,11 @@ class ClusterResourceInfo(WinComponentInfo):
     ownernode = ProxyProperty('ownernode')
     description = ProxyProperty('description')
     ownergroup = ProxyProperty('ownergroup')
-    state = ProxyProperty('state')
+
+    @property
+    @info
+    def state(self):
+        return self._object.getState()
 
     @property
     @info
@@ -280,7 +288,11 @@ class ClusterNodeInfo(WinComponentInfo):
     implements(IClusterNodeInfo)
     assignedvote = ProxyProperty('assignedvote')
     currentvote = ProxyProperty('currentvote')
-    state = ProxyProperty('state')
+
+    @property
+    @info
+    def state(self):
+        return self._object.getState()
 
     @property
     @info
@@ -301,7 +313,11 @@ class ClusterDiskInfo(WinComponentInfo):
     size = ProxyProperty('size')
     freespace = ProxyProperty('freespace')
     assignedto = ProxyProperty('assignedto')
-    state = ProxyProperty('state')
+
+    @property
+    @info
+    def state(self):
+        return self._object.getState()
 
     @property
     @info
@@ -313,7 +329,11 @@ class ClusterNetworkInfo(WinComponentInfo):
     implements(IClusterNetworkInfo)
     description = ProxyProperty('description')
     role = ProxyProperty('role')
-    state = ProxyProperty('state')
+
+    @property
+    @info
+    def state(self):
+        return self._object.getState()
 
 
 class ClusterInterfaceInfo(WinComponentInfo):
@@ -322,7 +342,11 @@ class ClusterInterfaceInfo(WinComponentInfo):
     network = ProxyProperty('network')
     ipaddresses = ProxyProperty('ipaddresses')
     adapter = ProxyProperty('adapter')
-    state = ProxyProperty('state')
+
+    @property
+    @info
+    def state(self):
+        return self._object.getState()
 
     @property
     @info

--- a/ZenPacks/zenoss/Microsoft/Windows/utils.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/utils.py
@@ -294,3 +294,19 @@ def sizeof_fmt(byte=0):
 
 def pipejoin(items):
     return " + '|' + ".join(items.split())
+
+
+def cluster_state_string(state):
+    return {0: 'Online',
+            1: 'Up',
+            2: 'Offline',
+            3: 'PartialOnline',
+            4: 'Failed'}.get(state, 'Unknown')
+
+
+def cluster_state_value(state):
+    return {'Online': 0,
+            'Up': 1,
+            'Offline': 2,
+            'PartialOnline': 3,
+            'Failed': 4}.get(state, 5)


### PR DESCRIPTION
Fixes https://jira.zenoss.com/browse/ZEN-22345 for zendesk ticket https://zenoss.zendesk.com/agent/tickets/111650.  We should not be applying datamaps to possibly thousands of components every 5 minutes.  The datapoint was already defined for state, so let's tie into it.  Use pingStatus for 'Up' renderers also.

Also, some PEP8 stuff