### PR TITLE
Don't send objectmaps to bog down zenhub

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1228,6 +1228,9 @@ Installing this ZenPack will add the following items to your Zenoss system.
 
 == Changes ==
 
+;2.6.9
+* Fix Windows Shell Datasources are sending datamaps and bogging down ZenHub (ZEN-26226)
+
 ;2.6.7
 * Fix TypeError during zenpython collection of a ShellDataSource (ZEN-25978)
 

--- a/ZenPacks/zenoss/Microsoft/Windows/WinSQLDatabase.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/WinSQLDatabase.py
@@ -15,7 +15,13 @@ log = logging.getLogger("zen.MicrosoftWindows")
 class WinSQLDatabase(schema.WinSQLDatabase):
     '''
     Base class for WinSQLDatabase classes.
-    
+
     This file exists to avoid ZenPack upgrade issues
     '''
+    def getStatus(self):
+        try:
+            status = int(self.cacheRRDValue('status', None))
+        except Exception:
+            return 'Unknown'
 
+        return 'Up' if status else 'Down'

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
@@ -1263,7 +1263,6 @@ class ShellDataSourcePlugin(PythonDataSourcePlugin):
             data['events'] = cmdResult.events
             if result.exit_code == 0:
                 dsconf = dsconfs[0]
-                data['maps'] = cmdResult.maps
                 for dp, value in cmdResult.values:
                     data['values'][dsconf.component][dp.id] = value, 'N'
             else:
@@ -1359,14 +1358,8 @@ class ShellDataSourcePlugin(PythonDataSourcePlugin):
                     if not dsconf:
                         continue
 
-                    dbid = dsconf.params['instanceid']
-                    dbstatus = 'Up' if db_statuses[db] else 'Down'
-                    instname = dsconf.params['instancename']
-
-                    data['maps'].append(ObjectMap({
-                        "compname": "os/winsqlinstances/{0}/databases/{1}".format(instname, dbid),
-                        "status": dbstatus
-                    }))
+                    dbstatus = 1 if db_statuses[db] else 0
+                    data['values'][dsconf.component]['status'] = dbstatus
 
                     summary='Database {0} is {1}.'.format(dsconf.params['contexttitle'], 'Accessible' if db_statuses[db] else 'Inaccessible')
                     data['events'].append(dict(

--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinMSSQL.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinMSSQL.py
@@ -388,7 +388,6 @@ class WinMSSQL(WinRMPlugin):
                             owner_node.strip(), sqlserver)
                         om_database.systemobject = dbdict['systemobject']
                         om_database.recoverymodel = dbdict['recoverymodel']
-                        om_database.status= 'Up' if dbdict['isaccessible'] == 'True' else 'Down'
 
                         database_oms.append(om_database)
                 elif in_backups:

--- a/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
+++ b/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
@@ -567,8 +567,10 @@ classes:
         label: System Object
       recoverymodel:
         label: Recovery Model
-      status:
+      getStatus:
         label: Status
+        api_only: true
+        api_backendtype: method
         grid_display: true
         order: 3
       cluster_node_server:


### PR DESCRIPTION
Fixes ZEN-26226

We shouldn't be applying objectmaps during monitoring.  this bogs down
zenhub.  set a simple status value that we can query.