### PR TITLE
No need to start reindexing job if one is pending

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1261,6 +1261,7 @@ Installing this ZenPack will add the following items to your Zenoss system.
 * Added option to specify winrm envelope size
 * Added localization support
 * Fix ShellDataSource Doesn't Associate Event Severity or Class from Data Sources (ZPS-491)
+* Fix Modifying the WinService template causes parallel reindexing of the same components (ZPS-570)
 
 ;2.6.12
 * Fix ZenPack throws traceback when non windows data source is added (ZPS-661)

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ServiceDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ServiceDataSource.py
@@ -190,6 +190,11 @@ class ServiceDataSourceInfo(InfoBase):
 
     def post_update(self):
         if self.reindex:
+            for job in self._object.getDmdRoot('Devices').JobManager.getPendingJobs():
+                if job.type == ReindexWinServices.getJobType():
+                    log.info('ServiceDataSource: ReindexWinServices already pending')
+                    self.reindex = False
+                    return
             self._object.dmd.JobManager.addJob(ReindexWinServices,
                                                kwargs=dict(uid=self.uid))
             self.reindex = False

--- a/ZenPacks/zenoss/Microsoft/Windows/handlers.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/handlers.py
@@ -21,10 +21,21 @@ DEFAULT_SERVICE = '/zport/dmd/Devices/Server/Microsoft/rrdTemplates/WinService/d
 
 @adapter(ServiceDataSource, IObjectWillBeMovedEvent)
 def onServiceDataSourceMoved(ob, event):
+    """Run ReindexWinServices job on template removal
+    Do not run if removing a temporary template used by ZenPackLib during
+    install/remove of the ZenPack.
+    Do not run if there are pending Reindex jobs.
+    """
     if isinstance(event, ObjectWillBeRemovedEvent):
         dmd = ob.getDmdRoot("Devices")
         template = ob.rrdTemplate().id
         temporary = [x for x in ['-new', '-backup', '-preupgrade'] if x in template]
+
         if dmd and not temporary:
+            for job in dmd.JobManager.getPendingJobs():
+                if job.type == ReindexWinServices.getJobType():
+                    log.debug('handler: ReindexWinServices already pending')
+                    return
+
             log.debug('handler: Starting ReindexWinServices job')
             dmd.JobManager.addJob(ReindexWinServices, kwargs=dict(uid=DEFAULT_SERVICE))


### PR DESCRIPTION
Fixes ZPS-570

* Only run reindexing job if one is not pending or if it is not a
  temporary ZPL template.