### PR TITLE
Index services when datasource has been enabled/disabled

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -498,11 +498,13 @@ There are multiple ways to configure Windows service monitoring depending on if 
 
 See the following examples:
 
-;Enable or disable monitoring for a single service on a single server.
+;Manually Enable or disable monitoring for a single service on a single server.
 # Navigate to the service on the server.
 # Click to select it.
 # Choose ''Monitoring'' from the gear menu.
 # Choose Yes or No depending on what you want.
+
+{{note}} Once monitoring has been enabled or disabled for a service, no monitoring template will apply.  To reset this option for a service, uncheck the 'Manually Selected Monitor State' box in the Details of the service and save the change.
 
 ;Enable monitoring by default for the WinRM service wherever it is enabled.
 Option 1
@@ -526,7 +528,7 @@ Option 2
 # Optionally select a Local Failure Severity
 # Save
 
-[[note]] Setting a service to be monitored in this fashion will enable monitoring for the service regardless of device class.
+{{note}} Setting a service to be monitored in this fashion will enable monitoring for the service regardless of device class.
 
 ;Enable/Disable monitoring by default for the WinRM service for a select group of servers.
 # Create a new device class somewhere under ''/Server/Microsoft/Windows'' for the select group of servers.

--- a/ZenPacks/zenoss/Microsoft/Windows/WinService.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/WinService.py
@@ -33,12 +33,12 @@ class WinService(BaseWinService):
     datasource_id = None
 
     _properties = BaseWinService._properties + (
-        {'id': 'servicename', 'label': 'Service Name', 'type': 'string'},
+        {'id': 'serviceName', 'label': 'Service Name', 'type': 'string'},
         {'id': 'caption', 'label': 'Caption', 'type': 'string'},
         {'id': 'description', 'label': 'Description', 'type': 'string'},
-        {'id': 'startmode', 'label': 'Start Mode', 'type': 'string'},
-        {'id': 'account', 'label': 'Account', 'type': 'string'},
-        {'id': 'usermonitor', 'label': 'User Selected Monitor State',
+        {'id': 'startMode', 'label': 'Start Mode', 'type': 'string'},
+        {'id': 'startName', 'label': 'Start Name', 'type': 'string'},
+        {'id': 'usermonitor', 'label': 'Manually Selected Monitor State',
             'type': 'boolean'},
     )
 

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ServiceDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ServiceDataSource.py
@@ -161,7 +161,15 @@ class ServiceDataSourceInfo(InfoBase):
     testable = False
     cycletime = ProxyProperty('cycletime')
     servicename = ProxyProperty('servicename')
-    enabled = ProxyProperty('enabled')
+
+    def get_enabled(self, value):
+        return self._object.enabled
+
+    def set_enabled(self, value):
+        self._object.enabled = value
+        for service in self._object.getAffectedServices():
+            service.index_object()
+
     component = ProxyProperty('component')
 
     def get_alertifnot(self):
@@ -209,6 +217,7 @@ class ServiceDataSourceInfo(InfoBase):
         return self._object.severity
 
     severity = property(get_severity, set_severity)
+    enabled = property(get_enabled, set_enabled)
 
     startmode = property(get_startmode, set_startmode)
     in_exclusions = property(get_in_exclusions, set_in_exclusions)

--- a/ZenPacks/zenoss/Microsoft/Windows/interfaces.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/interfaces.py
@@ -42,4 +42,5 @@ class IWinServiceInfo(zuul.IWinServiceInfo):
     """
     Info adapter for WinService components.
     """
-    usermonitor = form_schema.Bool(title=_t(u'User Selected Monitor State'), readonly=True)
+    usermonitor = form_schema.Bool(title=_t(u'User Selected Monitor State'),
+                                   alwaysEditable=True)

--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/Services.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/Services.py
@@ -45,6 +45,7 @@ class Services(WinRMPlugin):
             om.serviceType = service.ServiceType
             om.startMode = service.StartMode
             om.startName = service.StartName
+            om.description = service.Description
             rm.append(om)
 
         maps = []


### PR DESCRIPTION
Fixes ZEN-23761

Added option to reset manually set monitoring for a service.
Fixed missing Details info, added Description to the modeler plugin