### PR TITLE
Specify Device Class for Cluster Nodes (ZPS-581)

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/ClusterDevice.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/ClusterDevice.py
@@ -60,8 +60,11 @@ class ClusterDevice(schema.ClusterDevice):
             @transact
             def create_device():
                 # Need to create cluster server device
-                dc = self.dmd.Devices.getOrganizer('/Devices/Server/Microsoft/Windows')
-
+                path = getattr(self, 'zWinRMClusterNodeClass', '/Devices/Server/Microsoft/Windows')
+                try:
+                    dc = self.dmd.Devices.getOrganizer(path)
+                except KeyError:
+                    dc = self.dmd.Devices.createOrganizer(path)
                 clusterhost = dc.createInstance(clusterhostdnsname)
                 clusterhost.manageIp = clusterhostip
                 clusterhost.title = clusterhostdnsname

--- a/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
+++ b/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
@@ -38,7 +38,8 @@ zProperties:
   zWinRSCodePage:
     default: 65001
     type: int
-
+  zWinRMClusterNodeClass:
+    default: /Devices/Server/Microsoft/Windows
 
 class_relationships:
   - ZenPacks.zenoss.Microsoft.Windows.OperatingSystem.OperatingSystem(winrmservices) 1:MC (os)ZenPacks.zenoss.Microsoft.Windows.WinService.WinService


### PR DESCRIPTION
- Fixes ZPS-581
- added zWinRMClusterNodeClass ZProperty
- zWinRMClusterNodeClass specifies the device class path under which
node devices are automatically created by WinCluster modeler plugin