### PR TITLE
Make sure datasource has startmode attribute

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1228,6 +1228,9 @@ Installing this ZenPack will add the following items to your Zenoss system.
 
 == Changes ==
 
+;2.6.12
+* Fix ZenPack throws traceback when non windows data source is added (ZPS-661)
+
 ;2.6.11
 * Fix Monitoring of SQL Instances results in a UUID error (ZPS-453)
 * Added additional event classes and handlers for Kerberos failures (ZEN-25700)

--- a/ZenPacks/zenoss/Microsoft/Windows/WinService.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/WinService.py
@@ -102,7 +102,7 @@ class WinService(BaseWinService):
             datasource = template.datasources._getOb('DefaultService', None)
             if datasource and not datasource.enabled and template.id == self.serviceName:
                 return False
-            if datasource and datasource.enabled:
+            if datasource and datasource.enabled and hasattr(datasource, 'startmode'):
                 status = self.getMonitored(datasource)
                 if status is MONITORED:
                     self.failSeverity = datasource.severity


### PR DESCRIPTION
Fixes ZPS-661

* Some templates may end up with a bad datasource that is not a
  Windows Service datasource.  Skip them