### PR TITLE
Fix Processes GUI display (ZPS-572)

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/OSProcess.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/OSProcess.py
@@ -19,9 +19,6 @@ class OSProcess(schema.OSProcess):
     counters available.
     '''
 
-    def getClassObject(self):
-        return BaseOSProcess.getClassObject(self)
-
     def getRRDTemplateName(self):
         '''
         Return monitoring template name appropriate for this component.

--- a/ZenPacks/zenoss/Microsoft/Windows/migrate/ResetOSProcesses.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/migrate/ResetOSProcesses.py
@@ -1,0 +1,75 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2015, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+"""Reset meta_type and portal_type for objects that need it."""
+
+# Logging
+import logging
+LOG = logging.getLogger("zen.Microsoft.Windows.migrate.{}".format(__name__))
+
+# Zenoss Imports
+from zope.event import notify
+from Products.ZenModel.migrate.Migrate import Version
+from Products.ZenModel.ZenPack import ZenPackMigration
+from Products.Zuul.catalog.events import IndexingEvent
+from Products.Zuul.interfaces import ICatalogTool
+
+# ZenPack Imports
+from ZenPacks.zenoss.Microsoft.Windows import progresslog
+
+
+# If the migration takes longer than this interval, a running progress
+# showing elapsed and estimated remaining time will be logged this
+# often. The value is in seconds.
+PROGRESS_LOG_INTERVAL = 10
+
+
+class ResetOSProcesses(ZenPackMigration):
+    version = Version(2, 7, 0)
+
+    def migrate(self, pack):
+        LOG.info("Reindexing Processes")
+        results = ICatalogTool(pack.getDmdRoot("Devices")).search(types=(
+            'ZenPacks.zenoss.Microsoft.Windows.OSProcess.OSProcess',
+            ))
+
+        if not results.total:
+            return
+
+        LOG.info("Found {} Processes that may require indexing".format(results.total))
+        progress = progresslog.ProgressLogger(
+            LOG,
+            prefix="progress",
+            total=results.total,
+            interval=PROGRESS_LOG_INTERVAL)
+
+        objects_migrated = 0
+
+        for result in results:
+            if self.migrate_result(result):
+                objects_migrated += 1
+
+            progress.increment()
+
+        LOG.info(
+            "Finished indexing {} of {} Processes".format(objects_migrated, results.total))
+
+    def migrate_result(self, result):
+        """Return True if result needed to be migrated.
+        Reindex object
+        """
+        try:
+            obj = result.getObject()
+        except Exception:
+            return False
+
+        obj.index_object()
+        notify(IndexingEvent(obj))
+
+        return True

--- a/ZenPacks/zenoss/Microsoft/Windows/patches/platform.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/patches/platform.py
@@ -114,14 +114,3 @@ def _editDetails(self, info, data):
 
     return result
 
-# # ZPS-572 Make sure our OSProcess subclass is included in the Process tab
-from Products.Zuul.facades.processfacade import ProcessFacade
-
-@property
-def get_instance_class(ob):
-    return ob._types
-
-if not hasattr(ProcessFacade, '_types'):
-    ProcessFacade._types = ('Products.ZenModel.OSProcess.OSProcess', 'ZenPacks.zenoss.Microsoft.Windows.OSProcess.OSProcess')
-ProcessFacade._instanceClass = get_instance_class
-


### PR DESCRIPTION
- Fixes ZPS-572
- Reverted earlier partial fix (platform patch)
- Updated setup.py dependency to ZenPackLib 2.0.2 (forthcoming), which
contains the actual fix
- added ResetOSProcesses migrate script for existing OSProcess objects
- removed "getClassObject" method from OSProcess override (no longer
needed)