### PR TITLE
Assign object displayName to object title

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/Processes.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/Processes.py
@@ -83,6 +83,7 @@ class Processes(WinRMPlugin):
 
         for om in oms:
             om.supports_WorkingSetPrivate = supports_WorkingSetPrivate
+            om.title = om.displayName
             rm.append(om)
 
         return rm

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testProcesses.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testProcesses.py
@@ -30,3 +30,4 @@ class TestProcesses(BaseTestCase):
             self.assertTrue(i.id.startswith('zport_dmd_Processes_Zenoss_osProcessClasses_WIN_'))
             self.assertEquals(i.setOSProcessClass, '/Processes/Zenoss/osProcessClasses/WIN')
             self.assertEquals(i.displayName, i.monitoredProcesses[0])
+            self.assertEquals(i.displayName, i.title)


### PR DESCRIPTION
Fixes ZEN-25311

We need to populate object title with object displayName.
Otherwise object id will be used as title, and we don't want that.
Update unit test as well.