### PR TITLE
Fixes ZEN-23713

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/WinService.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/WinService.py
@@ -22,7 +22,6 @@ class WinService(BaseWinService):
     '''
     Model class for Windows Service.
     '''
-    meta_type = portal_type = 'WinRMService'
 
     servicename = None
     caption = None

--- a/ZenPacks/zenoss/Microsoft/Windows/WinService.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/WinService.py
@@ -164,9 +164,32 @@ class WinService(BaseWinService):
             if svc.monitored():
                 data[svc.id] = {'modes': svc.get_serviceclass_startmodes(),
                                 'mode': svc.startMode,
-                                'monitor': svc.monitored()
+                                'monitor': svc.monitored(),
+                                'severity': svc.getFailSeverity(),
                                 }
         return data
+
+    def getTemplateDefaultService(self):
+        '''Return datasource for template if it exists'''
+        template = self.getRRDTemplate()
+        if template:
+            return template.datasources._getOb('DefaultService', None)
+        return None
+
+    def getFailSeverity(self):
+        """
+        Return the severity for this service when it fails.
+        """
+        datasource = self.getTemplateDefaultService()
+        if datasource:
+            return datasource.severity
+        return self.getAqProperty("zFailSeverity")
+
+    def getFailSeverityString(self):
+        """
+        Return a string representation of zFailSeverity
+        """
+        return self.ZenEventManager.severities[self.getFailSeverity()]
 
     def getMonitoredStartModes(self):
         return self.get_serviceclass_startmodes()

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ServiceDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ServiceDataSource.py
@@ -264,7 +264,7 @@ class ServicePlugin(PythonDataSourcePlugin):
             serviceinfo = results[results.keys()[0]]
         except:
             data['events'].append({
-                'eventClass': "/Status",
+                'eventClass': "/Status/WinService",
                 'severity': ZenEventClasses.Error,
                 'eventClassKey': 'WindowsServiceCollectionStatus',
                 'eventKey': 'WindowsServiceCollection',
@@ -288,7 +288,7 @@ class ServicePlugin(PythonDataSourcePlugin):
                 continue
 
             service = services[svc_id]
-            eventClass = service['eventClass'] if service['eventClass'] else "/Status"
+            eventClass = service['eventClass'] if service['eventClass'] else "/Status/WinService"
             eventKey = service['eventKey'] if service['eventKey'] else "WindowsService"
 
             if svc_info.State != service['alertifnot']:
@@ -334,7 +334,7 @@ class ServicePlugin(PythonDataSourcePlugin):
 
         # Event to provide notification that check has completed
         data['events'].append({
-            'eventClass': "/Status",
+            'eventClass': "/Status/WinService",
             'device': config.id,
             'summary': 'Windows Service Check: successful service collection',
             'severity': ZenEventClasses.Clear,
@@ -345,7 +345,7 @@ class ServicePlugin(PythonDataSourcePlugin):
         return data
 
     def onError(self, result, config):
-        eventClass = "/Status"
+        eventClass = "/Status/WinService"
         prefix = 'failed collection - '
         if isinstance(result, Failure):
             result = result.value

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ServiceDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ServiceDataSource.py
@@ -343,7 +343,7 @@ class ServicePlugin(PythonDataSourcePlugin):
                     'eventClass': "/Status/WinService",
                     'eventClassKey': 'WindowsServiceLog',
                     'eventKey': "WindowsService",
-                    'severity': service['severity'],
+                    'severity': winsvc.get('severity', service.get('severity', 3)),
                     'summary': evtmsg,
                     'component': prepId(svc_id),
                     'device': config.id,

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ServiceDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ServiceDataSource.py
@@ -306,7 +306,7 @@ class ServicePlugin(PythonDataSourcePlugin):
                     'eventClass': eventClass,
                     'eventClassKey': 'WindowsServiceLog',
                     'eventKey': eventKey,
-                    'severity': service['severity'],
+                    'severity': winsvc.get('severity', service.get('severity', 3)),
                     'summary': evtmsg,
                     'component': prepId(svc_id),
                     'device': config.id,

--- a/ZenPacks/zenoss/Microsoft/Windows/info.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/info.py
@@ -12,7 +12,7 @@ from Products.Zuul.infos.component.filesystem import FileSystemInfo
 from Products.Zuul.infos.component.cpu import CPUInfo
 from Products.Zuul.infos.component.osprocess import OSProcessInfo
 from Products.Zuul.infos.component.ipinterface import IpInterfaceInfo
-from Products.Zuul.infos.component import ComponentInfo
+from Products.Zuul.infos.component.winservice import WinServiceInfo
 from Products.Zuul.infos import ProxyProperty
 from Products.Zuul.decorators import info
 
@@ -41,22 +41,10 @@ class InterfaceInfo(schema.InterfaceInfo, IpInterfaceInfo):
     implements(IInterfaceInfo)
 
 
-class WinServiceInfo(ComponentInfo):
+class WinServiceInfo(WinServiceInfo):
     implements(IWinServiceInfo)
 
-    title = ProxyProperty('title')
-    serviceName = ProxyProperty('serviceName')
-    caption = ProxyProperty('caption')
-    description = ProxyProperty('description')
-    startMode = ProxyProperty('startMode')
-    startName = ProxyProperty('startName')
     usermonitor = ProxyProperty('usermonitor')
-
-    @property
-    @info
-    def formatted_description(self):
-        return '<div style="white-space: normal;">{}</div>'.format(
-            self._object.description)
 
     def getMonitor(self):
         monitorstatus = self._object.monitored()

--- a/ZenPacks/zenoss/Microsoft/Windows/interfaces.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/interfaces.py
@@ -7,13 +7,10 @@
 #
 ##############################################################################
 
-
 from . import schema
 
 from Products.Zuul.form import schema as form_schema
-
 import Products.Zuul.interfaces.component as zuul
-from Products.Zuul.interfaces.component import IComponentInfo
 from Products.Zuul.utils import ZuulMessageFactory as _t
 
 
@@ -41,11 +38,8 @@ class IInterfaceInfo(schema.IInterfaceInfo, zuul.IIpInterfaceInfo):
     """
 
 
-class IWinServiceInfo(IComponentInfo):
-    title = form_schema.TextLine(title=_t(u'Title'), readonly=True)
-    servicename = form_schema.TextLine(title=_t(u'Service Name'), readonly=True)
-    caption = form_schema.TextLine(title=_t(u'Caption'), readonly=True)
-    formatted_description = form_schema.TextLine(title=_t(u'Description'), readonly=True)
-    startmode = form_schema.TextLine(title=_t(u'Start Mode'), readonly=True)
-    account = form_schema.TextLine(title=_t(u'Account'), readonly=True)
-    usermonitor = form_schema.TextLine(title=_t(u'User Selected Monitor State'), readonly=True)
+class IWinServiceInfo(zuul.IWinServiceInfo):
+    """
+    Info adapter for WinService components.
+    """
+    usermonitor = form_schema.Bool(title=_t(u'User Selected Monitor State'), readonly=True)

--- a/ZenPacks/zenoss/Microsoft/Windows/resources/js/global.js
+++ b/ZenPacks/zenoss/Microsoft/Windows/resources/js/global.js
@@ -15,22 +15,22 @@ Ext.define("Zenoss.component.WinRMServicePanel", {
     extend:"Zenoss.component.ComponentGridPanel",
     constructor: function(config) {
         config = Ext.applyIf(config||{}, {
-            autoExpandColumn: 'displayname',
+            autoExpandColumn: 'caption',
             componentType: 'WinRMService',
             fields: [
                 {name: 'uid'},
                 {name: 'severity'},
-                {name: 'meta_type'},
+                {name: 'status'},
                 {name: 'name'},
-                {name: 'title'},
-                {name: 'serviceName'},
+                {name: 'meta_type'},
+                {name: 'locking'},
+                {name: 'usesMonitorAttribute'},
+                {name: 'monitor'},
+                {name: 'monitored'},
                 {name: 'caption'},
                 {name: 'startMode'},
                 {name: 'startName'},
-                {name: 'usesMonitorAttribute'},
-                {name: 'monitor'},
-                {name: 'locking'},
-                {name: 'monitored'}
+                {name: 'serviceClassUid'}
             ],
             columns: [{
                 id: 'severity',
@@ -38,23 +38,18 @@ Ext.define("Zenoss.component.WinRMServicePanel", {
                 header: _t('Events'),
                 renderer: Zenoss.render.severity,
                 sortable: true,
-                width: 50
+                width: 60
             },{
                 id: 'name',
-                dataIndex: 'serviceName',
-                header: _t('Name'),
+                dataIndex: 'name',
+                header: _t('Service Name'),
                 sortable: true,
-                width: 110
+                flex: 1,
+                renderer: Zenoss.render.WinServiceClass
             },{
-                id: 'displayname',
+                id: 'caption',
                 dataIndex: 'caption',
-                header: _t('Display Name'),
-                sortable: true
-            },{
-                id: 'startName',
-                dataIndex: 'startName',
-                header: _t('Start Name'),
-                widht: 110,
+                header: _t('Caption'),
                 sortable: true
             },{
                 id: 'startmode',
@@ -62,6 +57,18 @@ Ext.define("Zenoss.component.WinRMServicePanel", {
                 header: _t('Start Mode'),
                 sortable: true,
                 width: 110
+            },{
+                id: 'startName',
+                dataIndex: 'startName',
+                header: _t('Start Name'),
+                widht: 110,
+                sortable: true
+            },{
+               id: 'status',
+                dataIndex: 'status',
+                header: _t('Status'),
+                renderer: Zenoss.render.pingStatus,
+                width: 60
             },{
                 id: 'monitored',
                 dataIndex: 'monitored',
@@ -80,7 +87,7 @@ Ext.define("Zenoss.component.WinRMServicePanel", {
     }
 });
 
-ZC.registerName('WinRMService', _t('Service'), _t('Services'));
+ZC.registerName('WinRMService', _t('Windows Service'), _t('Windows Services'));
 
 
 /* WinRS Datasource UI ******************************************************/


### PR DESCRIPTION
- override WinService's getFailSeverity method to take into account
template-based  as well as service class severities
- revise ServiceDataSource to use WinService's getFailSeverity
- revise info.py and interface.py to include Fail Severity drop-down
(subclass WinServiceInfo/IWinServiceInfo)
- preserve info.py/interface.py overrides for usermonitor property
- revise javascript to better align with legacy while providing
formatting enhancements (column width)