### PR TITLE
Fix partial subclassing of platform model classes

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
+++ b/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
@@ -48,17 +48,11 @@ class_relationships:
 
 
 classes:
-  DEFAULTS:
-    base: [BaseComponent]
-
   BaseDevice:
     base: [zenpacklib.Device]
-  
-  BaseComponent:
-    base: [zenpacklib.Component, Products.ZenModel.OSComponent.OSComponent]
 
   ClusterObject:
-    base: [BaseComponent]
+    base: [zenpacklib.OSComponent]
     properties:
       DEFAULTS:
         grid_display: false
@@ -364,7 +358,7 @@ classes:
 
   CPU:
     label: Processor
-    base: [zenpacklib.Component, Products.ZenModel.CPU.CPU]
+    base: [zenpacklib.CPU]
     properties:
       DEFAULTS:
         grid_display: false
@@ -397,7 +391,7 @@ classes:
 
   FileSystem:
     label: File System
-    base: [BaseComponent, Products.ZenModel.FileSystem.FileSystem]
+    base: [zenpacklib.FileSystem]
     properties:
       DEFAULTS:
         details_display: false
@@ -422,7 +416,7 @@ classes:
 
   Interface:
     label: Interface
-    base: [BaseComponent, Products.ZenModel.IpInterface.IpInterface]
+    base: [zenpacklib.IpInterface]
     monitoring_templates: [ethernetCsmacd]
     impacts: []
     impacted_by: [device]
@@ -438,7 +432,7 @@ classes:
 
   OSProcess:
     label: Process
-    base: [BaseComponent, Products.ZenModel.OSProcess.OSProcess]
+    base: [zenpacklib.OSProcess]
     monitoring_templates: [OSProcess]
     properties:
       supports_WorkingSetPrivate:
@@ -454,7 +448,7 @@ classes:
 
   TeamInterface:
     label: Team Interface
-    base: [BaseComponent, Products.ZenModel.IpInterface.IpInterface]
+    base: [zenpacklib.IpInterface]
     monitoring_templates: [TeamInterface]
     properties:
       DEFAULTS:
@@ -477,6 +471,7 @@ classes:
 
   WinIIS:
     label: IIS Site
+    base: [zenpacklib.OSComponent]
     plural_label: IIS Sites
     properties:
       DEFAULTS:
@@ -514,6 +509,7 @@ classes:
 
   WinSQLBackup:
     label: SQL Backup
+    base: [zenpacklib.OSComponent]
     order: 13
     properties:
       DEFAULTS:
@@ -539,6 +535,7 @@ classes:
 
   WinSQLDatabase:
     label: SQL Database
+    base: [zenpacklib.OSComponent]
     order: 11
     properties:
       DEFAULTS:
@@ -586,6 +583,7 @@ classes:
 
   WinSQLInstance:
     label: SQL Instance
+    base: [zenpacklib.OSComponent]
     order: 10
     properties:
       DEFAULTS:
@@ -615,6 +613,7 @@ classes:
 
   WinSQLJob:
     label: SQL Job
+    base: [zenpacklib.OSComponent]
     order: 12
     properties:
       DEFAULTS:

--- a/ZenPacks/zenoss/Microsoft/Windows/zenpacklib.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/zenpacklib.py
@@ -68,10 +68,6 @@ from Products.AdvancedQuery import Eq, Or
 from Products.AdvancedQuery.AdvancedQuery import _BaseQuery as BaseQuery
 from Products.Five import zcml
 
-from Products.ZenModel.Device import Device as BaseDevice
-from Products.ZenModel.DeviceComponent import DeviceComponent as BaseDeviceComponent
-from Products.ZenModel.HWComponent import HWComponent as BaseHWComponent
-from Products.ZenModel.ManagedEntity import ManagedEntity as BaseManagedEntity
 from Products.ZenModel.ZenossSecurity import ZEN_CHANGE_DEVICE
 from Products.ZenModel.ZenPack import ZenPack as ZenPackBase
 from Products.ZenModel.CommentGraphPoint import CommentGraphPoint
@@ -90,6 +86,26 @@ from Products.ZenUI3.utils.javascript import JavaScriptSnippet
 from Products.ZenUtils.guid.interfaces import IGlobalIdentifier
 from Products.ZenUtils.Search import makeFieldIndex, makeKeywordIndex
 from Products.ZenUtils.Utils import monkeypatch, importClass
