### PR TITLE
Fixes ZEN-23517

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/objects/objects.xml
+++ b/ZenPacks/zenoss/Microsoft/Windows/objects/objects.xml
@@ -5551,7 +5551,7 @@ True
 WinRM Ping
 </property>
 <property type="boolean" id="enabled" mode="w" >
-True
+False
 </property>
 <property type="int" id="severity" mode="w" >
 3


### PR DESCRIPTION
- disable WinRMPing datasource by default