### PR TITLE
Migrate for OS relations added in 2.5.0

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1227,6 +1227,9 @@ Installing this ZenPack will add the following items to your Zenoss system.
 
 == Changes ==
 
+; 2.6.3
+* Fix potential "clusternetworks" and "clusternodes" errors after upgrading (ZEN-24401)
+
 ; 2.6.2
 * Fix WinRM ZenPack - Windows Services page elections conflict with WinService template exclusions (ZEN-24165)
 * Fix Modifying the WinService template causes parallel reindexing of the same components (ZEN-24375)

--- a/ZenPacks/zenoss/Microsoft/Windows/migrate/AddOSRelations.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/migrate/AddOSRelations.py
@@ -1,0 +1,67 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2016, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+import logging
+LOG = logging.getLogger("zen.Microsoft.Windows.migrate.{}".format(__name__))
+
+# Zenoss Imports
+from Products.ZenModel.migrate.Migrate import Version
+from Products.ZenModel.ZenPack import ZenPackMigration
+from Products.Zuul.interfaces import ICatalogTool
+
+# ZenPack Imports
+from ZenPacks.zenoss.Microsoft.Windows import progresslog
+from ZenPacks.zenoss.Microsoft.Windows.Device import Device
+from ZenPacks.zenoss.Microsoft.Windows.OperatingSystem import OperatingSystem
+
+
+# If the migration takes longer than this interval, a running progress
+# showing elapsed and estimated remaining time will be logged this
+# often. The value is in seconds.
+PROGRESS_LOG_INTERVAL = 10
+
+
+class AddOSRelations(ZenPackMigration):
+
+    version = Version(2, 6, 3)
+
+    def migrate(self, pack):
+        results = ICatalogTool(pack.dmd.Devices).search(Device)
+
+        LOG.info("starting: %s total devices", results.total)
+        progress = progresslog.ProgressLogger(
+            LOG,
+            prefix="progress",
+            total=results.total,
+            interval=PROGRESS_LOG_INTERVAL)
+
+        objects_migrated = 0
+
+        for result in results:
+            try:
+                if self.updateRelations(result.getObject()):
+                    objects_migrated += 1
+            except Exception:
+                LOG.exception(
+                    "error updating relationships for %s", result.id)
+
+            progress.increment()
+
+        LOG.info(
+            "finished: %s of %s devices required migration",
+            objects_migrated,
+            results.total)
+
+    def updateRelations(self, device):
+        for relname in (x[0] for x in OperatingSystem._relations):
+            if not device.os.aqBaseHasAttr(relname):
+                device.os.buildRelations()
+                return True
+
+        return False

