### PR TITLE
FIX ZEN-26086, Unit Test Failure, Remove assertEquals(ObjectMap.title, ObjectMap.displayname)

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testProcesses.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testProcesses.py
@@ -30,4 +30,3 @@ class TestProcesses(BaseTestCase):
             self.assertTrue(i.id.startswith('zport_dmd_Processes_Zenoss_osProcessClasses_WIN_'))
             self.assertEquals(i.setOSProcessClass, '/Processes/Zenoss/osProcessClasses/WIN')
             self.assertEquals(i.displayName, i.monitoredProcesses[0])
-            self.assertEquals(i.displayName, i.title)


### PR DESCRIPTION
plugin.process() no longer sets title on an ObjectMap instance. The change to the test should've been reverted along with the reversion in commit b10e4a1fe9e6baef981ffec42272691d92a3edce