### PR TITLE
Revert change from ZEN-25311

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/Processes.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/Processes.py
@@ -83,7 +83,6 @@ class Processes(WinRMPlugin):
 
         for om in oms:
             om.supports_WorkingSetPrivate = supports_WorkingSetPrivate
-            om.title = om.displayName
             rm.append(om)
 
         return rm


### PR DESCRIPTION
Fixes ZEN-25311

Changes in 2.6.6 correctly subclassed OSProcess so setting 'title'
became unnecessary, and as it turns out, destructive.  Zendesk ticket