### PR TITLE
Need to keep this file for backwards compatibility

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/zope_utils.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/zope_utils.py
@@ -1,0 +1,14 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2016, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+from ZenPacks.zenoss.Microsoft.Windows.BaseDevice import BaseDevice
+
+'''
+For backwards compatibility
+'''


### PR DESCRIPTION
Fixes ZEN-23967

Other zenpacks rely on the Windows zp.  Added this back in for
compatibility