### PR TITLE
Service monitoring should follow the order of precedence

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1214,6 +1214,9 @@ Installing this ZenPack will add the following items to your Zenoss system.
 
 == Changes ==
 
+; 2.6.2
+* Fix WinRM ZenPack - Windows Services page elections conflict with WinService template exclusions (ZEN-24165)
+
 ; 2.6.1
 * Fix Microsoft Windows ZenPack doesn't work with HyperV pack (ZEN-23967)
 * Fix Microsoft Windows:  no collection when Processes are modeled (ZEN-24010)

--- a/ZenPacks/zenoss/Microsoft/Windows/WinService.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/WinService.py
@@ -13,9 +13,13 @@ import string
 from Globals import InitializeClass
 from AccessControl import ClassSecurityInfo
 from Products.ZenModel.WinService import WinService as BaseWinService
-from Products.ZenModel.Service import Service
+from Products.ZenEvents import ZenEventClasses
 
 log = logging.getLogger('zen.MicrosoftWindows')
+
+UNMONITORED = 0
+MONITORED = 1
+EXCLUDED = 2
 
 
 class WinService(BaseWinService):
@@ -25,8 +29,6 @@ class WinService(BaseWinService):
 
     description = None
     usermonitor = False
-
-    datasource_id = None
 
     _properties = BaseWinService._properties + (
         {'id': 'description', 'label': 'Description', 'type': 'string'},
@@ -55,170 +57,79 @@ class WinService(BaseWinService):
     def getRRDTemplates(self):
         return [self.getRRDTemplateByName(self.getRRDTemplateName())]
 
-    def is_match(self, service_regex):
+    def isMatch(self, service_regex):
         # can be actual name of service or a regex
         allowed_chars = set(string.ascii_letters + string.digits + '_-')
         if not set(service_regex) - allowed_chars:
             return service_regex.lower() == self.serviceName.lower()
         try:
-            regx = re.compile(service_regex, re.I)
+            regx = re.compile(service_regex)
         except re.error as e:
             log.warn(e)
             return False
-        if regx.match(self.serviceName):
+        if regx.match(self.serviceName, re.I):
             return True
         return False
 
     def getMonitored(self, datasource):
         # match on start mode and include/exclude list of regex/service names
         # exclusion will override an inclusion
-        rtn = False
+        # return one of UNMONITORED, MONITORED, EXCLUDED
+        monitored = UNMONITORED
         for startmode in datasource.startmode.split(','):
             if startmode in self.startMode.split(',') and hasattr(datasource, 'in_exclusions'):
                 for service in datasource.in_exclusions.split(','):
                     service_regex = service.strip()
-                    if service_regex.startswith('+') and self.is_match(service_regex[1:]):
-                        rtn = True
-                    elif service_regex.startswith('-') and self.is_match(service_regex[1:]):
-                        return False
-        return rtn
+                    if service_regex.startswith('+') and self.isMatch(service_regex[1:]):
+                        monitored = MONITORED
+                    elif service_regex.startswith('-') and self.isMatch(service_regex[1:]):
+                        return EXCLUDED
+        return monitored
 
     def monitored(self):
-        """detect and set changes to self.monitor and ensure reindexing."""
-        to_monitor = self.is_monitored()
-        if self.monitor != to_monitor:
-            setattr(self, 'monitor', to_monitor)
-            self.index_object()
-        return getattr(self, 'monitor')
-
-    def is_monitored(self):
-        """Return True if this service should be monitored. False otherwise."""
+        # Determine whether or not to monitor this service
+        # Set necessary defaults
+        self.alertifnot = 'Running'
+        self.failSeverity = ZenEventClasses.Error
         # 1 - Check to see if the user has manually set monitor status
-        if not self.usermonitor:
-            datasource = self.getMonitoredDataSource()
-            sc = self.getClassObject()
-            # 2 - Check what our template says to do.
-            if datasource and datasource.enabled and self.getMonitored(datasource):
-                return True
-            # 3 check the service class
-            elif sc:
-                valid_start = self.startMode in sc.monitoredStartModes
-                # check the inherited zMonitor property
-                return valid_start and self.getAqProperty('zMonitor')
-            # 4 otherwise just inherit from the base WinService class
-            else:
-                return BaseWinService.monitored(self)
-        else:
-            self.datasource_id = None
-            # if so, return whatever user has set it to
+        if self.usermonitor:
             return self.monitor
-        return False
 
-    def get_monitored_startmodes(self):
-        ''' determine the start modes for this services
-            giving precedence to manual monitoring, followed
-            by local template override, and falling back on
-            service class if not defined
-        '''
-        if self.usermonitor is True:
-            return [self.startMode]
+        # Check what our template says to do.
+        template = self.getRRDTemplate()
+        if template:
+            # 2 - Check DefaultService DataSource
+            datasource = template.datasources._getOb('DefaultService', None)
+            if datasource and datasource.enabled:
+                status = self.getMonitored(datasource)
+                if status is MONITORED:
+                    self.failSeverity = datasource.severity
+                    self.alertifnot = datasource.alertifnot
+                    return True
+                elif status is EXCLUDED:
+                    return False
+            # 3 - Check other DataSources
+            for datasource in template.getRRDDataSources():
+                if datasource.id != 'DefaultService' and\
+                   hasattr(datasource, 'startmode') and\
+                   datasource.enabled:
+                        status = self.getMonitored(datasource)
+                        if status is MONITORED:
+                            self.failSeverity = datasource.severity
+                            self.alertifnot = datasource.alertifnot
+                            return True
+                        elif status is EXCLUDED:
+                            return False
 
-        # give priority to template
-        datasource = self.get_template_datasource()
-        if datasource and self.getMonitored(datasource) and hasattr(datasource, 'startmode'):
-            modes = datasource.startmode.split(',')
-            if 'None' in modes:
-                modes.remove('None')
-            if len(modes) > 0:
-                return modes
-
-        # fallback to serviceclass
+        # 4 check the service class
         sc = self.getClassObject()
         if sc:
-            return sc.monitoredStartModes
-        return []
+            valid_start = self.startMode in sc.monitoredStartModes
+            # check the inherited zMonitor property
+            self.failSeverity = self.getAqProperty("zFailSeverity")
+            return valid_start and self.getAqProperty('zMonitor')
 
-    def get_winservices_modes(self):
-        '''Return data about this service to ServiceDataSource'''
-        return {'modes': self.getMonitoredStartModes(),
-                'mode': self.startMode,
-                'monitor': self.isMonitored(),
-                'severity': self.getFailSeverity(),
-                'manual': self.usermonitor,
-                'alertifnot': self.get_alertifnot(),
-                }
-
-    def getMonitoredDataSource(self):
-        '''Return datasource for template if it exists'''
-        # try to return datasource, setting back to None if fails
-        if self.datasource_id:
-            datasource = self.get_template_datasource()
-            if not datasource:
-                self.datasource_id = None
-            return datasource
-        else:
-            template = self.getRRDTemplate()
-            if template:
-                self.setMonitoredDataSource()
-                return self.get_template_datasource()
-        return None
-
-    def setMonitoredDataSource(self):
-        ''' set the datasource_id parameter if
-            a valid datasource can be found
-        '''
-        def test_datasource(ds):
-            '''set self.datasource_id if valid'''
-            if hasattr(ds, 'startmode') and ds.enabled and self.getMonitored(ds):
-                self.datasource_id = ds.id
-
-        # if not defined, try to define it
-        if not self.datasource_id:
-            template = self.getRRDTemplate()
-            if template:
-                # first check DefaultService
-                datasource = template.datasources._getOb('DefaultService', None)
-                if datasource:
-                    test_datasource(datasource)
-                # if it's still undefined, check for other datasources
-                if not self.datasource_id:
-                    for datasource in template.getRRDDataSources():
-                        if datasource.id == 'DefaultService':
-                            continue
-                        test_datasource(datasource)
-
-    def get_alertifnot(self):
-        datasource = self.get_template_datasource()
-        if datasource:
-            return getattr(datasource, 'alertifnot', 'Running')
-        return 'Running'
-
-    def get_template_datasource(self):
-        """
-            Attempt to return the proper template datasource if it exists
-        """
-        template = self.getRRDTemplate()
-        if template and self.datasource_id:
-            return template.datasources._getOb(self.datasource_id, None)
-        return None
-
-    def getFailSeverity(self):
-        """
-        Return the severity for this service when it fails.
-        """
-        datasource = self.get_template_datasource()
-        if datasource:
-            return datasource.severity
-        return self.getAqProperty("zFailSeverity")
-
-    def getFailSeverityString(self):
-        """
-        Return a string representation of zFailSeverity
-        """
-        return self.ZenEventManager.severities[self.getFailSeverity()]
-
-    def getMonitoredStartModes(self):
-        return self.get_monitored_startmodes()
+        return False
 
     security.declareProtected('Manage DMD', 'manage_editService')
     def manage_editService(self, *args, **kwargs):

--- a/ZenPacks/zenoss/Microsoft/Windows/configure.zcml
+++ b/ZenPacks/zenoss/Microsoft/Windows/configure.zcml
@@ -5,6 +5,8 @@
     xmlns:zcml="http://namespaces.zope.org/zcml"
     >
 
+    <subscriber handler=".handlers.onServiceDataSourceMoved" />
+
 	<!-- components -->
     <adapter
         factory=".info.FileSystemInfo"

--- a/ZenPacks/zenoss/Microsoft/Windows/handlers.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/handlers.py
@@ -1,0 +1,25 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2013, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+from zope.component import adapter
+from OFS.interfaces import IObjectWillBeMovedEvent
+from OFS.event import ObjectWillBeRemovedEvent
+
+from datasources.ServiceDataSource import ServiceDataSource
+from jobs import ReindexWinServices
+
+DEFAULT_SERVICE = '/zport/dmd/Devices/Server/Microsoft/rrdTemplates/WinService/datasources/DefaultService'
+
+
+@adapter(ServiceDataSource, IObjectWillBeMovedEvent)
+def onServiceDataSourceMoved(ob, event):
+    if isinstance(event, ObjectWillBeRemovedEvent):
+        dmd = ob.getDmdRoot("Devices")
+        if dmd:
+            dmd.JobManager.addJob(ReindexWinServices, kwargs=dict(uid=DEFAULT_SERVICE))

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testServiceDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testServiceDataSource.py
@@ -30,18 +30,19 @@ class TestServiceDataSourcePlugin(BaseTestCase):
                         'alertifnot': 'Running',
                         }
 
-        self.ds = [MagicMock(params={'eventlog': sentinel.eventlog, 
+        self.ds = [MagicMock(params={'eventlog': sentinel.eventlog,
                                      'winservices': self.context,
                                      'usermonitor': False,
-                                     'servicename': 'aspnet_state'
+                                     'servicename': 'aspnet_state',
+                                     'severity': 3,
+                                     'alertifnot': 'Running'
                                      })]
 
     def test_onSuccess(self):
-        self.plugin.buildServicesDict(self.ds)
         data = self.plugin.onSuccess(self.success, MagicMock(
-           id=sentinel.id,
-           datasources=self.ds,
-        ))
+                                     id=sentinel.id,
+                                     datasources=self.ds,
+                                     ))
         self.assertEquals(len(data['events']), 2)
         self.assertEquals(data['events'][0]['summary'],
                           'Service Alert: aspnet_state has changed to Stopped state')


### PR DESCRIPTION
Fixes ZEN-24165

Enabling/disabling monitoring for a service should obey the 4 laws
Simplified the monitored() method.  We can get all the
information we need from the context when a datasource is created.
We know which services are monitored because there are datasources
for the ones that are being monitored.  We should also reindex
services if a datasource is removed.

update readme

fix version #