### PR TITLE
Respect Component WinService template over all others

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1230,6 +1230,7 @@ Installing this ZenPack will add the following items to your Zenoss system.
 
 ; 2.6.4
 * Fix Windows ZenPack incorrectly assumes that the first database returned is the master when modeling databases, backups, and jobs (ZEN-24519)
+* Fix WinRM ZenPack - WinService components disabled at template still show "Monitored" in component view (ZEN-24528)
 
 ; 2.6.3
 * Fix potential "clusternetworks" and "clusternodes" errors after upgrading (ZEN-24401)

--- a/ZenPacks/zenoss/Microsoft/Windows/WinService.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/WinService.py
@@ -100,6 +100,8 @@ class WinService(BaseWinService):
         if template:
             # 2 - Check DefaultService DataSource
             datasource = template.datasources._getOb('DefaultService', None)
+            if datasource and not datasource.enabled and template.id == self.serviceName:
+                return False
             if datasource and datasource.enabled:
                 status = self.getMonitored(datasource)
                 if status is MONITORED:


### PR DESCRIPTION
Fixes ZEN-24528

If a user has copied the default template in order to disable monitoring
we should honor that before any other datasources in the default template