### PR TITLE
use ps_script, not ps_command

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinCluster.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinCluster.py
@@ -44,7 +44,7 @@ class ClusterCommander(object):
         command = "\"& {{{}}}\"".format(
             ''.join(self.psClusterCommands + command)
         )
-        return self.winrs.run_command(self.pscommand, ps_command=command)
+        return self.winrs.run_command(self.pscommand, ps_script=command)
 
 
 class WinCluster(WinRMPlugin):


### PR DESCRIPTION
Fixes ZPS-701

* Parameter keyword is ps_script, not ps_command