### PR TITLE
Check for 'in_exlusions' attribute on datasource

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1147,6 +1147,7 @@ Installing this ZenPack will add the following items to your Zenoss system.
 * Document Microsoft Windows Event Log Monitoring Returns Information Events (ZEN-22904)
 * Fix zWinRMServerName not resolving properly on remote collector (ZEN-22880)
 * Fix WinRM ZP Error about concurrent shells doesn't close when not reoccuring (ZEN-23010)
+* Fix Latest version of WinRM pack (2.5.12) causes "AttributeError: in_exclusions" tracebacks (ZEN-23063)
 
 ; 2.5.12
 * Fix Windows EvenLog Datasource causes CPU 100% utilization (ZEN-20232)

--- a/ZenPacks/zenoss/Microsoft/Windows/WinService.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/WinService.py
@@ -79,7 +79,7 @@ class WinService(OSComponent):
         # exclusion will override an inclusion
         rtn = False
         for startmode in datasource.startmode.split(','):
-            if startmode in self.startmode.split(','):
+            if startmode in self.startmode.split(',') and hasattr(datasource, 'in_exclusions'):
                 for service in datasource.in_exclusions.split(','):
                     service_regex = service.strip()
                     if service_regex.startswith('+') and self.is_match(service_regex[1:]):


### PR DESCRIPTION
Fixes ZEN-23063

Check for attribute.  it could be missing due to the wrong datasource
inside of a service template.  or an old datasource that has not been updated