### PR TITLE
Add support for Hard Disks in Windows

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -46,8 +46,13 @@ The following components will be automatically discovered through the Windows se
 ;Processors
 : Attributes: Name, Description, Model, Socket, Cores, Threads, Clock Speed, External Speed, Voltage, L1 Cache Size, L2 Cache Size and Speed, L3 Cache Size and Speed
 
-;File System
+;Hard Disks
+: Attributes: Name, Size, Number of Partitions, Disk Ids, Free Space, Capabilities
+: Relationships: File Systems
+
+;File Systems
 : Attributes: Mount Point, Status, Storage Device, Type, Block Size, Total Blocks, Total Bytes, Maximum Name Length
+:Relationships: Hard Disks
 
 ;Interfaces
 : Attributes: Name, Description, MAC Address, MTU, Speed, Duplex, Type, Administrative Status, Operational Status, IP Addresses
@@ -1232,6 +1237,10 @@ Installing this ZenPack will add the following items to your Zenoss system.
 * ClusterInterface (in /Server/Microsoft/Cluster)
 
 == Changes ==
+
+;2.7.0
+* Add support for Hard Disk association with storage servers
+* Added Session Management to lower number of connections to Windows Servers
 
 ;2.6.11
 * Fix Monitoring of SQL Instances results in a UUID error (ZPS-453)

--- a/ZenPacks/zenoss/Microsoft/Windows/FileSystem.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/FileSystem.py
@@ -10,6 +10,7 @@
 from . import schema
 from .utils import get_properties
 
