### PR TITLE
Remove unneeded Interfaces/info/subclass code

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/FileSystem.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/FileSystem.py
@@ -8,15 +8,12 @@
 ##############################################################################
 
 from . import schema
-from .utils import get_properties
 
 
 class FileSystem(schema.FileSystem):
     '''
     Model class for FileSystem.
     '''
-
-    _properties = get_properties(schema.FileSystem)
 
     def monitored(self):
         '''

--- a/ZenPacks/zenoss/Microsoft/Windows/HardDisk.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/HardDisk.py
@@ -8,13 +8,10 @@
 ##############################################################################
 
 from . import schema
-from .utils import get_properties
 
 
 class HardDisk(schema.HardDisk):
     """Model class for HardDisk."""
-
-    _properties = get_properties(schema.HardDisk)
 
     def utilization(self):
         if self.size == 0:

--- a/ZenPacks/zenoss/Microsoft/Windows/Interface.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/Interface.py
@@ -8,7 +8,6 @@
 ##############################################################################
 
 from . import schema
-from .utils import get_properties
 
 
 class Interface(schema.Interface):
@@ -16,8 +15,6 @@ class Interface(schema.Interface):
     Model class for Interface
     '''
     portal_type = meta_type = 'IpInterface'
-
-    _properties = get_properties(schema.Interface)
 
     def monitored(self):
         '''

--- a/ZenPacks/zenoss/Microsoft/Windows/TeamInterface.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/TeamInterface.py
@@ -10,7 +10,6 @@
 from . import schema
 from zope.event import notify
 from Products.Zuul.catalog.events import IndexingEvent
-from .utils import get_properties
 
 
 class TeamInterface(schema.TeamInterface):
@@ -18,7 +17,6 @@ class TeamInterface(schema.TeamInterface):
     Model class for TeamInterface.
     '''
 
-    _properties = get_properties(schema.TeamInterface)
 
     def monitored(self):
         '''

--- a/ZenPacks/zenoss/Microsoft/Windows/configure.zcml
+++ b/ZenPacks/zenoss/Microsoft/Windows/configure.zcml
@@ -9,17 +9,6 @@
 
 	<!-- components -->
     <adapter
-        factory=".info.FileSystemInfo"
-        for=".FileSystem.FileSystem"
-        provides=".interfaces.IFileSystemInfo"
-        />
-
-    <adapter
-        factory=".info.CPUInfo"
-        for=".CPU.CPU"
-        provides=".interfaces.ICPUInfo"
-        />
-    <adapter
         factory=".info.InterfaceInfo"
         for=".Interface.Interface"
         provides=".interfaces.IInterfaceInfo"

--- a/ZenPacks/zenoss/Microsoft/Windows/info.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/info.py
@@ -8,8 +8,6 @@
 ##############################################################################
 
 from zope.interface import implements
-from Products.Zuul.infos.component.filesystem import FileSystemInfo
-from Products.Zuul.infos.component.cpu import CPUInfo
 from Products.Zuul.infos.component.ipinterface import IpInterfaceInfo
 from Products.Zuul.infos.component.winservice import WinServiceInfo
 from Products.Zuul.infos import ProxyProperty
@@ -17,18 +15,8 @@ from Products.Zuul.decorators import info
 
 from . import schema
 from ZenPacks.zenoss.Microsoft.Windows.interfaces import (
-    IFileSystemInfo,
-    ICPUInfo,
     IInterfaceInfo,
     IWinServiceInfo)
-
-
-class FileSystemInfo(schema.FileSystemInfo, FileSystemInfo):
-    implements(IFileSystemInfo)
-
-
-class CPUInfo(schema.CPUInfo, CPUInfo):
-    implements(ICPUInfo)
 
 
 class InterfaceInfo(schema.InterfaceInfo, IpInterfaceInfo):

--- a/ZenPacks/zenoss/Microsoft/Windows/interfaces.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/interfaces.py
@@ -14,17 +14,6 @@ import Products.Zuul.interfaces.component as zuul
 from Products.Zuul.utils import ZuulMessageFactory as _t
 
 
-class IFileSystemInfo(schema.IFileSystemInfo, zuul.IFileSystemInfo):
-    """
-    Info adapter for FileSystem components.
-    """
-
-
-class ICPUInfo(schema.ICPUInfo, zuul.ICPUInfo):
-    """
-    Info adapter for CPU components.
-    """
-
 
 class IInterfaceInfo(schema.IInterfaceInfo, zuul.IIpInterfaceInfo):
     """

--- a/ZenPacks/zenoss/Microsoft/Windows/utils.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/utils.py
@@ -14,15 +14,6 @@ Basic utilities that don't cause any Zope stuff to be imported.
 import json
 from Products.ZenEvents import ZenEventClasses
 
-def get_properties(klass):
-    '''
-        avoid duplicates when adding properties 
-        to ZPL schema-based class from a base class
-    '''
-    seen = set()
-    seen_add = seen.add
-    props = tuple([x for x in klass._properties if not (x.get('id') in seen or seen_add(x.get('id')))])
-    return props
 
 def addLocalLibPath():
     """
@@ -118,7 +109,7 @@ def parseDBUserNamePass(dbinstances='', username='', password=''):
             # Retain the default behaviour, before zProps change.
             if not dbinstance:
                 dblogins['MSSQLSERVER'] = {
-                    'username': username, # 'sa',
+                    'username': username,  # 'sa',
                     'password': password,
                     'login_as_user':True
                 }
@@ -133,7 +124,7 @@ def filter_sql_stdout(val):
     Filters SQL stdout from service messages
     """
     # SQL 2005 returns in stdout when Win auth
-    return filter(lambda x: x!="LogonUser succedded", val)
+    return filter(lambda x: x != "LogonUser succedded", val)
 
 
 def getSQLAssembly(version=None):


### PR DESCRIPTION
- With ZPL2.0, some info/interfaces and subclass code is no longer
needed, so removing it
- info/interfaces for Interface, TeamInterface is left in place since
these do not yet inherit properly from platform (ZPS-494)