### PR TITLE
Make sure a service is not excluded

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/WinService.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/WinService.py
@@ -108,7 +108,8 @@ class WinService(BaseWinService):
                     return True
                 elif status is EXCLUDED:
                     return False
-            # 3 - Check other DataSources
+            # 3 - Check all other DataSources
+            ds_monitored = False
             for datasource in template.getRRDDataSources():
                 if datasource.id != 'DefaultService' and\
                    hasattr(datasource, 'startmode') and\
@@ -117,9 +118,11 @@ class WinService(BaseWinService):
                         if status is MONITORED:
                             self.failSeverity = datasource.severity
                             self.alertifnot = datasource.alertifnot
-                            return True
+                            ds_monitored = True
                         elif status is EXCLUDED:
                             return False
+            if ds_monitored:
+                return True
 
         # 4 check the service class
         sc = self.getClassObject()
@@ -127,6 +130,7 @@ class WinService(BaseWinService):
             valid_start = self.startMode in sc.monitoredStartModes
             # check the inherited zMonitor property
             self.failSeverity = self.getAqProperty("zFailSeverity")
+
             return valid_start and self.getAqProperty('zMonitor')
 
         return False

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ServiceDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ServiceDataSource.py
@@ -240,7 +240,6 @@ class ServicePlugin(PythonDataSourcePlugin):
         return(
             context.device().id,
             datasource.getCycleTime(context),
-            datasource.id,
             datasource.plugin_classname,
         )
 


### PR DESCRIPTION
Fixes ZEN-24165

We need to look through all other datasources to see if a service
needs to be excluded from monitoring.  Also, no need to split up
configs by datasource id.  This can causes multiple queries for the
same service, which floods the system with unnecessary events.