### PR TITLE
Ensure Windows Process display in Processes UI (ZPS-572)

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/OSProcess.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/OSProcess.py
@@ -8,8 +8,6 @@
 ##############################################################################
 
 from . import schema
-from .utils import get_properties
-
 from Products.ZenModel.OSProcess import OSProcess as BaseOSProcess
 
 
@@ -21,8 +19,6 @@ class OSProcess(schema.OSProcess):
     Depending on the version of Windows there are different per-process
     counters available.
     '''
-
-    _properties = get_properties(schema.OSProcess)
 
     def getClassObject(self):
         return BaseOSProcess.getClassObject(self)

--- a/ZenPacks/zenoss/Microsoft/Windows/configure.zcml
+++ b/ZenPacks/zenoss/Microsoft/Windows/configure.zcml
@@ -19,13 +19,6 @@
         for=".CPU.CPU"
         provides=".interfaces.ICPUInfo"
         />
-
-    <adapter
-        factory=".info.OSProcessInfo"
-        for=".OSProcess.OSProcess"
-        provides=".interfaces.IOSProcessInfo"
-        />
-
     <adapter
         factory=".info.InterfaceInfo"
         for=".Interface.Interface"

--- a/ZenPacks/zenoss/Microsoft/Windows/info.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/info.py
@@ -10,7 +10,6 @@
 from zope.interface import implements
 from Products.Zuul.infos.component.filesystem import FileSystemInfo
 from Products.Zuul.infos.component.cpu import CPUInfo
-from Products.Zuul.infos.component.osprocess import OSProcessInfo
 from Products.Zuul.infos.component.ipinterface import IpInterfaceInfo
 from Products.Zuul.infos.component.winservice import WinServiceInfo
 from Products.Zuul.infos import ProxyProperty
@@ -20,7 +19,6 @@ from . import schema
 from ZenPacks.zenoss.Microsoft.Windows.interfaces import (
     IFileSystemInfo,
     ICPUInfo,
-    IOSProcessInfo,
     IInterfaceInfo,
     IWinServiceInfo)
 
@@ -31,10 +29,6 @@ class FileSystemInfo(schema.FileSystemInfo, FileSystemInfo):
 
 class CPUInfo(schema.CPUInfo, CPUInfo):
     implements(ICPUInfo)
-
-
-class OSProcessInfo(schema.OSProcessInfo, OSProcessInfo):
-    implements(IOSProcessInfo)
 
 
 class InterfaceInfo(schema.InterfaceInfo, IpInterfaceInfo):

--- a/ZenPacks/zenoss/Microsoft/Windows/interfaces.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/interfaces.py
@@ -26,12 +26,6 @@ class ICPUInfo(schema.ICPUInfo, zuul.ICPUInfo):
     """
 
 
-class IOSProcessInfo(schema.IOSProcessInfo, zuul.IOSProcessInfo):
-    """
-    Info adapter for OSProcess components.
-    """
-
-
 class IInterfaceInfo(schema.IInterfaceInfo, zuul.IIpInterfaceInfo):
     """
     Info adapter for Interface components.

--- a/ZenPacks/zenoss/Microsoft/Windows/patches/platform.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/patches/platform.py
@@ -113,3 +113,13 @@ def _editDetails(self, info, data):
         info.post_update()
 
     return result
+
+
+# ZPS-572 Make sure our OSProcess subclass is included in the Process tab
+from Products.Zuul.facades.processfacade import ProcessFacade
+@property
+def _instanceClass(ob):
+    return ('Products.ZenModel.OSProcess.OSProcess', 'ZenPacks.zenoss.Microsoft.Windows.OSProcess.OSProcess')
+
+ProcessFacade._instanceClass = _instanceClass
+


### PR DESCRIPTION
- Fixes ZPS-572
- override _instanceClass attribute in ProcessFacade so that OSProcess
subclass is included
- Also removed unneeded info/interfaces/override code for OSProcess
class