### PR TITLE
Make winrm ping more understandable

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -580,7 +580,11 @@ See https://technet.microsoft.com/en-us/library/dd772723(v=ws.10).aspx for more 
 
 === WinRM Ping ===
 
-Device status relies on ping status, but if a target's IP has been reassigned to a non-Windows device, it is still pingable and will show as Up.  WinRM Ping is a simple datasource that will attempt to retrieve data over winrm.  If it fails, then we will send a Device Down message to '/Status/Ping', which will set the device status to down.
+WinRM Ping is a simple datasource that will attempt to retrieve basic data over winrm.  If the device cannot return a simple query, then Zenoss will view this device as being down.  An event will appear in the /Status/Winrm/Ping event class with any resulting error message.  This is a more comprehensive test than using a ping.  A simple ping test could easily result in a false positive in many scenarios.  The following are just a few:
+
+* A target's IP has been reassigned to a non-Windows device between models.
+* The winrm service has stopped and cannot be restarted.
+* The monitoring user account password has expired.
 
 == Requirements ==
 

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/WinRMPingDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/WinRMPingDataSource.py
@@ -154,7 +154,7 @@ class WinRMPingDataSourcePlugin(PythonDataSourcePlugin):
             data['events'].append({
                 'eventClass': '/Status/Winrm/Ping',
                 'severity': ZenEventClasses.Critical,
-                'summary': 'Device is DOWN!',
+                'summary': 'Device is DOWN:  {}'.format(results.value.message),
                 'ipAddress': config.manageIp,
                 'device': config.id})
         return data


### PR DESCRIPTION
Fixes ZEN-22166

Updated the readme to explain winrm ping and why it's better than a
simple ping.  Also, we'll add any error message to the device down summary
so users will know why it's down.