### PR TITLE
Check ping status if there are no winrm ping status problems

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/Device.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/Device.py
@@ -21,13 +21,17 @@ from Products.ZenUtils.IpUtil import getHostByName
 
 from . import schema
 
+
 class Device(schema.Device):
     '''
     Model class for a Windows operating system device.
     '''
 
     def getPingStatus(self):
-        return self.getStatus('/Status/Winrm/Ping')
+        pingStatus = self.getStatus('/Status/Winrm/Ping')
+        if not pingStatus:
+            return super(Device, self).getPingStatus()
+        return pingStatus
 
     def setClusterMachines(self, clusterdnsnames):
         '''


### PR DESCRIPTION
Fixes ZEN-24556

First check if there is a winrmping down event.  if there are none
then check the ping status.