### PR TITLE
Fixes ZEN-23326

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testIISSiteDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testIISSiteDataSource.py
@@ -29,7 +29,12 @@ class TestIISSiteDataSourcePlugin(BaseTestCase):
         self.assertIn("is in Unknown state", data['events'][0]['summary'])
 
     def test_onError(self):
-        data = self.plugin.onError(Failure('foo'), MagicMock(
+        f = None
+        try:
+            f = Failure('foo')
+        except TypeError:
+            f = Failure()
+        data = self.plugin.onError(f, MagicMock(
             id=sentinel.id,
             datasources=[MagicMock(params={'eventlog': sentinel.eventlog})],
         ))

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testProcessDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testProcessDataSource.py
@@ -24,7 +24,12 @@ class TestProcessDataSourcePlugin(BaseTestCase):
 
     @patch('ZenPacks.zenoss.Microsoft.Windows.datasources.ProcessDataSource.LOG', Mock())
     def test_onError(self):
-        data = self.plugin.onError(Failure('process datasource error'), sentinel)
+        f = None
+        try:
+            f = Failure('process datasource error')
+        except TypeError:
+            f = Failure()
+        data = self.plugin.onError(f, sentinel)
         self.assertEquals(len(data['events']), 1)
         self.assertEquals(data['events'][0]['summary'], "process scan error: process datasource error")
 

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testServiceDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testServiceDataSource.py
@@ -33,6 +33,11 @@ class TestServiceDataSourcePlugin(BaseTestCase):
 
     @patch('ZenPacks.zenoss.Microsoft.Windows.datasources.ServiceDataSource.log', Mock())
     def test_onError(self):
-        data = self.plugin.onError(Failure('foo'), sentinel)
+        f = None
+        try:
+            f = Failure('foo')
+        except TypeError:
+            f = Failure()
+        data = self.plugin.onError(f, sentinel)
         self.assertEquals(len(data['events']), 1)
         self.assertEquals(data['events'][0]['severity'], 4)

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testShellDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testShellDataSource.py
@@ -32,6 +32,11 @@ class TestShellDataSourcePlugin(BaseTestCase):
 
     @patch('ZenPacks.zenoss.Microsoft.Windows.datasources.ShellDataSource.log', Mock())
     def test_onError(self):
-        data = self.plugin.onError(Failure('foo'), sentinel)
+        f = None
+        try:
+            f = Failure('foo')
+        except TypeError:
+            f = Failure()
+        data = self.plugin.onError(f, sentinel)
         self.assertEquals(len(data['events']), 1)
         self.assertEquals(data['events'][0]['severity'], 3)

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testWinCluster.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testWinCluster.py
@@ -48,7 +48,6 @@ class TestProcesses(BaseTestCase):
         self.assertEquals(data[1].maps[0].description, 'description0')
         self.assertEquals(data[1].maps[0].domain, 'domain0')
         self.assertEquals(data[1].maps[0].ownernode, 'node0')
-        self.assertEquals(data[1].maps[0].state, 'state0')
         self.assertEquals(data[1].maps[0].title, 'title0')
         self.assertEquals(data[4].maps[0].id, '2beb')
         self.assertEquals(data[4].maps[0].freespace, '1.85MB')
@@ -59,7 +58,6 @@ class TestProcesses(BaseTestCase):
         self.assertEquals(data[4].maps[0].domain, 'domain0')
         self.assertEquals(data[4].maps[0].title, 'disk1')
         self.assertEquals(data[4].maps[0].volumepath, 'Vol{2beb}')
-        self.assertEquals(data[4].maps[0].state, 'Online')
         self.assertEquals(data[4].maps[0].assignedto, 'service')
 
         # Test for missing freespace ZEN-21242


### PR DESCRIPTION
- Python twisted Failure object is different in 5.x, so rewrote to
account for differences.