### PR TITLE
Enable the windows services page

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -505,6 +505,7 @@ See the following examples:
 # Choose Yes or No depending on what you want.
 
 ;Enable monitoring by default for the WinRM service wherever it is enabled.
+Option 1
 # Navigate to Advanced -> Monitoring Templates.
 # Verify the list of templates is grouped by template.
 # Expand the ''WinService'' tree.
@@ -516,6 +517,16 @@ See the following examples:
 # Choose ''View and Edit Details'' from the Template gear menu at the bottom left of the page.
 # Change the template's name to ''WinRM''.
 # Tick the ''Auto'' checkbox under ''Service Options'' and click save.
+
+Option 2
+# Navigate to Infrastructure -> Windows Services
+# Locate the WinRM service
+# Select the start modes desired for this service
+# Enable monitoring by setting a Local Value
+# Optionally select a Local Failure Severity
+# Save
+
+[[note]] Setting a service to be monitored in this fashion will enable monitoring for the service regardless of device class.
 
 ;Enable/Disable monitoring by default for the WinRM service for a select group of servers.
 # Create a new device class somewhere under ''/Server/Microsoft/Windows'' for the select group of servers.
@@ -551,6 +562,7 @@ The order of precedence for monitoring a service is:
 # User manually sets monitoring
 # 'DefaultService' datasource from default WinService template or copy of default template
 # Datasource other than the DefaultService in default WinService template or copy of default template
+# Monitoring is enabled via the Infrastructure -> Windows Services page
 
 You can optionally include or exclude certain services to be monitored when selecting the ''Auto'', ''Manual'', and/or ''Disabled'' start mode(s) by entering a comma separated list of services.  These can be the service names or a valid regular expression.  Entered names and expressions are case sensitive.  To exclude services, you must specify a '-' at the beginning of the name or regular expression.  To include services, specify a '+' at the beginning of the name or regular expression.  Exclusions will take precedence over inclusions.
 
@@ -1152,6 +1164,7 @@ Installing this ZenPack will add the following items to your Zenoss system.
 == Changes ==
 
 ; 2.6.0
+* Enabled the use of the Infrastructure -> Windows Services page
 * Document Microsoft Windows Event Log Monitoring Returns Information Events (ZEN-22904)
 * Fix zWinRMServerName not resolving properly on remote collector (ZEN-22880)
 * Fix WinRM ZP Error about concurrent shells doesn't close when not reoccuring (ZEN-23010)

--- a/ZenPacks/zenoss/Microsoft/Windows/WinService.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/WinService.py
@@ -110,6 +110,7 @@ class WinService(BaseWinService):
                         return True
 
         # 3 check the service class
+        # be sure we can get the serviceclass and that we have a relationship with serviceclass
         if hasattr(self, 'serviceclass') and 'serviceclass' in self.getRelationshipNames():
             sc = self.serviceclass()
             if sc:

--- a/ZenPacks/zenoss/Microsoft/Windows/WinService.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/WinService.py
@@ -11,23 +11,18 @@ import re
 import logging
 import string
 from Globals import InitializeClass
+from AccessControl import ClassSecurityInfo
 
-from Products.ZenModel.OSComponent import OSComponent
-from Products.ZenRelations.RelSchema import ToOne, ToManyCont
+from Products.ZenModel.WinService import WinService as BaseWinService
 
 log = logging.getLogger('zen.MicrosoftWindows')
 
 
-class WinService(OSComponent):
+class WinService(BaseWinService):
     '''
     Model class for Windows Service.
     '''
     meta_type = portal_type = 'WinRMService'
-
-
-    #startmode [string] = The start mode for the servicename
-    #account [string] = The account name the service runs as
-    #usermonitor [boolean] = Did user manually set monitor.
 
     servicename = None
     caption = None
@@ -37,7 +32,7 @@ class WinService(OSComponent):
     monitor = False
     usermonitor = False
 