--- a/ZenPacks/zenoss/Microsoft/Windows/progresslog.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/progresslog.py
@@ -1,0 +1,90 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2014, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+"""Periodic progress logging for long-running operations.
+
+Example usage:
+
+    import logging
+    LOG = logging.getLogger(__name__)
+
+    import time
+    import progresslog
+
+    mylist = range(100)
+
+    progress = ProgressLogger(
+        LOG,
+        prefix="progress",
+        total=len(mylist),
+        interval=1)
+
+    for i in mylist:
+        progress.increment()
+        time.sleep(0.2)
+
+"""
+
+import datetime
+import logging
+
+
+class ProgressLogger(object):
+
+    """Periodic progress logging for long-running operations."""
+
+    def __init__(
+            self,
+            logger,
+            level=logging.INFO,
+            prefix='',
+            total=None,
+            interval=60):
+
+        self.logger = logger
+        self.level = level
+        self.prefix = prefix
+        self.total = total
+        self.interval = datetime.timedelta(seconds=interval)
+
+        self.pos = 0
+        self.start_time = datetime.datetime.now()
+        self.last_time = self.start_time
+
+    def increment(self, by=1):
+        """Increment internal position and emit progress log if needed."""
+        self.pos += by
+
+        now = datetime.datetime.now()
+        if now - self.last_time >= self.interval:
+            self.last_time = now
+
+            progress = '{} of {}'.format(
+                self.pos,
+                self.total if self.total else '?')
+
+            elapsed = now - self.start_time
+
+            if self.total:
+                per = elapsed / self.pos
+                remaining = per * (self.total - self.pos)
+
+                msg = '{}, elapsed={}, remaining={}'.format(
+                    progress,
+                    str(elapsed).split('.', 1)[0],
+                    str(remaining).split('.', 1)[0])
+            else:
+                msg = '{}, elapsed={}'.format(
+                    progress,
+                    str(elapsed).split('.', 1)[0])
+
+            if self.prefix:
+                msg = '{}: {}'.format(self.prefix, msg)
+
+            self.logger.log(self.level, msg)

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/test_AddOSRelations.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/test_AddOSRelations.py
@@ -1,0 +1,103 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2016, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+# stdlib imports
+import copy
+
+# ZenPack imports
+from .. import zenpacklib
+from .. import ZenPack
+from ..OperatingSystem import OperatingSystem
+from ..migrate.AddOSRelations import AddOSRelations
+
+# Local testing imports
+from .utils import create_device
+
+zenpacklib.enableTesting()
+
+
+class migrateTests(zenpacklib.TestCase):
+    """Tests for AddOSRelations.migrate()."""
+
+    def afterSetUp(self):
+        super(migrateTests, self).afterSetUp()
+
+        pack = ZenPack("ZenPacks.zenoss.Microsoft.Windows")
+        packs = self.dmd.ZenPackManager.packs
+        packs._setObject(pack.id, pack)
+        self.pack = packs._getOb(pack.id)
+        self.step = AddOSRelations()
+
+    def test_needed(self):
+        """Test that migration works when it is needed."""
+        original_relations = copy.copy(OperatingSystem._relations)
+
+        # Remove the new relations from OperatingSystem. This will allow the
+        # following device creation to simulate how the device and it's os
+        # would have been created in versions before 2.5.0.
+        OperatingSystem._relations = tuple(
+            x for x in OperatingSystem._relations
+            if x[0] not in ("clusternodes", "clusternetworks"))
+
+        try:
+            device = create_device(
+                dmd=self.dmd,
+                zPythonClass="ZenPacks.zenoss.Microsoft.Windows.Device",
+                device_id="test-windows1",
+                datamaps=[])
+        finally:
+            # Restore OperatingSystem._relations to its original value to avoid
+            # interfering with other tests.
+            OperatingSystem._relations = original_relations
+
+        os = device.os
+
+        # Make sure our test is setup properly.
+        self.assertFalse(
+            os.aqBaseHasAttr("clusternodes") or os.aqBaseHasAttr("clusternetworks"),
+            "{}.os has clusternodes or clusternetworks relationships before migrate"
+            .format(device.id))
+
+        self.step.migrate(self.pack)
+
+        # Validate that the relationships were created.
+        self.assertTrue(
+            os.aqBaseHasAttr("clusternodes") and os.aqBaseHasAttr("clusternetworks"),
+            "{}.os is missing clusternodes or clusternetworks relationship(s) after migrate"
+            .format(device.id))
+
+        # Validate that the relationship methods return iterables.
+        len(os.clusternodes() + os.clusternetworks())
+
+    def test_unneeded(self):
+        """Test the migration doesn't fail with it isn't needed."""
+        device = create_device(
+            dmd=self.dmd,
+            zPythonClass="ZenPacks.zenoss.Microsoft.Windows.Device",
+            device_id="test-windows1",
+            datamaps=[])
+
+        os = device.os
+
+        # Make sure our test is setup properly.
+        self.assertTrue(
+            os.aqBaseHasAttr("clusternodes") and os.aqBaseHasAttr("clusternetworks"),
+            "{}.os is missing clusternodes or clusternetworks relationship(s) before migrate"
+            .format(device.id))
+
+        self.step.migrate(self.pack)
+
+        # Validate that the relationships were created.
+        self.assertTrue(
+            os.aqBaseHasAttr("clusternodes") and os.aqBaseHasAttr("clusternetworks"),
+            "{}.os is missing clusternodes or clusternetworks relationship(s) after migrate"
+            .format(device.id))
+
+        # Validate that the relationship methods return iterables.
+        len(os.clusternodes() + os.clusternetworks())

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/utils.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/utils.py
@@ -11,6 +11,8 @@ import os
 import gzip
 import pickle
 
+from Products.DataCollector.ApplyDataMap import ApplyDataMap
+
 
 class StringAttributeObject(dict):
     def __setattr__(self, k, v):
@@ -40,3 +42,17 @@ def test_suite(testnames):
     for testname in testnames:
         suite.addTest(makeSuite(testname))
     return suite
+
+
+def create_device(dmd, zPythonClass, device_id, datamaps):
+    device = dmd.Devices.findDeviceByIdExact(device_id)
+    if not device:
+        deviceclass = dmd.Devices.createOrganizer("/Server/SSH/Linux")
+        deviceclass.setZenProperty("zPythonClass", zPythonClass)
+        device = deviceclass.createInstance(device_id)
+
+    adm = ApplyDataMap()._applyDataMap
+
+    [adm(device, datamap) for datamap in datamaps]
+
+    return device


### PR DESCRIPTION
7a2024c added clusternetworks and clusternodes relationships to the
OperatingSystem class, but it didn't include a migration script to get
those relationships added to existing devices. This can result in errors
such as the following in UI flares, and perhaps elsewhere.

    AttributeError: clusternetworks

Partially fixes ZEN-24401.