### PR TITLE
ZEN-23827: Editing a Windows Service (WinService) Locks Up Zope and Times Out

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/jobs.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/jobs.py
@@ -1,0 +1,35 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2016, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+"""
+Zenpack's jobs.
+"""
+
+from Products.Jobber.jobs import Job
+
+
+class ReindexWinServices(Job):
+
+    """Job for reindexing affected Windows services components when related
+    datasource was updated.
+    """
+
+    @classmethod
+    def getJobType(cls):
+        return "Reindex Windows services"
+
+    @classmethod
+    def getJobDescription(cls, *args, **kwargs):
+        return "Reindex Windows services linked to {uid} template".format(**kwargs)
+
+    def _run(self, uid, **kwargs):
+        template = self.dmd.unrestrictedTraverse(uid)
+
+        for service in template.getAffectedServices():
+            service.index_object()

--- a/ZenPacks/zenoss/Microsoft/Windows/patches/platform.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/patches/platform.py
@@ -101,3 +101,15 @@ def getDevTypes(self, uid):
         return data
     return filter(lambda x: x['value'] != '/zport/dmd/Devices/Server/Microsoft',
                   data)
+
+@monkeypatch('Products.Zuul.facades.templatefacade.TemplateFacade')
+def _editDetails(self, info, data):
+    """
+    Calls `post_update` method if defined.
+    """
+    result = original(self, info, data)
+
+    if hasattr(info, 'post_update'):
+        info.post_update()
+
+    return result


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-23827

As re-indexing of all affected WinServices takes to much time, moved this operation to zenjobs to don't block UI.