### PR TITLE
Fixes 22240

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
@@ -118,7 +118,7 @@ class DataPersister(object):
     devices = None
 
     # For performing periodic cleanup of stale data.
-    maintenance_interval = 600
+    maintenance_interval = 300
 
     # Data older than this (in seconds) will be dropped on maintenance.
     max_data_age = 3600


### PR DESCRIPTION
- reducing the maintencance interval to 300 for perfmondatasource
- suspect that the 600s interval is behind the additional polling for invalid, removed file systems, but don't have ability to confirm.