### PR TITLE
Only load the assembly version needed for the instance

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -825,7 +825,7 @@ The monitoring templates for SQL Server are component templates so there is no n
 
 {{note}} The default instance of MSSQLSERVER appears as the host name.
 
-{{note}} The authenticated user will need to be granted permission to view the server state.  For example, "GRANT VIEW SERVER STATE TO 'MYDOMAIN\zenoss_user'" or through the GUI in SQL Server Management Studio.
+{{note}} The authenticated user will need to be granted permission to view the server state.  For example, "GRANT VIEW SERVER STATE TO 'MYDOMAIN\zenoss_user'" or through the GUI in SQL Server Management Studio.  The user must also be interactive, i.e. the account must not be denied local logon rights.
 
 === Working with WinCommand Notification Action ===
 
@@ -1232,6 +1232,7 @@ Installing this ZenPack will add the following items to your Zenoss system.
 * Added additional event classes to cover connection errors (ZEN-25700)
 * Fix Windows Error Events come across as Info Events (ZEN-24633)
 * Fix Windows ZenPack - No "bad credentials" event for monitoring (ZEN-24726)
+* Fix MSSQL modeling doesn't pick up multiple instances if they're running different versions (ZEN-25851)
 
 ;2.6.5
 * Fix missing Process Set process title (ZEN-25311)

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
@@ -353,20 +353,22 @@ class CustomCommandStrategy(object):
                 'device': config.id})
         return collectedResult
 
+
 gsm.registerUtility(CustomCommandStrategy(), IStrategy, 'Custom Command')
 
 
 class SqlConnection(object):
 
-    def __init__(self, instance, sqlusername, sqlpassword, login_as_user):
+    def __init__(self, instance, sqlusername, sqlpassword, login_as_user, version):
         # Need to modify query where clause.
         # Currently all counters are retrieved for each database
         self.sqlConnection = []
+        self.version = version
 
         # DB Connection Object
         self.sqlConnection.append("$con = new-object "
-            "('Microsoft.SqlServer.Management.Common.ServerConnection')"
-                        "'{}', '{}', '{}';".format(instance, sqlusername, sqlpassword))
+                                  "('Microsoft.SqlServer.Management.Common.ServerConnection')"
+                                  "'{}', '{}', '{}';".format(instance, sqlusername, sqlpassword))
 
         if login_as_user:
             # Login using windows credentials
@@ -414,7 +416,7 @@ class PowershellMSSQLStrategy(object):
                                       'else { Write-Host "databasename:"$db.Name;}}}')
         command = "{0} \"& {{{1}}}\"".format(
             pscommand,
-            ''.join(getSQLAssembly() + sqlConnection.sqlConnection + counters_sqlConnection))
+            ''.join(getSQLAssembly(sqlConnection.version) + sqlConnection.sqlConnection + counters_sqlConnection))
         return command
 
     def parse_result(self, dsconfs, result):
@@ -482,7 +484,7 @@ class PowershellMSSQLJobStrategy(object):
         jobs_sqlConnection.append("}}")
         command = "{0} \"& {{{1}}}\"".format(
             pscommand,
-            ''.join(getSQLAssembly() + sqlConnection.sqlConnection + jobs_sqlConnection))
+            ''.join(getSQLAssembly(sqlConnection.version) + sqlConnection.sqlConnection + jobs_sqlConnection))
         return command
 
     def parse_result(self, dsconfs, result):
@@ -1070,29 +1072,30 @@ class ShellDataSourcePlugin(PythonDataSourcePlugin):
         resource = datasource.talesEval(datasource.resource, context)
         if not resource.startswith('\\') and \
             datasource.strategy not in ('powershell MSSQL',
-                'powershell Cluster Services',
-                'powershell Cluster Resources',
-                'powershell Cluster Nodes',
-                'powershell Cluster Disks',
-                'powershell Cluster Network',
-                'powershell Cluster Interface',
-                'Custom Command',
-                'DCDiag',
-                'powershell MSSQL Instance',
-                'powershell MSSQL Job'):
+                                        'powershell Cluster Services',
+                                        'powershell Cluster Resources',
+                                        'powershell Cluster Nodes',
+                                        'powershell Cluster Disks',
+                                        'powershell Cluster Network',
+                                        'powershell Cluster Interface',
+                                        'Custom Command',
+                                        'DCDiag',
+                                        'powershell MSSQL Instance',
+                                        'powershell MSSQL Job'):
             resource = '\\' + resource
         if safe_hasattr(context, 'perfmonInstance') and context.perfmonInstance is not None:
             resource = context.perfmonInstance + resource
-        
-        if safe_hasattr(context, 'instancename'):
-            instancename = context.instancename
-        else:
-            instancename = ''
 
