### PR TITLE
Fix EventLogDataSource AttributeError (ZPS-788)

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/EventLogDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/EventLogDataSource.py
@@ -340,7 +340,7 @@ class EventLogPlugin(PythonDataSourcePlugin):
                 'device': config.id,
                 'summary': 'Windows EventLog: successful event collection',
                 'severity': ZenEventClasses.Clear,
-                'eventKey': 'WindowsEventCollection: {}'.format(ds.id),
+                'eventKey': 'WindowsEventCollection: {}'.format(ds.params.get('eventid', '')),
                 'eventClassKey': 'WindowsEventLogSuccess',
             })
 
@@ -366,7 +366,7 @@ class EventLogPlugin(PythonDataSourcePlugin):
                 data['events'].append({
                     'severity': severity,
                     'eventClassKey': 'WindowsEventCollectionError',
-                    'eventKey': 'WindowsEventCollection: {}'.format(ds.id),
+                    'eventKey': 'WindowsEventCollection: {}'.format(ds.params.get('eventid', '')),
                     'summary': msg,
                     'device': config.id
                 })


### PR DESCRIPTION
- Fixes ZPS-788
- Change references to "id" to params.get('eventid'), which contains the
datasource id