### PR TITLE
Fix AttributeError for ShellDataSource (ZPS-506)

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
@@ -1057,12 +1057,12 @@ class ShellDataSourcePlugin(PythonDataSourcePlugin):
             return (context.device().id,
                     datasource.getCycleTime(context),
                     datasource.strategy,
-                    context.instancename)
+                    getattr(context, 'instancename', ''))
         elif datasource.strategy == 'powershell MSSQL Instance':
             return (context.device().id,
                     datasource.getCycleTime(context),
                     datasource.strategy,
-                    context.instancename,
+                    getattr(context, 'instancename', ''),
                     context.id)
         return (context.device().id,
                 datasource.getCycleTime(context),


### PR DESCRIPTION
- Issue caused by lack of "instancename" attribute on context that is
not WinSQLInstance
- Changed direct reference to instancename to a getattr() instead