### PR TITLE
MSSQL Database state should reflect instance status (Fixes ZPS-299)

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/WinSQLInstance.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/WinSQLInstance.py
@@ -9,22 +9,12 @@
 from . import schema
 
 
-class WinSQLDatabase(schema.WinSQLDatabase):
+class WinSQLInstance(schema.WinSQLInstance):
     '''
     Base class for WinSQLDatabase classes.
 
     This file exists to avoid ZenPack upgrade issues
     '''
 
-    def getState(self):
-        """Return database state if instance state is OK"""
-        status = None
-        instance = getattr(self, 'winsqlinstance', None)
-        if instance:
-            if instance().getStatus():
-                return "Down"
-        try:
-            status = int(self.cacheRRDValue('status', None))
-        except Exception:
-            return 'Unknown'
-        return 'Up' if status  else 'Down'
+    def getStatus(self):
+        return super(WinSQLInstance, self).getStatus('/')

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
@@ -1394,16 +1394,30 @@ class ShellDataSourcePlugin(PythonDataSourcePlugin):
                         )
                     severity = ZenEventClasses.Warning
 
-        data['events'].append(dict(
-            severity=severity,
-            eventClass=dsconf0.eventClass or "/Status",
-            eventClassKey='winrsCollection',
-            eventKey='winrsCollection {}'.format(
-                dsconf0.params['contexttitle']
-            ),
-            summary=msg,
-            component=dsconf0.component,
-            device=config.id))
+        if strategy.key == "PowershellMSSQL":
+            instances = {dsc.component for dsc in dsconfs}
+            for i in list(instances):
+                data['events'].append(dict(
+                    severity=severity,
+                    eventClass=dsconf0.eventClass or "/Status",
+                    eventClassKey='winrsCollection',
+                    eventKey='winrsCollection {}'.format(
+                        dsconf0.params['contexttitle']
+                    ),
+                    summary=msg,
+                    component=i,
+                    device=config.id))
+        else:
+            data['events'].append(dict(
+                severity=severity,
+                eventClass=dsconf0.eventClass or "/Status",
+                eventClassKey='winrsCollection',
+                eventKey='winrsCollection {}'.format(
+                    dsconf0.params['contexttitle']
+                ),
+                summary=msg,
+                component=dsconf0.component,
+                device=config.id))
 
         data['events'].append(dict(
             severity=ZenEventClasses.Clear,

--- a/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
+++ b/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
@@ -1979,6 +1979,10 @@ device_classes:
         description: Microsoft SQL Server per-database monitoring.
         targetPythonClass: ZenPacks.zenoss.Microsoft.Windows.WinSQLDatabase
         datasources:
+          status:
+            type: 'Built-In'
+            datapoints:
+              status: GAUGE
           LogFileSize:
             type: Windows Shell
             datapoints:


### PR DESCRIPTION
- Fixes ZPS-299
- Updated WinSQLInstance getStatus method to return 1 if any events
- Updated WinSQLDatabase "getState" method to first check WinSQLInstance
state
- Updated ShellDataSource to generate events for every affected
component when a query fails
- added built-in "status" datasource to WinDatabase template so that
"cacheRRDValue" will work