-    _properties = OSComponent._properties + (
+    _properties = BaseWinService._properties + (
         {'id': 'servicename', 'label': 'Service Name', 'type': 'string'},
         {'id': 'caption', 'label': 'Caption', 'type': 'string'},
         {'id': 'description', 'label': 'Description', 'type': 'string'},
@@ -45,33 +40,38 @@ class WinService(OSComponent):
         {'id': 'account', 'label': 'Account', 'type': 'string'},
         {'id': 'usermonitor', 'label': 'User Selected Monitor State',
             'type': 'boolean'},
-        )
-
-    _relations = OSComponent._relations + (
-        ("os", ToOne(ToManyCont,
-         "ZenPacks.zenoss.Microsoft.Windows.OperatingSystem",
-                     "winrmservices")),
     )
+
+    security = ClassSecurityInfo()
+
+    def getClassObject(self):
+        """
+        Return the ServiceClass for this service.
+        """
+        return self.serviceClass()
 
     def getRRDTemplateName(self):
         try:
-            if self.getRRDTemplateByName(self.servicename):
-                return self.servicename
+            if self.getRRDTemplateByName(self.serviceName):
+                return self.serviceName
         except TypeError:
             pass
         return 'WinService'
+
+    def getRRDTemplates(self):
+        return [self.getRRDTemplateByName(self.getRRDTemplateName())]
 
     def is_match(self, service_regex):
         # can be actual name of service or a regex
         allowed_chars = set(string.ascii_letters + string.digits + '_-')
         if not set(service_regex) - allowed_chars:
-            return service_regex == self.servicename
+            return service_regex == self.serviceName
         try:
             regx = re.compile(service_regex)
         except re.error as e:
             log.warn(e)
             return False
-        if regx.match(self.servicename):
+        if regx.match(self.serviceName):
             return True
         return False
 
@@ -80,7 +80,7 @@ class WinService(OSComponent):
         # exclusion will override an inclusion
         rtn = False
         for startmode in datasource.startmode.split(','):
-            if startmode in self.startmode.split(',') and hasattr(datasource, 'in_exclusions'):
+            if startmode in self.startMode.split(',') and hasattr(datasource, 'in_exclusions'):
                 for service in datasource.in_exclusions.split(','):
                     service_regex = service.strip()
                     if service_regex.startswith('+') and self.is_match(service_regex[1:]):
@@ -109,6 +109,74 @@ class WinService(OSComponent):
                     if self.getMonitored(datasource):
                         return True
 
+        # 3 check the service class
+        if hasattr(self, 'serviceclass') and 'serviceclass' in self.getRelationshipNames():
+            sc = self.serviceclass()
+            if sc:
+                org = sc.serviceorganizer()
+                # check the service class monitored start modes
+                if self.startMode in sc.monitoredStartModes:
+                    # check the zMonitor organizer property
+                    if org and hasattr(org, 'zMonitor'):
+                        return org.zMonitor
+        # don't monitor Disabled services
+        if self.startMode and self.startMode == "Disabled":
+            return False
+
         return False
+
+    def get_serviceclass_startmodes(self):
+        ''' determine the start modes for this services
+            giving precedence to manual monitoring, followed
+            by local template override, and falling back on
+            service class if not defined
+        '''
+        if self.usermonitor is True:
+            return [self.startMode]
+
+        template = self.getRRDTemplate()
+        if template:
+            datasource = template.datasources._getOb('DefaultService', None)
+            if datasource and self.getMonitored(datasource):
+                modes = datasource.startmode.split(',')
+                if 'None' in modes:
+                    modes.remove('None')
+                if len(modes) > 0:
+                    return modes
+            # 3 - Allow for other datasources to be specified.
+            for datasource in template.getRRDDataSources():
+                if datasource.id != 'DefaultService' and hasattr(datasource, 'startmode'):
+                    if self.getMonitored(datasource):
+                        modes = datasource.startmode.split(',')
+                        if 'None' in modes:
+                            modes.remove('None')
+                        if len(modes) > 0:
+                            return modes
+        sc = self.serviceclass()
+        if sc:
+            return sc.monitoredStartModes
+
+    def get_winservices_modes(self):
+        ''''''
+        data = {}
+        for svc in self.device().os.winservices():
+            if svc.monitored():
+                data[svc.id] = {'modes': svc.get_serviceclass_startmodes(),
+                                'mode': svc.startMode,
+                                'monitor': svc.monitored()
+                                }
+        return data
+
+    def getMonitoredStartModes(self):
+        return self.get_serviceclass_startmodes()
+
+    security.declareProtected('Manage DMD', 'manage_editService')
+    def manage_editService(self, *args, **kwargs):
+        """Edit a Service from a web page.
+        """
+        tmpl = super(WinService, self).manage_editService(
+            *args, **kwargs)
+        self.index_object()
+        return tmpl
 
 InitializeClass(WinService)

--- a/ZenPacks/zenoss/Microsoft/Windows/info.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/info.py
@@ -45,11 +45,11 @@ class WinServiceInfo(ComponentInfo):
     implements(IWinServiceInfo)
 
     title = ProxyProperty('title')
-    servicename = ProxyProperty('servicename')
+    serviceName = ProxyProperty('serviceName')
     caption = ProxyProperty('caption')
     description = ProxyProperty('description')
-    startmode = ProxyProperty('startmode')
-    account = ProxyProperty('account')
+    startMode = ProxyProperty('startMode')
+    startName = ProxyProperty('startName')
     usermonitor = ProxyProperty('usermonitor')
 
     @property

--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/Services.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/Services.py
@@ -15,16 +15,17 @@ Models list of installed services by querying Win32_Service via WMI.
 
 from ZenPacks.zenoss.Microsoft.Windows.modeler.WinRMPlugin import WinRMPlugin
 from ZenPacks.zenoss.Microsoft.Windows.utils import save
+from Products.DataCollector.plugins.DataMaps import RelationshipMap
 
 
 class Services(WinRMPlugin):
     compname = 'os'
-    relname = 'winrmservices'
+    relname = 'winservices'
     modname = 'ZenPacks.zenoss.Microsoft.Windows.WinService'
 
     queries = {
         'Win32_Service': "SELECT * FROM Win32_Service",
-        }
+    }
 
     @save
     def process(self, device, results, log):
