### PR TITLE
Omit WinService from ResetClassTypes migration

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/migrate/ResetClassTypes.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/migrate/ResetClassTypes.py
@@ -34,7 +34,6 @@ from ZenPacks.zenoss.Microsoft.Windows.Interface import Interface
 from ZenPacks.zenoss.Microsoft.Windows.OSProcess import OSProcess
 from ZenPacks.zenoss.Microsoft.Windows.TeamInterface import TeamInterface
 from ZenPacks.zenoss.Microsoft.Windows.WinIIS import WinIIS
-from ZenPacks.zenoss.Microsoft.Windows.WinService import WinService
 from ZenPacks.zenoss.Microsoft.Windows.WinSQLBackup import WinSQLBackup
 from ZenPacks.zenoss.Microsoft.Windows.WinSQLDatabase import WinSQLDatabase
 from ZenPacks.zenoss.Microsoft.Windows.WinSQLInstance import WinSQLInstance
@@ -65,7 +64,6 @@ class ResetClassTypes(ZenPackMigration):
             OSProcess,
             TeamInterface,
             WinIIS,
-            WinService,
             WinSQLBackup,
             WinSQLDatabase,
             WinSQLInstance,


### PR DESCRIPTION
The RemoveWinRMServices migration script that's also targeted at 2.6.3
removes all WinRMSerice instances that this migration script was
reindexing. Due to ZenPackCmd performing all migrations within the same
paused(onIndexingEvent) context manager this lead to a situation where
the deferred indexing if WinRMService instances would fail with the
following traceback.

    ...
      File "/opt/zenoss/Products/Zuul/catalog/global_catalog.py", line 287, in searchExcerpt
        o.name(), o.device().titleOrId())
    AttributeError: 'NoneType' object has no attribute 'titleOrId'

This bug was introduced in 68a2b76. I thought the omision of WinService
indexing was accidental, so I added it. In retrospect the omission was
necessary.

The simple solution is to stop reindexing WinRMService instances that
are going to be removed anyway.

Fixes ZEN-24436.