### PR TITLE
disable datasource by default

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -626,6 +626,8 @@ WinRM Ping is a simple datasource that will attempt to retrieve basic data over 
 * The winrm service has stopped and cannot be restarted.
 * The monitoring user account password has expired.
 
+This datasource is not enabled by default.
+
 == Requirements ==
 
 This ZenPack has the following requirements.
@@ -1224,6 +1226,7 @@ Installing this ZenPack will add the following items to your Zenoss system.
 * Fix Windows Installed on UCS shows 2 interfaces where there's only 1 (ZEN-23379)
 * Fix Windows ZenPack, doesn't send Datasource fields in 'cmd' to Parsers (ZEN-23739)
 * Fix Windows Zenpack Impact relationships are inconsistent (ZEN-18648)
+* Fix WinRMPing datasource should be disabled by default (ZEN-23517)
 
 ; 2.5.13
 * Fix Active Directory not correctly detected (ZEN-23137)

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/WinRMPingDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/WinRMPingDataSource.py
@@ -38,7 +38,7 @@ ZENPACKID = 'ZenPacks.zenoss.Microsoft.Windows'
 
 class WinRMPingDataSource(PythonDataSource):
     ZENPACKID = ZENPACKID
-    cycletime = '${here/zWinPerfmonInterval}'
+    cycletime = '300'
     sourcetypes = ('WinRM Ping',)
     sourcetype = sourcetypes[0]
     enabled = True

--- a/ZenPacks/zenoss/Microsoft/Windows/objects/objects.xml
+++ b/ZenPacks/zenoss/Microsoft/Windows/objects/objects.xml
@@ -5557,7 +5557,7 @@ False
 3
 </property>
 <property type="string" id="cycletime" mode="w" >
-${here/zWinPerfmonInterval}
+300
 </property>
 <property type="string" id="plugin_classname" mode="w" >
 ZenPacks.zenoss.Microsoft.Windows.datasources.WinRMPingDataSource.WinRMPingDataSourcePlugin


### PR DESCRIPTION
Fixes ZEN-23517

Many customer/support complaints that this should not be enabled
by default.