### PR TITLE
change subclass for service datasource info

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1173,6 +1173,7 @@ Installing this ZenPack will add the following items to your Zenoss system.
 * Fix WinRM monitoring does not emit message for expired password (ZEN-23183)
 * Fix Windows kinit: Internal credentials cache error while storing credentials while getting initial credentials (ZEN-23238)
 * Fix MSSQL Queries wrong database for metric (ZEN-23228)
+* Fix Windows Service shows 'Up' when down if event class modified (ZEN-19615)
 
 ; 2.5.13
 * Fix Active Directory not correctly detected (ZEN-23137)

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ServiceDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ServiceDataSource.py
@@ -18,11 +18,12 @@ from zope.interface import implements
 from zope.schema.vocabulary import SimpleVocabulary
 from twisted.internet import defer, error
 from twisted.python.failure import Failure
-from Products.Zuul.infos.template import RRDDataSourceInfo
-from Products.Zuul.interfaces import ICatalogTool, IRRDDataSourceInfo
+from Products.Zuul.infos import InfoBase
+from Products.Zuul.interfaces import ICatalogTool, IInfo
 from Products.Zuul.form import schema
 from Products.Zuul.infos import ProxyProperty
 from Products.Zuul.utils import ZuulMessageFactory as _t
+from Products.Zuul.utils import severityId
 from Products.ZenEvents import ZenEventClasses
 from Products.ZenUtils.Utils import prepId
 
@@ -106,10 +107,26 @@ class ServiceDataSource(PythonDataSource):
                     yield service
 
 
-class IServiceDataSourceInfo(IRRDDataSourceInfo):
+class IServiceDataSourceInfo(IInfo):
     """
     Provide the UI information for the WinRS Service datasource.
     """
+    newId = schema.TextLine(
+        title=_t(u'Name'),
+        xtype="idfield",
+        description=_t(u'The name of this datasource')
+    )
+    type = schema.TextLine(
+        title=_t(u'Type'),
+        readonly=True
+    )
+    enabled = schema.Bool(
+        title=_t(u'Enabled')
+    )
+
+    severity = schema.TextLine(title=_t(u'Severity'),
+                               xtype='severity')
+    component = schema.TextLine(title=_t(u'Component'))
 
     cycletime = schema.TextLine(
         title=_t(u'Cycle Time (seconds)'))
@@ -133,7 +150,7 @@ class IServiceDataSourceInfo(IRRDDataSourceInfo):
         title=_t('Inclusions(+)/Exclusions(-) separated by commas.  Regex accepted'))
 
 
-class ServiceDataSourceInfo(RRDDataSourceInfo):
+class ServiceDataSourceInfo(InfoBase):
     """
     Pull in proxy values so they can be utilized
     within the WinRS Service plugin.
@@ -144,6 +161,8 @@ class ServiceDataSourceInfo(RRDDataSourceInfo):
     testable = False
     cycletime = ProxyProperty('cycletime')
     servicename = ProxyProperty('servicename')
+    enabled = ProxyProperty('enabled')
+    component = ProxyProperty('component')
 
     def get_alertifnot(self):
         return self._object.alertifnot
@@ -168,6 +187,28 @@ class ServiceDataSourceInfo(RRDDataSourceInfo):
         self._object.in_exclusions = value
         for service in self._object.getAffectedServices():
             service.index_object()
+
+    @property
+    def type(self):
+        return self._object.sourcetype
+
+    @property
+    def newId(self):
+        return self._object.id
+
+    def set_severity(self, value):
+        try:
+            if isinstance(value, str):
+                value = severityId(value)
+        except ValueError:
+            # they entered junk somehow (default to info if invalid)
+            value = severityId('info')
+        self._object.severity = value
+
+    def get_severity(self):
+        return self._object.severity
+
+    severity = property(get_severity, set_severity)
 
     startmode = property(get_startmode, set_startmode)
     in_exclusions = property(get_in_exclusions, set_in_exclusions)
@@ -231,9 +272,7 @@ class ServicePlugin(PythonDataSourcePlugin):
     def buildServicesDict(self, datasources):
         services = {}
         for ds in datasources:
-            services[ds.params['servicename']] = {'eventClass': ds.eventClass,
-                                                  'eventKey': ds.eventKey,
-                                                  'severity': ds.severity,
+            services[ds.params['servicename']] = {'severity': ds.severity,
                                                   'alertifnot': ds.params['alertifnot']}
         return services
 
@@ -264,7 +303,7 @@ class ServicePlugin(PythonDataSourcePlugin):
             serviceinfo = results[results.keys()[0]]
         except:
             data['events'].append({
-                'eventClass': "/Status",
+                'eventClass': "/Status/WinService",
                 'severity': ZenEventClasses.Error,
                 'eventClassKey': 'WindowsServiceCollectionStatus',
                 'eventKey': 'WindowsServiceCollection',
@@ -288,8 +327,6 @@ class ServicePlugin(PythonDataSourcePlugin):
                 continue
 
             service = services[svc_id]
-            eventClass = service['eventClass'] if service['eventClass'] else "/Status"
-            eventKey = service['eventKey'] if service['eventKey'] else "WindowsService"
 
             if svc_info.State != service['alertifnot']:
 
@@ -303,9 +340,9 @@ class ServicePlugin(PythonDataSourcePlugin):
                     'service_name': svc_id,
                     'service_state': svc_info.State,
                     'service_status': svc_info.Status,
-                    'eventClass': eventClass,
+                    'eventClass': "/Status/WinService",
                     'eventClassKey': 'WindowsServiceLog',
-                    'eventKey': eventKey,
+                    'eventKey': "WindowsService",
                     'severity': service['severity'],
                     'summary': evtmsg,
                     'component': prepId(svc_id),
@@ -323,9 +360,9 @@ class ServicePlugin(PythonDataSourcePlugin):
                     'service_name': svc_id,
                     'service_state': svc_info.State,
                     'service_status': svc_info.Status,
-                    'eventClass': eventClass,
+                    'eventClass': "/Status/WinService",
                     'eventClassKey': 'WindowsServiceLog',
-                    'eventKey': eventKey,
+                    'eventKey': "WindowsService",
                     'severity': ZenEventClasses.Clear,
                     'summary': evtmsg,
                     'component': prepId(svc_id),
@@ -334,7 +371,7 @@ class ServicePlugin(PythonDataSourcePlugin):
 
         # Event to provide notification that check has completed
         data['events'].append({
-            'eventClass': "/Status",
+            'eventClass': "/Status/WinService",
             'device': config.id,
             'summary': 'Windows Service Check: successful service collection',
             'severity': ZenEventClasses.Clear,
@@ -345,7 +382,6 @@ class ServicePlugin(PythonDataSourcePlugin):
         return data
 
     def onError(self, result, config):
-        eventClass = "/Status"
         prefix = 'failed collection - '
         if isinstance(result, Failure):
             result = result.value
@@ -358,7 +394,7 @@ class ServicePlugin(PythonDataSourcePlugin):
         checkExpiredPassword(config, data['events'], result.message)
         if not data['events']:
             data['events'].append({
-                'eventClass': eventClass,
+                'eventClass': "/Status/WinService",
                 'severity': ZenEventClasses.Error,
                 'eventClassKey': 'WindowsServiceCollectionStatus',
                 'eventKey': 'WindowsServiceCollection',


### PR DESCRIPTION
Fixes ZEN-19615

Subclass interface and info off of base and add in only what we need
Change event class to /Status/WinService
We should not allow users to select an event class for service monitoring.
We need to see status by looking in /Status/WinService.