### PR TITLE
Send clear event on successful model for powershell commands

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1095,6 +1095,7 @@ Installing this ZenPack will add the following items to your Zenoss system.
 ; 2.6.0
 * Document Microsoft Windows Event Log Monitoring Returns Information Events (ZEN-22904)
 * Fix zWinRMServerName not resolving properly on remote collector (ZEN-22880)
+* Fix WinRM ZP Error about concurrent shells doesn't close when not reoccuring (ZEN-23010)
 
 ; 2.5.12
 * Fix Windows EvenLog Datasource causes CPU 100% utilization (ZEN-20232)

--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/WinRMPlugin.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/WinRMPlugin.py
@@ -235,7 +235,7 @@ class WinRMPlugin(PythonPlugin):
                 query_results = yield client.do_collect(
                     conn_info, query_map.iterkeys())
                 msg = "connection for %s is established"
-                self._send_event(msg % device.id, device.id, 0)
+                self._send_event(msg % device.id, device.id, 0, eventClass='/Status/Winrm/Ping')
             except Exception as e:
                 self.log_error(log, device, e)
             else:
@@ -261,6 +261,8 @@ class WinRMPlugin(PythonPlugin):
             for command_key, command in commands.iteritems():
                 try:
                     results[command_key] = yield winrs.run_command(command)
+                    msg = 'shell command completed successfully for {}'.format(device.id)
+                    self._send_event(msg, device.id, 0, eventClass='/Status/Winrm/Ping')
                 except Exception as e:
                     self.log_error(log, device, e)
 


### PR DESCRIPTION
Fixes ZEN-23010

Need to send a clear event for successful shell/powershell commands.
Tested by sending a critical event, then remodeling