@@ -35,14 +36,21 @@ class Services(WinRMPlugin):
         rm = self.relMap()
 
         for service in results.get('Win32_Service', ()):
-            rm.append(self.objectMap({
-                'id': self.prepId(service.Name),
-                'title': service.Caption,
-                'servicename': service.Name,
-                'caption': service.Caption,
-                'description': service.Description,
-                'startmode': service.StartMode,
-                'account': service.StartName,
-                }))
+            om = self.objectMap()
+            om.id = self.prepId(service.Name)
+            om.serviceName = service.Name
+            om.caption = service.Caption
+            om.setServiceClass = {'name': service.Name, 'description': service.Caption}
+            om.pathName = service.PathName
+            om.serviceType = service.ServiceType
+            om.startMode = service.StartMode
+            om.startName = service.StartName
+            rm.append(om)
 
-        return rm
+        maps = []
+        maps.append(RelationshipMap(
+            relname="winrmservices",
+            compname='os',
+            objmaps=[]))
+        maps.append(rm)
+        return maps

--- a/ZenPacks/zenoss/Microsoft/Windows/resources/js/global.js
+++ b/ZenPacks/zenoss/Microsoft/Windows/resources/js/global.js
@@ -23,10 +23,10 @@ Ext.define("Zenoss.component.WinRMServicePanel", {
                 {name: 'meta_type'},
                 {name: 'name'},
                 {name: 'title'},
-                {name: 'servicename'},
+                {name: 'serviceName'},
                 {name: 'caption'},
-                {name: 'startmode'},
-                {name: 'account'},
+                {name: 'startMode'},
+                {name: 'startName'},
                 {name: 'usesMonitorAttribute'},
                 {name: 'monitor'},
                 {name: 'locking'},
@@ -41,7 +41,7 @@ Ext.define("Zenoss.component.WinRMServicePanel", {
                 width: 50
             },{
                 id: 'name',
-                dataIndex: 'servicename',
+                dataIndex: 'serviceName',
                 header: _t('Name'),
                 sortable: true,
                 width: 110
@@ -51,14 +51,14 @@ Ext.define("Zenoss.component.WinRMServicePanel", {
                 header: _t('Display Name'),
                 sortable: true
             },{
-                id: 'account',
-                dataIndex: 'account',
+                id: 'startName',
+                dataIndex: 'startName',
                 header: _t('Start Name'),
                 widht: 110,
                 sortable: true
             },{
                 id: 'startmode',
-                dataIndex: 'startmode',
+                dataIndex: 'startMode',
                 header: _t('Start Mode'),
                 sortable: true,
                 width: 110
@@ -450,45 +450,6 @@ Zenoss.form.StartModeGroup = Ext.extend(Ext.panel.Panel, {
         Ext.reg('startmodegroup', Zenoss.form.StartModeGroup);
     }
 })();
-
-Ext.onReady(function() {
-    Ext.ComponentMgr.onAvailable('monitoredStartModes', function(){
-        var message = _t('This page has been deprecated in ZenPacks.zenoss.Microsoft.Windows.  Please use the WinService monitoring template.');
-        var dlg = new Zenoss.FormDialog({
-            title: _t('Windows Services'),
-            modal: true,
-            items: [ {
-                        xtype: 'label',
-                        text: message,
-                        ref: 'messagelabel'
-                    },
-                    {
-                        xtype: 'checkboxfield',
-                        boxLabel  : 'Check if you no longer want to see this message.',
-                        name      : 'hidemessage',
-                        inputValue: '1',
-                        stateId   : 'services_checkbox',
-                        stateful: true,
-                        stateEvents: ['change'],
-                        getState: function() {
-                            return {checked: this.getValue()}
-                        },
-                        applyState: function(state){
-                            this.setValue(state.checked);
-                        }
-                    }],
-            buttons: [
-                        {
-                            xtype: 'HideDialogButton',
-                            text: _t('OK'),
-                        }
-                    ],
-        });
-        if (dlg.down('checkboxfield').getValue() == false){
-            dlg.show();
-        }
-    });
-});
 
 var DEVICE_SUMMARY_PANEL = 'deviceoverviewpanel_summary';
 


### PR DESCRIPTION
Fixes ZEN-20148

Subclass platform WinService so services will be shown on services
page.  Existing winrmservices will be removed on a remodel.  Users
can enable monitoring on services page now.  Remove deprecated
message when navigating to windows services page