### PR TITLE
ZEN-22369: Improperly setting the Active Directory Template

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/OperatingSystem.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/OperatingSystem.py
@@ -57,7 +57,7 @@ class OperatingSystem(WinRMPlugin):
         operatingSystem = results.get('Win32_OperatingSystem', (None,))[0]
         clusterInformation = results.get('MSCluster', ())
         exchange_version = results.get('exchange_version')
-        domainController = results.get('ActiveDirectory', (None,))
+        domainController = results.get('ActiveDirectory', (None,))[0]
 
         if exchange_version:
             exchange_version = exchange_version.stdout[0][:2] if exchange_version.stdout else None


### PR DESCRIPTION
Fixes https://jira.zenoss.com/browse/ZEN-22369

Non empty tuple converted to boolean in true, so modeler marks host as DC