-        if safe_hasattr(context, 'id'):
-            instanceid = context.id
-        else:
-            instanceid = ''
+        instancename = getattr(context, 'instancename', '')
+
+        instanceid = getattr(context, 'id', '')
+
+        version = getattr(context, 'sql_server_version', 0)
+        if not re.match('\d+\..*', version):
+            version = 0
+        # get the major version number so we pull the correct assembly in powershell
+        if version:
+            version = int(version.split('.')[0])
 
         try:
             contextURL = context.getPrimaryUrlPath()
@@ -1121,17 +1124,18 @@ class ShellDataSourcePlugin(PythonDataSourcePlugin):
         script = get_script(datasource, context)
 
         return dict(resource=resource,
-            strategy=datasource.strategy,
-            instancename=instancename,
-            instanceid=instanceid,
-            servername=servername,
-            script=script,
-            parser=parser,
-            usePowershell=datasource.usePowershell,
-            contextrelname=contextrelname,
-            contextcompname=contextcompname,
-            contextmodname=contextmodname,
-            contexttitle=contexttitle)
+                    strategy=datasource.strategy,
+                    instancename=instancename,
+                    instanceid=instanceid,
+                    servername=servername,
+                    script=script,
+                    parser=parser,
+                    usePowershell=datasource.usePowershell,
+                    contextrelname=contextrelname,
+                    contextcompname=contextcompname,
+                    contextmodname=contextmodname,
+                    contexttitle=contexttitle,
+                    version=version)
 
     def getSQLConnection(self, dsconf, conn_info):
         dbinstances = dsconf.zDBInstances
@@ -1174,7 +1178,8 @@ class ShellDataSourcePlugin(PythonDataSourcePlugin):
         sqlConnection = SqlConnection(instance_name,
                                       instance_login['username'],
                                       instance_login['password'],
-                                      instance_login['login_as_user'])
+                                      instance_login['login_as_user'],
+                                      dsconf.params['version'])
         return sqlConnection, conn_info
 
     @defer.inlineCallbacks
@@ -1193,7 +1198,7 @@ class ShellDataSourcePlugin(PythonDataSourcePlugin):
 
         if dsconf0.params['strategy'].startswith('powershell MSSQL'):
             cmd_line_input, conn_info = self.getSQLConnection(dsconf0,
-                                                             conn_info)
+                                                              conn_info)
             if dsconf0.params['strategy'] == 'powershell MSSQL Instance':
                 owner_node, server = dsconf.cluster_node_server.split('//')
                 if len(server.split('\\')) < 2:

--- a/ZenPacks/zenoss/Microsoft/Windows/migrate/MigrateSQLInstances.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/migrate/MigrateSQLInstances.py
@@ -1,0 +1,31 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2016, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+from Products.ZenModel.ZenPack import ZenPackMigration
+from Products.ZenModel.migrate.Migrate import Version
+from Products.Zuul.interfaces import ICatalogTool
+from ZenPacks.zenoss.Microsoft.Windows.WinSQLInstance import WinSQLInstance
+
+
+class MigrateSQLInstances(ZenPackMigration):
+    # Main class that contains the migrate() method.
+    # Note version setting.
+    version = Version(2, 6, 6)
+
+    def migrate(self, dmd):
+        results = ICatalogTool(dmd.getDmdRoot("Devices")).search(types=[WinSQLInstance])
+        for result in results:
+            try:
+                obj = result.getObject()
+            except Exception:
+                continue
+
+            version = getattr(obj, 'sql_server_version', None)
+            if version == 'None' or version is None:
+                obj.sql_server_version = 'Unknown'

--- a/ZenPacks/zenoss/Microsoft/Windows/utils.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/utils.py
@@ -136,8 +136,30 @@ def filter_sql_stdout(val):
     return filter(lambda x: x!="LogonUser succedded", val)
 
 
-def getSQLAssembly():
+def getSQLAssembly(version=None):
+    """Return only the powershell assembly version needed for the instance.
+    These statements are prepended to any sql server connections.
+    SQL server 2012 and 2014 can use the same version.
+    If no version is given then return all and hope the first one that
+    loads is correct.
+    Multiple versions of sql server can co-exist on the same machine.
 
+    example using sql server 11 or 12
+    try {
+        add-type -AssemblyName 'Microsoft.SqlServer.ConnectionInfo, Version=11.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91' -EA Stop
+    }
+    catch {
+        write-host 'assembly load error'
+    }
+    try {
+        add-type -AssemblyName 'Microsoft.SqlServer.Smo, Version=11.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91' -EA Stop
+    }
+    catch {
+        write-host 'assembly load error'
+    }
+
+    TODO:  Test with 2016 server
+    """
     ASSEMBLY_Connection = "add-type -AssemblyName 'Microsoft.SqlServer.ConnectionInfo"
     ASSEMBLY_Smo = "add-type -AssemblyName 'Microsoft.SqlServer.Smo"
 
