### PR TITLE
Fix AttributeError, missing 'uuid' in zope

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1228,6 +1228,9 @@ Installing this ZenPack will add the following items to your Zenoss system.
 
 == Changes ==
 
+;2.6.11
+* Fix Monitoring of SQL Instances results in a UUID error (ZPS-453)
+
 ;2.6.9
 * Added Auth event clears, getPingStatus includes /Status/Ping event class (ZEN-25700)
 * Fix Windows Shell Datasources are sending datamaps and bogging down ZenHub (ZEN-26226)

--- a/ZenPacks/zenoss/Microsoft/Windows/WinSQLDatabase.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/WinSQLDatabase.py
@@ -18,7 +18,7 @@ class WinSQLDatabase(schema.WinSQLDatabase):
 
     This file exists to avoid ZenPack upgrade issues
     '''
-    def getStatus(self):
+    def getState(self):
         try:
             status = int(self.cacheRRDValue('status', None))
         except Exception:

--- a/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
+++ b/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
@@ -567,7 +567,7 @@ classes:
         label: System Object
       recoverymodel:
         label: Recovery Model
-      getStatus:
+      getState:
         label: Status
         api_only: true
         api_backendtype: method

--- a/ZenPacks/zenoss/Microsoft/Windows/zenpacklib.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/zenpacklib.py
@@ -2567,7 +2567,7 @@ class ClassSpec(Spec):
         if not bases:
             if self.is_device:
                 bases = [IBaseDeviceInfo]
-            elif self.is_component:
+            elif self.is_component or self.is_a(OSComponent):
                 bases = [IBaseComponentInfo]
             elif self.is_hardware_component:
                 bases = [IHardwareComponentInfo]
@@ -2624,7 +2624,7 @@ class ClassSpec(Spec):
         if not bases:
             if self.is_device:
                 bases = [BaseDeviceInfo]
-            elif self.is_component:
+            elif self.is_component or self.is_a(OSComponent):
                 bases = [BaseComponentInfo]
             elif self.is_hardware_component:
                 bases = [HardwareComponentInfo]


### PR DESCRIPTION
Fixes ZPS-453

OSComponents should also use the same info/interface classes as a Component

Also, getStatus is a reserved name, changed to getState