### PR TITLE
Ensure that status will display up/down

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/interfaces.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/interfaces.py
@@ -1,6 +1,6 @@
 ##############################################################################
 #
-# Copyright (C) Zenoss, Inc. 2016, all rights reserved.
+# Copyright (C) Zenoss, Inc. 2016-2017, all rights reserved.
 #
 # This content is made available according to terms specified in
 # License.zenoss under the directory where your Zenoss product is installed.
@@ -14,7 +14,6 @@ import Products.Zuul.interfaces.component as zuul
 from Products.Zuul.utils import ZuulMessageFactory as _t
 
 
-
 class IInterfaceInfo(schema.IInterfaceInfo, zuul.IIpInterfaceInfo):
     """
     Info adapter for Interface components.
@@ -26,5 +25,6 @@ class IWinServiceInfo(zuul.IWinServiceInfo):
     Info adapter for WinService components.
     """
     formatted_description = form_schema.TextLine(title=_t(u'Description'), readonly=True)
-    usermonitor = form_schema.Bool(title=_t(u'Manually Selected Monitor State'),
+    usermonitor = form_schema.Bool(title=_t(u'Manually Selected Monitor State.'
+                                            '  This does not enable/disable monitoring.'),
                                    alwaysEditable=True)


### PR DESCRIPTION
Fixes ZPS-632

* Underlying class depends upon monitoredStartModes being populated.
  Populate it with the appropriate start modes depending upon how
  service is being monitored
* Also make it clear that the checkbox for usermonitor does not enable/disable monitoring
* Make sure that DefaultService has startmodes attribute