@@ -161,6 +183,11 @@ def getSQLAssembly():
         ASSEMBLY_2012,
         ASSEMBLY)
 
+    MSSQL_CONNECTION_INFO = {9: MSSQL2005_CONNECTION_INFO,
+                             10: MSSQL2008_CONNECTION_INFO,
+                             11: MSSQL2012_CONNECTION_INFO,
+                             12: MSSQL2012_CONNECTION_INFO}
+
     MSSQL2005_SMO = '{0}, {1}, {2}'.format(
         ASSEMBLY_Smo,
         ASSEMBLY_2005,
@@ -176,32 +203,49 @@ def getSQLAssembly():
         ASSEMBLY_2012,
         ASSEMBLY)
 
+    MSSQL_SMO = {9: MSSQL2005_SMO,
+                 10: MSSQL2008_SMO,
+                 11: MSSQL2012_SMO,
+                 12: MSSQL2012_SMO}
+
     ASSEMBLY_LOAD_ERROR = "write-host 'assembly load error'"
 
     sqlConnection = []
-    sqlConnection.append("try{")
-    sqlConnection.append(MSSQL2012_CONNECTION_INFO)
-    sqlConnection.append("}catch{")
-    sqlConnection.append("try{")
-    sqlConnection.append(MSSQL2008_CONNECTION_INFO)
-    sqlConnection.append("}catch{")
-    sqlConnection.append("try{")
-    sqlConnection.append(MSSQL2005_CONNECTION_INFO)
-    sqlConnection.append("}catch{")
-    sqlConnection.append(ASSEMBLY_LOAD_ERROR)
-    sqlConnection.append("}}}")
+    if version not in [9, 10, 11, 12]:
+        sqlConnection.append("try{")
+        sqlConnection.append(MSSQL2012_CONNECTION_INFO)
+        sqlConnection.append("}catch{")
+        sqlConnection.append("try{")
+        sqlConnection.append(MSSQL2008_CONNECTION_INFO)
+        sqlConnection.append("}catch{")
+        sqlConnection.append("try{")
+        sqlConnection.append(MSSQL2005_CONNECTION_INFO)
+        sqlConnection.append("}catch{")
+        sqlConnection.append(ASSEMBLY_LOAD_ERROR)
+        sqlConnection.append("}}}")
 
-    sqlConnection.append("try{")
-    sqlConnection.append(MSSQL2012_SMO)
-    sqlConnection.append("}catch{")
-    sqlConnection.append("try{")
-    sqlConnection.append(MSSQL2008_SMO)
-    sqlConnection.append("}catch{")
-    sqlConnection.append("try{")
-    sqlConnection.append(MSSQL2005_SMO)
-    sqlConnection.append("}catch{")
-    sqlConnection.append(ASSEMBLY_LOAD_ERROR)
-    sqlConnection.append("}}}")
+        sqlConnection.append("try{")
+        sqlConnection.append(MSSQL2012_SMO)
+        sqlConnection.append("}catch{")
+        sqlConnection.append("try{")
+        sqlConnection.append(MSSQL2008_SMO)
+        sqlConnection.append("}catch{")
+        sqlConnection.append("try{")
+        sqlConnection.append(MSSQL2005_SMO)
+        sqlConnection.append("}catch{")
+        sqlConnection.append(ASSEMBLY_LOAD_ERROR)
+        sqlConnection.append("}}}")
+    else:
+        sqlConnection.append("try{")
+        sqlConnection.append(MSSQL_CONNECTION_INFO.get(version))
+        sqlConnection.append("}catch{")
+        sqlConnection.append(ASSEMBLY_LOAD_ERROR)
+        sqlConnection.append("}")
+        sqlConnection.append("try{")
+        sqlConnection.append(MSSQL_SMO.get(version))
+        sqlConnection.append("}catch{")
+        sqlConnection.append(ASSEMBLY_LOAD_ERROR)
+        sqlConnection.append("}")
 
     return sqlConnection
 

--- a/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
+++ b/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
@@ -592,6 +592,9 @@ classes:
       instancename:
         label: Instance Name
         grid_display: true
+      sql_server_version:
+        label: SQL Server Version
+        grid_display: true
       backupdevices:
         label: Backup Devices
       roles:


### PR DESCRIPTION
Fixes ZEN-25851

Multiple versions of sql server can co-exist.  we should only load
the assembly for the version of the instance we're modeling/monitoring.
This will also display the current version