### PR TITLE
We only need to set the perfmon counter on physical adapters

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1174,6 +1174,7 @@ Installing this ZenPack will add the following items to your Zenoss system.
 * Fix Windows kinit: Internal credentials cache error while storing credentials while getting initial credentials (ZEN-23238)
 * Fix MSSQL Queries wrong database for metric (ZEN-23228)
 * Fix Windows Service shows 'Up' when down if event class modified (ZEN-19615)
+* Fix Windows Installed on UCS shows 2 interfaces where there's only 1 (ZEN-23379)
 
 ; 2.5.13
 * Fix Active Directory not correctly detected (ZEN-23137)

--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/Interfaces.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/Interfaces.py
@@ -320,7 +320,9 @@ class Interfaces(WinRMPlugin):
                 int_om.ifindex = inter.Index
 
             if inter.Index in perfmonInstanceMap:
-                int_om.perfmonInstance = perfmonInstanceMap[inter.Index]
+                # only physical adapters will have perfmon data
+                if inter.PhysicalAdapter.lower() == 'true':
+                    int_om.perfmonInstance = perfmonInstanceMap[inter.Index]
             else:
                 log.warning("Adapter '%s':%d does not have a perfmon "
                             "instance name and will not be monitored for "

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testInterfaces.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testInterfaces.py
@@ -77,7 +77,7 @@ class TestInterfacesCounters(BaseTestCase):
         data = self.plugin.process(self.device, self.results, Mock())
         self.assertEquals(len(data.maps), 14)
 
-        self.assertEquals(data.maps[7].perfmonInstance, "\\Network Interface(RedHat PV NIC Driver)")
+        self.assertFalse(hasattr(data.maps[7], 'perfmonInstance'))
         self.assertEquals(data.maps[12].perfmonInstance, "\\Network Interface(RedHat PV NIC Driver _2)")
 
 


### PR DESCRIPTION
Fixes ZEN-23379

Fix unit test to account for Interfaces modeler change