### PR TITLE
Fixes ZEN-23713

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/WinService.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/WinService.py
@@ -202,7 +202,8 @@ class WinService(BaseWinService):
                 # if it's still undefined, check for other datasources
                 if not self.datasource_id:
                     for datasource in template.getRRDDataSources():
-                        if datasource.id == 'DefaultService': continue
+                        if datasource.id == 'DefaultService': 
+                            continue
                         test_datasource(datasource)
 
     def getFailSeverity(self):
@@ -212,8 +213,8 @@ class WinService(BaseWinService):
         template = self.getRRDTemplate()
         if template:
             datasource = template.datasources._getOb(self.datasource_id, None)
-        if datasource:
-            return datasource.severity
+            if datasource:
+                return datasource.severity
         return self.getAqProperty("zFailSeverity")
 
     def getFailSeverityString(self):

--- a/ZenPacks/zenoss/Microsoft/Windows/WinService.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/WinService.py
@@ -22,7 +22,6 @@ class WinService(BaseWinService):
     '''
     Model class for Windows Service.
     '''
-    meta_type = portal_type = 'WinRMService'
 
     servicename = None
     caption = None
@@ -31,6 +30,7 @@ class WinService(BaseWinService):
     account = None
     monitor = False
     usermonitor = False
+    datasource_id = None
 
     _properties = BaseWinService._properties + (
         {'id': 'servicename', 'label': 'Service Name', 'type': 'string'},
@@ -97,17 +97,10 @@ class WinService(BaseWinService):
             return self.monitor
 
         # 2 - Check what our template says to do.
-        template = self.getRRDTemplate()
-        if template:
-            datasource = template.datasources._getOb('DefaultService', None)
-            if datasource:
-                if self.getMonitored(datasource):
-                    return True
-            # 3 - Allow for other datasources to be specified.
-            for datasource in template.getRRDDataSources():
-                if datasource.id != 'DefaultService' and hasattr(datasource, 'startmode'):
-                    if self.getMonitored(datasource):
-                        return True
+        datasource = self.getMonitoredDataSource()
+        if datasource and self.getMonitored(datasource):
+            self.monitor = True
+            return True
 
         # 3 check the service class
         # be sure we can get the serviceclass and that we have a relationship with serviceclass
@@ -119,11 +112,14 @@ class WinService(BaseWinService):
                 if self.startMode in sc.monitoredStartModes:
                     # check the zMonitor organizer property
                     if org and hasattr(org, 'zMonitor'):
+                        self.monitor = org.zMonitor
                         return org.zMonitor
         # don't monitor Disabled services
         if self.startMode and self.startMode == "Disabled":
+            self.monitor = False
             return False
 
+        self.monitor = False
         return False
 
     def get_serviceclass_startmodes(self):
@@ -161,12 +157,70 @@ class WinService(BaseWinService):
         ''''''
         data = {}
         for svc in self.device().os.winservices():
-            if svc.monitored():
+            if svc.monitor:
                 data[svc.id] = {'modes': svc.get_serviceclass_startmodes(),
                                 'mode': svc.startMode,
-                                'monitor': svc.monitored()
+                                'monitor': svc.monitor,
+                                'severity': svc.getFailSeverity(),
                                 }
         return data
+
+    def getMonitoredDataSource(self):
+        '''Return datasource for template if it exists'''
+        # first there must be a template
+        if not self.datasource_id:
+            self.setMonitoredDataSource()
+        # return the datasource if it is set
+        if self.datasource_id:
+            # return monitored datasource
+            template = self.getRRDTemplate()
+            if template:
+                datasource = template.datasources._getOb(self.datasource_id, None)
+                if datasource and self.getMonitored(datasource):
+                    return datasource
+        # if returning the datasource fails reset the datasource_id to none
+        self.datasource_id = None
+        return None
+
+    def setMonitoredDataSource(self):
+        ''' set the datasource_id parameter if
+            a valid datasource can be found
+        '''
+        def test_datasource(ds):
+            '''set self.datasource_id if valid'''
+            if hasattr(ds, 'startmode') and self.getMonitored(ds):
+                self.datasource_id = ds.id
+
+        # if not defined, try to define it
+        if not self.datasource_id:
+            template = self.getRRDTemplate()
+            if template:
+                # first check DefaultService
+                datasource = template.datasources._getOb('DefaultService', None)
+                if datasource:
+                    test_datasource(datasource)
+                # if it's still undefined, check for other datasources
+                if not self.datasource_id:
+                    for datasource in template.getRRDDataSources():
+                        if datasource.id == 'DefaultService': continue
+                        test_datasource(datasource)
+
+    def getFailSeverity(self):
+        """
+        Return the severity for this service when it fails.
+        """
+        template = self.getRRDTemplate()
+        if template:
+            datasource = template.datasources._getOb(self.datasource_id, None)
+        if datasource:
+            return datasource.severity
+        return self.getAqProperty("zFailSeverity")
+
+    def getFailSeverityString(self):
+        """
+        Return a string representation of zFailSeverity
+        """
+        return self.ZenEventManager.severities[self.getFailSeverity()]
 
     def getMonitoredStartModes(self):
         return self.get_serviceclass_startmodes()

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ServiceDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ServiceDataSource.py
@@ -343,7 +343,7 @@ class ServicePlugin(PythonDataSourcePlugin):
                     'eventClass': "/Status/WinService",
                     'eventClassKey': 'WindowsServiceLog',
                     'eventKey': "WindowsService",
-                    'severity': service['severity'],
+                    'severity': winsvc.get('severity', service.get('severity', 3)),
                     'summary': evtmsg,
                     'component': prepId(svc_id),
                     'device': config.id,

--- a/ZenPacks/zenoss/Microsoft/Windows/info.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/info.py
@@ -12,7 +12,7 @@ from Products.Zuul.infos.component.filesystem import FileSystemInfo
 from Products.Zuul.infos.component.cpu import CPUInfo
 from Products.Zuul.infos.component.osprocess import OSProcessInfo
 from Products.Zuul.infos.component.ipinterface import IpInterfaceInfo
-from Products.Zuul.infos.component import ComponentInfo
+from Products.Zuul.infos.component.winservice import WinServiceInfo
 from Products.Zuul.infos import ProxyProperty
 from Products.Zuul.decorators import info
 
@@ -41,22 +41,10 @@ class InterfaceInfo(schema.InterfaceInfo, IpInterfaceInfo):
     implements(IInterfaceInfo)
 
 
-class WinServiceInfo(ComponentInfo):
+class WinServiceInfo(WinServiceInfo):
     implements(IWinServiceInfo)
 
-    title = ProxyProperty('title')
-    serviceName = ProxyProperty('serviceName')
-    caption = ProxyProperty('caption')
-    description = ProxyProperty('description')
-    startMode = ProxyProperty('startMode')
-    startName = ProxyProperty('startName')
     usermonitor = ProxyProperty('usermonitor')
-
-    @property
-    @info
-    def formatted_description(self):
-        return '<div style="white-space: normal;">{}</div>'.format(
-            self._object.description)
 
     def getMonitor(self):
         monitorstatus = self._object.monitored()

--- a/ZenPacks/zenoss/Microsoft/Windows/interfaces.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/interfaces.py
@@ -7,13 +7,10 @@
 #
 ##############################################################################
 
-
 from . import schema
 
 from Products.Zuul.form import schema as form_schema
-
 import Products.Zuul.interfaces.component as zuul
-from Products.Zuul.interfaces.component import IComponentInfo
 from Products.Zuul.utils import ZuulMessageFactory as _t
 
 
@@ -41,11 +38,8 @@ class IInterfaceInfo(schema.IInterfaceInfo, zuul.IIpInterfaceInfo):
     """
 
 
-class IWinServiceInfo(IComponentInfo):
-    title = form_schema.TextLine(title=_t(u'Title'), readonly=True)
-    servicename = form_schema.TextLine(title=_t(u'Service Name'), readonly=True)
-    caption = form_schema.TextLine(title=_t(u'Caption'), readonly=True)
-    formatted_description = form_schema.TextLine(title=_t(u'Description'), readonly=True)
-    startmode = form_schema.TextLine(title=_t(u'Start Mode'), readonly=True)
-    account = form_schema.TextLine(title=_t(u'Account'), readonly=True)
-    usermonitor = form_schema.TextLine(title=_t(u'User Selected Monitor State'), readonly=True)
+class IWinServiceInfo(zuul.IWinServiceInfo):
+    """
+    Info adapter for WinService components.
+    """
+    usermonitor = form_schema.Bool(title=_t(u'User Selected Monitor State'), readonly=True)

--- a/ZenPacks/zenoss/Microsoft/Windows/resources/js/global.js
+++ b/ZenPacks/zenoss/Microsoft/Windows/resources/js/global.js
@@ -15,22 +15,22 @@ Ext.define("Zenoss.component.WinRMServicePanel", {
     extend:"Zenoss.component.ComponentGridPanel",
     constructor: function(config) {
         config = Ext.applyIf(config||{}, {
-            autoExpandColumn: 'displayname',
+            autoExpandColumn: 'caption',
             componentType: 'WinRMService',
             fields: [
                 {name: 'uid'},
                 {name: 'severity'},
-                {name: 'meta_type'},
+                {name: 'status'},
                 {name: 'name'},
-                {name: 'title'},
-                {name: 'serviceName'},
+                {name: 'meta_type'},
+                {name: 'locking'},
+                {name: 'usesMonitorAttribute'},
+                {name: 'monitor'},
+                {name: 'monitored'},
                 {name: 'caption'},
                 {name: 'startMode'},
                 {name: 'startName'},
-                {name: 'usesMonitorAttribute'},
-                {name: 'monitor'},
-                {name: 'locking'},
-                {name: 'monitored'}
+                {name: 'serviceClassUid'}
             ],
             columns: [{
                 id: 'severity',
@@ -38,23 +38,18 @@ Ext.define("Zenoss.component.WinRMServicePanel", {
                 header: _t('Events'),
                 renderer: Zenoss.render.severity,
                 sortable: true,
-                width: 50
+                width: 60
             },{
                 id: 'name',
-                dataIndex: 'serviceName',
-                header: _t('Name'),
+                dataIndex: 'name',
+                header: _t('Service Name'),
                 sortable: true,
-                width: 110
+                flex: 1,
+                renderer: Zenoss.render.WinServiceClass
             },{
-                id: 'displayname',
+                id: 'caption',
                 dataIndex: 'caption',
-                header: _t('Display Name'),
-                sortable: true
-            },{
-                id: 'startName',
-                dataIndex: 'startName',
-                header: _t('Start Name'),
-                widht: 110,
+                header: _t('Caption'),
                 sortable: true
             },{
                 id: 'startmode',
@@ -62,6 +57,18 @@ Ext.define("Zenoss.component.WinRMServicePanel", {
                 header: _t('Start Mode'),
                 sortable: true,
                 width: 110
+            },{
+                id: 'startName',
+                dataIndex: 'startName',
+                header: _t('Start Name'),
+                widht: 110,
+                sortable: true
+            },{
+               id: 'status',
+                dataIndex: 'status',
+                header: _t('Status'),
+                renderer: Zenoss.render.pingStatus,
+                width: 60
             },{
                 id: 'monitored',
                 dataIndex: 'monitored',
@@ -80,7 +87,7 @@ Ext.define("Zenoss.component.WinRMServicePanel", {
     }
 });
 
-ZC.registerName('WinRMService', _t('Service'), _t('Services'));
+ZC.registerName('WinRMService', _t('Windows Service'), _t('Windows Services'));
 
 
 /* WinRS Datasource UI ******************************************************/


### PR DESCRIPTION
- override WinService's getFailSeverity method to take into account
template-based  as well as service class severities
- revise ServiceDataSource to use WinService's getFailSeverity
- revise info.py and interface.py to include Fail Severity drop-down
(subclass WinServiceInfo/IWinServiceInfo)
- preserve info.py/interface.py overrides for usermonitor property
- revise javascript to better align with legacy while providing
formatting enhancements (column width)
- Revised template datasource identification method