+
 class FileSystem(schema.FileSystem):
     '''
     Model class for FileSystem.
@@ -38,3 +39,9 @@ class FileSystem(schema.FileSystem):
         Return the total bytes of a filesytem for analytics
         """
         return self.blockSize * self.totalBlocks
+
+    def harddisk(self):
+        for hd in self.device().hw.harddisks():
+            if self.id in hd.fs_ids:
+                return hd
+        return None

--- a/ZenPacks/zenoss/Microsoft/Windows/HardDisk.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/HardDisk.py
@@ -1,0 +1,36 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2016, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+from . import schema
+from .utils import get_properties
+
+
+class HardDisk(schema.HardDisk):
+    """Model class for HardDisk."""
+
+    _properties = get_properties(schema.HardDisk)
+
+    def utilization(self):
+        if self.size == 0:
+            return 'Unknown'
+
+        util = int(float(self.size - self.freespace) / self.size * 100)
+
+        return '{}%'.format(util)
+
+    def filesystems(self):
+        file_systems = []
+        for fs in self.fs_ids:
+            try:
+                filesystem = self.device().os.filesystems._getOb(fs)
+            except Exception:
+                pass
+            else:
+                file_systems.append(filesystem)
+        return file_systems

--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/HardDisks.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/HardDisks.py
@@ -1,0 +1,120 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2013, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+'''
+Windows Hard Disks
+
+Models hard disks by querying Win32_Disk via WMI.
+'''
+
+from ZenPacks.zenoss.Microsoft.Windows.modeler.WinRMPlugin import WinRMPlugin
+from ZenPacks.zenoss.Microsoft.Windows.utils import save
+
+
+class HardDisks(WinRMPlugin):
+    compname = 'hw'
+    relname = 'harddisks'
+    modname = 'ZenPacks.zenoss.Microsoft.Windows.HardDisk'
+
+    associators = {
+        'diskdrives': {
+            'seed_class': 'Win32_DiskDrive',
+            'associations': [{'return_class': 'Win32_DiskDriveToDiskPartition',
+                              'search_class': 'Win32_DiskDrive',
+                              'search_property': 'DeviceID',
+                              'where_type': 'AssocClass'},
+                             {'return_class': 'Win32_LogicalDiskToPartition',
+                              'search_class': 'Win32_DiskPartition',
+                              'search_property': 'DeviceID',
+                              'where_type': 'AssocClass'
+                              }]
+        }
+    }
+
+    @save
+    def process(self, device, results, log):
+        rm = self.relMap()
+        try:
+            diskdrives = results.get('diskdrives').get('Win32_DiskDrive')
+        except Exception:
+            return rm
+        if not diskdrives:
+            return rm
+        partitions = results.get('diskdrives').get('Win32_DiskDriveToDiskPartition')
+        volumes = results.get('diskdrives').get('Win32_LogicalDiskToPartition')
+        for drive in diskdrives:
+            utilization = 0
+            fs_ids = []
+            for partition in partitions[drive.DeviceID]:
+                utilization += int(partition.Size)
+                for volume in volumes[partition.DeviceID]:
+                    fs_ids.append(self.prepId(volume.DeviceID))
+            freespace = int(drive.Size) - utilization
+            if freespace < 0:
+                freespace = 0
+            rm.append(self.objectMap({
+                'id': self.prepId(drive.PNPDeviceID),
+                'title': drive.Caption,
+                'size': int(drive.Size),
+                'partitions': int(drive.Partitions),
+                'capabilities': drive.CapabilityDescriptions,
+                'serialNumber': drive.SerialNumber.strip(),
+                'freespace': freespace,
+                'disk_ids': make_disk_ids(drive),
+                'fs_ids': fs_ids,
+            }))
+        return rm
+
+
+def reorder_serial(input_serial):
+    """
+    Take a serial number and reorder it into the orginal.
+
+    This will exclude the first 2 digits from the original format
+    since those are lost on the Windows side.
+    String must have even number of characters.
+    """
+    size = len(input_serial)
+    if size % 2 != 0:
+        return
+
+    # Remove the first 2 characters since not unique
+    input_serial = input_serial[2:]
+    new_serial = ''
+    for i in range(size, 0, -2):
+        new_serial += input_serial[i - 2:i]
+
+    return new_serial
+
+
+def make_disk_ids(disk_drive):
+    """From a Win32_DiskDrive object, create the disk_ids list."""
+    disk_ids = []
+    disk_ids.append(disk_drive.DeviceID)
+
+    # If no PNPDeviceID, its not a physical disk, so return None
+    pnpDevice = disk_drive.PNPDeviceID.strip()
+    if not pnpDevice:
+        return
+
+    disk_ids.append(pnpDevice)
+
+    # Append SerialNumber
+    serial = disk_drive.SerialNumber.strip()
+    if not serial:
+        return disk_ids
+
+    disk_ids.append(serial)
+
+    # Append the reordered serial to match CiscoUCS, minus first 2 characters
+    size = len(serial)
+    if size == 32:
+        disk_ids.append(reorder_serial(serial))
+
+    return disk_ids

--- a/ZenPacks/zenoss/Microsoft/Windows/objects/objects.xml
+++ b/ZenPacks/zenoss/Microsoft/Windows/objects/objects.xml
@@ -16430,7 +16430,7 @@ Windows Operating System
 [('Windows Server', 'WinRM')]
 </property>
 <property visible="True" type="lines" id="zCollectorPlugins" >
-['zenoss.winrm.OperatingSystem', 'zenoss.winrm.CPUs', 'zenoss.winrm.FileSystems', 'zenoss.winrm.Interfaces', 'zenoss.winrm.Services', 'zenoss.winrm.Processes', 'zenoss.winrm.Software']
+['zenoss.winrm.OperatingSystem', 'zenoss.winrm.CPUs', 'zenoss.winrm.FileSystems', 'zenoss.winrm.Interfaces', 'zenoss.winrm.Services', 'zenoss.winrm.Processes', 'zenoss.winrm.Software', 'zenoss.winrm.HardDisks']
 </property>
 <property visible="True" type="string" id="zPythonClass" >
 ZenPacks.zenoss.Microsoft.Windows.Device

--- a/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
+++ b/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
@@ -392,6 +392,47 @@ classes:
       impacts: []
       impacted_by: [device]
 
+  HardDisk:
+    label: Hard Disk
+    base: [zenpacklib.HardDisk]
+    meta_type: WindowsHardDisk
+    plural_label: Hard Disks
+    properties:
+      DEFAULTS:
+        grid_display: false
+      size:
+        label: Size
+        type: int
+        renderer: Zenoss.render.bytesString
+        order: 4.1
+        grid_display: true
+      utilization:
+        label: '% Util'
+        api_backendtype: method
+        api_only: true
+        grid_display: true
+      partitions:
+        label: Partitions
+        type: int
+        grid_display: true
+      capabilities:
+        label: Capabilities
+        type: lines
+      disk_ids:
+        label: 'Disk IDs'
+        type: lines
+      filesystems:
+        label: File Systems
+        type: entity
+        api_only: true
+        api_backendtype: method
+      fs_ids:
+        type: lines
+        details_display: false
+      freespace:
+        label: Free
+        type: int
+
   FileSystem:
     label: File System
     base: [zenpacklib.FileSystem]
@@ -409,6 +450,13 @@ classes:
         type: long
         label: Total Bytes
         default: 0
+      harddisk:
+        label: Hard Disk
+        type: entity
+        api_backendtype: method
+        api_only: true
+        grid_display: true
+        details_display: true
     monitoring_templates: [FileSystem]
     impacts: []
     impacted_by: [device]

--- a/ZenPacks/zenoss/Microsoft/Windows/zenpacklib.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/zenpacklib.py
@@ -130,6 +130,11 @@ from zope.publisher.interfaces.browser import IDefaultBrowserLayer
 from zope.viewlet.interfaces import IViewlet
 
 try:
+    from Products.Zuul.interfaces.component import IHardDiskInfo as IBaseHardDiskInfo
+except ImportError:
+    IBaseHardDiskInfo = IBaseComponentInfo
+
+try:
     import yaml
     import yaml.constructor
     YAML_INSTALLED = True
@@ -2567,6 +2572,8 @@ class ClassSpec(Spec):
         if not bases:
             if self.is_device:
                 bases = [IBaseDeviceInfo]
+            elif self.is_a(HardDisk):
+                bases = [IBaseHardDiskInfo]
             elif self.is_component or self.is_a(OSComponent):
                 bases = [IBaseComponentInfo]
             elif self.is_hardware_component:
@@ -2624,7 +2631,7 @@ class ClassSpec(Spec):
         if not bases:
             if self.is_device:
                 bases = [BaseDeviceInfo]
-            elif self.is_component or self.is_a(OSComponent):
+            elif self.is_component or self.is_a(OSComponent) or self.is_a(HardDisk):
                 bases = [BaseComponentInfo]
             elif self.is_hardware_component:
                 bases = [HardwareComponentInfo]


### PR DESCRIPTION
Fixes ZPS-479

This adds the Hard Disk component and modeler plugin to the ZenPack.
Models Hard Disk and finds associated file systems.  Links to File
System and provides a reverse link back to the Hard Disk.

TODO: Add Monitoring template