### PR TITLE
Device was being returned for the class object. should be OSProcess

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1216,6 +1216,7 @@ Installing this ZenPack will add the following items to your Zenoss system.
 
 ; 2.6.1
 * Fix Microsoft Windows ZenPack doesn't work with HyperV pack (ZEN-23967)
+* Fix Microsoft Windows:  no collection when Processes are modeled (ZEN-24010)
 
 ; 2.6.0
 * Enabled the use of the Infrastructure -> Windows Services page

--- a/ZenPacks/zenoss/Microsoft/Windows/OSProcess.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/OSProcess.py
@@ -10,6 +10,8 @@
 from . import schema
 from .utils import get_properties
 
+from Products.ZenModel.OSProcess import OSProcess as BaseOSProcess
+
 
 class OSProcess(schema.OSProcess):
     '''
@@ -21,6 +23,9 @@ class OSProcess(schema.OSProcess):
     '''
 
     _properties = get_properties(schema.OSProcess)
+
+    def getClassObject(self):
+        return BaseOSProcess.getClassObject(self)
 
     def getRRDTemplateName(self):
         '''


### PR DESCRIPTION
Fixes ZEN-24010

> 2016-07-12 17:18:20,624 ERROR zen.hub: Unhandled exception in zenhub service ZenPacks.zenoss.PythonCollector.services.PythonConfig.PythonConfig: zAlertOnRestart 
Traceback (most recent call last): 
> File "/opt/zenoss/Products/ZenCollector/services/config.py", line 117, in _wrapFunction 
return functor(*args, **kwargs) 
> File "/opt/zenoss/Products/ZenCollector/services/config.py", line 261, in _createDeviceProxies 
proxy = self._createDeviceProxy(device) 
> File "/opt/zenoss/ZenPacks/ZenPacks.zenoss.PythonCollector-1.7.4.egg/ZenPacks/zenoss/PythonCollector/services/PythonConfig.py", line 73, in _createDeviceProxy 
self.component_datasources(component, collector)) 
> File "/opt/zenoss/ZenPacks/ZenPacks.zenoss.PythonCollector-1.7.4.egg/ZenPacks/zenoss/PythonCollector/services/PythonConfig.py", line 166, in _datasources 
ds_config.params = ds.getParams(deviceOrComponent) 
> File "/opt/zenoss/ZenPacks/ZenPacks.zenoss.PythonCollector-1.7.4.egg/ZenPacks/zenoss/PythonCollector/datasources/PythonDataSource.py", line 94, in getParams 
return self.getPluginClass().params(self, context) 
> File "/opt/zenoss/ZenPacks/ZenPacks.zenoss.Microsoft.Windows-2.6.0.egg/ZenPacks/zenoss/Microsoft/Windows/datasources/ProcessDataSource.py", line 252, in params
params[key] = value() if callable(value) else value 
> File "/opt/zenoss/Products/ZenModel/OSProcess.py", line 223, in alertOnRestart 
return self.getAqProperty("zAlertOnRestart") 
> File "/opt/zenoss/Products/ZenModel/DeviceComponent.py", line 145, in getAqProperty 
return getattr(classObj, prop) 
> AttributeError: zAlertOnRestart
> Deleting all the processes allows a poll to go, but once processes are back, it dies again.