+
+# Extendable Model Classes
+from Products.ZenModel.CPU import CPU as BaseCPU
+from Products.ZenModel.Device import Device as BaseDevice
+from Products.ZenModel.DeviceComponent import DeviceComponent as BaseDeviceComponent
+from Products.ZenModel.ExpansionCard import ExpansionCard as BaseExpansionCard
+from Products.ZenModel.Fan import Fan as BaseFan
+from Products.ZenModel.FileSystem import FileSystem as BaseFileSystem
+from Products.ZenModel.HardDisk import HardDisk as BaseHardDisk
+from Products.ZenModel.HWComponent import HWComponent as BaseHWComponent
+from Products.ZenModel.IpInterface import IpInterface as BaseIpInterface
+from Products.ZenModel.IpRouteEntry import IpRouteEntry as BaseIpRouteEntry
+from Products.ZenModel.IpService import IpService as BaseIpService
+from Products.ZenModel.ManagedEntity import ManagedEntity as BaseManagedEntity
+from Products.ZenModel.OSComponent import OSComponent as BaseOSComponent
+from Products.ZenModel.OSProcess import OSProcess as BaseOSProcess
+from Products.ZenModel.PowerSupply import PowerSupply as BasePowerSupply
+from Products.ZenModel.Service import Service as BaseService
+from Products.ZenModel.TemperatureSensor import TemperatureSensor as BaseTemperatureSensor
+from Products.ZenModel.WinService import WinService as BaseWinService
 
 from Products import Zuul
 from Products.Zuul.catalog.events import IndexingEvent
@@ -1197,20 +1213,32 @@ def DeviceTypeFactory(name, bases):
     return device_type
 
 
-Device = DeviceTypeFactory(
-    'Device', (BaseDevice,))
-
-
 def ComponentTypeFactory(name, bases):
     """Return a "ZenPackified" component class given bases tuple."""
     return ModelTypeFactory(name, (ComponentBase,) + bases)
 
 
-Component = ComponentTypeFactory(
-    'Component', (BaseDeviceComponent, BaseManagedEntity))
+# Model Extension Classes
+Component = ComponentTypeFactory('Component', (BaseDeviceComponent, BaseManagedEntity))
+CPU = ComponentTypeFactory('CPU', (BaseCPU,))
+Device = DeviceTypeFactory('Device', (BaseDevice,))
+ExpansionCard = ComponentTypeFactory('ExpansionCard', (BaseExpansionCard,))
+Fan = ComponentTypeFactory('Fan', (BaseFan,))
+FileSystem = ComponentTypeFactory('FileSystem', (BaseFileSystem,))
+HardDisk = ComponentTypeFactory('HardDisk', (BaseHardDisk,))
+HWComponent = ComponentTypeFactory('HWComponent', (BaseHWComponent,))
+IpInterface = ComponentTypeFactory('IpInterface', (BaseIpInterface,))
+IpRouteEntry = ComponentTypeFactory('IpRouteEntry', (BaseIpRouteEntry,))
+IpService = ComponentTypeFactory('IpService', (BaseIpService,))
+OSComponent = ComponentTypeFactory('OSComponent', (BaseOSComponent,))
+OSProcess = ComponentTypeFactory('OSProcess', (BaseOSProcess,))
+PowerSupply = ComponentTypeFactory('PowerSupply', (BasePowerSupply,))
+Service = ComponentTypeFactory('Service', (BaseService,))
+TemperatureSensor = ComponentTypeFactory('TemperatureSensor', (BaseTemperatureSensor,))
+WinService = ComponentTypeFactory('WinService', (BaseWinService,))
 
-HardwareComponent = ComponentTypeFactory(
-    'HardwareComponent', (BaseHWComponent,))
+# Backwards-compatibility aliases.
+HardwareComponent = HWComponent
 
 
 class IHardwareComponentInfo(IBaseComponentInfo):


### PR DESCRIPTION
When zenpacklib is used with both zenpacklib.Component and a platform
component model classes such as IpInterface as base classes, some of the
platform model class' functionality is list. Specifically in this case
the IpInterface.index_object() method was never being called when
Windows Interface.index_object() was called. There's important
functionality in IpInterface.index_object() that must be used.

This fix enhances zenpacklib to provide a proxy base type for all
platform component model classes. This allows single-inheritence to be
used in zenpack.yaml, which greatly simplifies the ZenPack's job because
zenpacklib can take on the responsibility of making sure base class
functionality is used when appropriate.

Fixes ZEN-25559.