### PR TITLE
Send clear event for unmonitored services

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ServiceDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ServiceDataSource.py
@@ -287,9 +287,21 @@ class ServicePlugin(PythonDataSourcePlugin):
         services = self.buildServicesDict(config.datasources)
 
         for index, svc_info in enumerate(serviceinfo):
-            if svc_info.Name not in services.keys():
-                continue
             severity = ZenEventClasses.Clear
+            if svc_info.Name not in services.keys():
+                data['events'].append({
+                    'service_name': svc_info.Name,
+                    'service_state': svc_info.State,
+                    'service_status': svc_info.Status,
+                    'eventClass': "/Status/WinService",
+                    'eventClassKey': 'WindowsServiceLog',
+                    'eventKey': "WindowsService",
+                    'severity': severity,
+                    'summary': 'Service not monitored',
+                    'component': prepId(svc_info.Name),
+                    'device': config.id,
+                })
+                continue
 
             service = services[svc_info.Name]
 


### PR DESCRIPTION
Fixes ZPS-811

* In case an event exists for a service that changes from monitored
  to unmonitored we'll send a clear event