### PR TITLE
Set sql version to 0 for clusters

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinMSSQL.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinMSSQL.py
@@ -187,7 +187,10 @@ class WinMSSQL(WinRMPlugin):
                 serverlist = server_config[key]
             if key == 'instances':
                 instance_version = value.split(':')
-                serverlist[''.join(instance_version[:-1]).strip()] = ''.join(instance_version[-1:]).strip()
+                if len(instance_version) > 1:
+                    serverlist[''.join(instance_version[:-1]).strip()] = ''.join(instance_version[-1:]).strip()
+                else:
+                    serverlist[value.strip()] = 0
             else:
                 serverlist.append(value.strip())
             server_config[key] = serverlist


### PR DESCRIPTION
Fixes ZPS-660

* Cluster does not have sql version info, so go with 0 for now until
  we can figure out versioning