### PR TITLE
No need for user to be a domain user to run dcdiag

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1262,6 +1262,7 @@ Installing this ZenPack will add the following items to your Zenoss system.
 * Added localization support
 * Fix ShellDataSource Doesn't Associate Event Severity or Class from Data Sources (ZPS-491)
 * Fix Modifying the WinService template causes parallel reindexing of the same components (ZPS-570)
+* Fix MicrosoftWindows - Device status become down after adding device using local authentication (ZPS-713)
 
 ;2.6.12
 * Fix ZenPack throws traceback when non windows data source is added (ZPS-661)

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
@@ -216,10 +216,9 @@ class DCDiagStrategy(object):
 
     def build_command_line(self, tests, testparms, username, password):
         self.run_tests = set(tests)
-        try:
-            dcuser = '{}\\{}'.format((username.split('@')[1].split('.')[0]), username.split('@')[0])
-        except Exception:
-            raise WindowsShellException('Username invalid.  Must be in user@example.com format.  Check zWinRMUser: {}'.format(username))
+        user_parts = username.split('@')
+        domain = user_parts[1] if len(user_parts) > 1 else ''
+        dcuser = '{}\\{}'.format(domain.split('.')[0], user_parts[0])
         dcdiagcommand = 'dcdiag /q /u:{} /p:{} /test:'.format(dcuser, password) + ' /test:'.join(tests)
         if testparms:
             dcdiagcommand += ' ' + ' '.join(testparms)


### PR DESCRIPTION
Fixes ZPS-713

* Remove exception for non-domain user running dcdiag.
* Allow for non-domain user to be sent in on command line