### PR TITLE
Do not run service indexing job on temporary templates

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ServiceDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ServiceDataSource.py
@@ -1,6 +1,6 @@
 ##############################################################################
 #
-# Copyright (C) Zenoss, Inc. 2013-2016, all rights reserved.
+# Copyright (C) Zenoss, Inc. 2013-2017, all rights reserved.
 #
 # This content is made available according to terms specified in
 # License.zenoss under the directory where your Zenoss product is installed.
@@ -192,7 +192,7 @@ class ServiceDataSourceInfo(InfoBase):
         if self.reindex:
             self._object.dmd.JobManager.addJob(ReindexWinServices,
                                                kwargs=dict(uid=self.uid))
-            self._reindex = False
+            self.reindex = False
 
     severity = property(get_severity, set_severity)
 

--- a/ZenPacks/zenoss/Microsoft/Windows/handlers.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/handlers.py
@@ -23,11 +23,8 @@ DEFAULT_SERVICE = '/zport/dmd/Devices/Server/Microsoft/rrdTemplates/WinService/d
 def onServiceDataSourceMoved(ob, event):
     if isinstance(event, ObjectWillBeRemovedEvent):
         dmd = ob.getDmdRoot("Devices")
-        try:
-            template = ob.getPrimaryUrlPath().split('/')[-3]
-            temporary = [x for x in ['-new', '-backup', '-preupgrade'] if x in template]
-        except Exception:
-            temporary = None
+        template = ob.rrdTemplate().id
+        temporary = [x for x in ['-new', '-backup', '-preupgrade'] if x in template]
         if dmd and not temporary:
             log.debug('handler: Starting ReindexWinServices job')
             dmd.JobManager.addJob(ReindexWinServices, kwargs=dict(uid=DEFAULT_SERVICE))

--- a/ZenPacks/zenoss/Microsoft/Windows/handlers.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/handlers.py
@@ -1,12 +1,13 @@
 ##############################################################################
 #
-# Copyright (C) Zenoss, Inc. 2013, all rights reserved.
+# Copyright (C) Zenoss, Inc. 2016, 2017, all rights reserved.
 #
 # This content is made available according to terms specified in
 # License.zenoss under the directory where your Zenoss product is installed.
 #
 ##############################################################################
 
+import logging
 from zope.component import adapter
 from OFS.interfaces import IObjectWillBeMovedEvent
 from OFS.event import ObjectWillBeRemovedEvent
@@ -14,6 +15,7 @@ from OFS.event import ObjectWillBeRemovedEvent
 from datasources.ServiceDataSource import ServiceDataSource
 from jobs import ReindexWinServices
 
+log = logging.getLogger('zen.MicrosoftWindows')
 DEFAULT_SERVICE = '/zport/dmd/Devices/Server/Microsoft/rrdTemplates/WinService/datasources/DefaultService'
 
 
@@ -21,5 +23,11 @@ DEFAULT_SERVICE = '/zport/dmd/Devices/Server/Microsoft/rrdTemplates/WinService/d
 def onServiceDataSourceMoved(ob, event):
     if isinstance(event, ObjectWillBeRemovedEvent):
         dmd = ob.getDmdRoot("Devices")
-        if dmd:
+        try:
+            template = ob.getPrimaryUrlPath().split('/')[-3]
+            temporary = [x for x in ['-new', '-backup', '-preupgrade'] if x in template]
+        except Exception:
+            temporary = None
+        if dmd and not temporary:
+            log.debug('handler: Starting ReindexWinServices job')
             dmd.JobManager.addJob(ReindexWinServices, kwargs=dict(uid=DEFAULT_SERVICE))


### PR DESCRIPTION
Fixes ZPS-570

* Check for -new, -backup, -preupgrade so that we do not start job