### PR TITLE
Fix regex not matching

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/WinService.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/WinService.py
@@ -63,11 +63,11 @@ class WinService(BaseWinService):
         if not set(service_regex) - allowed_chars:
             return service_regex.lower() == self.serviceName.lower()
         try:
-            regx = re.compile(service_regex)
+            regx = re.compile(service_regex, re.I)
         except re.error as e:
             log.warn(e)
             return False
-        if regx.match(self.serviceName, re.I):
+        if regx.match(self.serviceName):
             return True
         return False
 


### PR DESCRIPTION
Fixes ZEN-24165

re.IGNORECASE does not match within the compiled regex in the match() method.
Move it to re.compile() and it does work