### PR TITLE
Migrate ZProperty Label/Descriptions to ZenPack Class override

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/__init__.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/__init__.py
@@ -86,6 +86,59 @@ class ZenPack(schema.ZenPack):
 
     binUtilities = ['winrm', 'winrs']
 
+    packZProperties_data = {'zDBInstances': {'type': 'instancecredentials',
+                                             'description': 'Microsoft SQL connection parameters',
+                                             'label': 'MSSQL Instance parameters'},
+                            'zWinRSCodePage': {'type': 'int',
+                                               'description': 'Code page used by monitoring user account',
+                                               'label': 'Windows Code Page'},
+                            'zWinTrustedRealm': {'type': 'string',
+                                                 'description': 'Authentication domain trusted by zWinRMUser',
+                                                 'label': 'Windows Trusted Realm'},
+                            'zWinPerfmonInterval': {'type': 'string', 'description':
+                                                    'Interval in seconds at which data is collected',
+                                                    'label': 'Windows Collection Interval'},
+                            'zWinKeyTabFilePath': {'type': 'string', 'description':
+                                                   'Reserved for future use keytab file',
+                                                   'label': 'Windows Keytab Path'},
+                            'zWinTrustedKDC': {'type': 'string',
+                                               'description': 'Domain controller IP or resolvable hostname',
+                                               'label': 'Windows Key Distribution Center (Trusted)'},
+                            'zWinRMLocale': {'type': 'string',
+                                             'description': 'Communication locale to use for monitoring',
+                                             'label': 'Windows Locale'},
+                            'zWinRMEnvelopeSize': {'type': 'int',
+                                                   'description': 'Used when WinRM configuration setting "MaxEnvelopeSizekb" exceeds default of 512k',
+                                                   'label': 'WMI Query Output Envelope Size'},
+                            'zWinScheme': {'type': 'string',
+                                           'description': 'Either "http" or "https"',
+                                           'label': 'Windows Protocol Scheme'},
+                            'zWinRMPassword': {'type': 'password', 'description':
+                                               'Password for user defined by zWinRMUser',
+                                               'label': 'Windows Authentication Password'},
+                            'zWinKDC': {'type': 'string',
+                                        'description': 'Domain controller IP or resolvable hostname',
+                                        'label': 'Windows Key Distribution Center'},
+                            'zWinRMPort': {'type': 'string',
+                                           'description': 'WS-Management TCP communication port',
+                                           'label': 'WS-Management Port'},
+                            'zWinRMUser': {'type': 'string',
+                                           'description': 'If user@somedomain then zWinKDC and zWinRMServerName are possibly required',
+                                           'label': 'Windows Authentication User'},
+                            'zWinRMClusterNodeClass': {'type': 'string',
+                                                       'description': 'Path under which to create cluster nodes',
+                                                       'label': 'Windows Cluster Node Device Class'},
+                            'zWinUseWsmanSPN': {'type': 'boolean',
+                                                'description': 'Set to true if HTTP/HTTPS service principles are exclusively for use by a particular service account',
+                                                'label': 'Use WSMAN Service Principal Name'},
+                            'zWinRMKrb5includedir': {'type': 'string',
+                                                     'description': 'Directory path for Kerberos config files',
+                                                     'label': 'Windows KRB5 Include Directory'},
+                            'zWinRMServerName': {'type': 'string',
+                                                 'description': 'FQDN for domain authentication if resolution fails or different from AD',
+                                                 'label': 'Server Fully Qualified Domain Name'}
+                            }
+
     def install(self, app):
         self.in_install = True
         super(ZenPack, self).install(app)

--- a/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
+++ b/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
@@ -5,78 +5,43 @@ zProperties:
   zWinRMPassword:
     type: password
     default: ''
-    label: Windows Authentication Password
-    description: Password for user defined by zWinRMUser
   zWinRMUser:
     default: ''
-    label: Windows Authentication User
-    description: If user@somedomain then zWinKDC and zWinRMServerName are possibly required
   zWinRMServerName:
     default: ''
-    label: Server Fully Qualified Domain Name
-    description: FQDN for domain authentication if resolution fails or different from AD
   zWinRMPort:
     default: '5985'
-    label: WS-Management Port
-    description: WS-Management TCP communication port
   zDBInstances:
     type: instancecredentials
     default: '[{"instance": "MSSQLSERVER", "user": "", "passwd": ""}]'
     category: 'Misc'
-    label: MSSQL Instance parameters
-    description: Microsoft SQL connection parameters 
   zWinKDC:
     default: ''
-    label: Windows Key Distribution Center 
-    description: Domain controller IP or resolvable hostname
   zWinKeyTabFilePath:
     default: ''
-    label: Windows Keytab Path
-    description: Reserved for future use keytab file
   zWinScheme:
     default: 'http'
-    label: Windows Protocol Scheme
-    description: Either "http" or "https"
   zWinPerfmonInterval:
     default: 300
-    label: Windows Collection Interval
-    description: Interval in seconds at which data is collected
   zWinTrustedRealm:
     default: ''
-    label: Windows Trusted Realm
-    description: Authentication domain trusted by zWinRMUser 
   zWinTrustedKDC:
     default: ''
-    label: Windows Key Distribution Center (Trusted)
-    description: Domain controller IP or resolvable hostname
   zWinUseWsmanSPN:
     default: false
     type: boolean
-    label: Use WSMAN Service Principal Name
-    description: Set to true if HTTP/HTTPS service principles are exclusively for use by a particular service account
   zWinRMEnvelopeSize:
     default: 512000
     type: int
-    label: WMI Query Output Envelope Size
-    description: Used when WinRM configuration setting "MaxEnvelopeSizekb" exceeds default of 512k
   zWinRMLocale:
     default: en-US
-    label: Windows Locale 
-    description: Communication locale to use for monitoring
   zWinRSCodePage:
     default: 65001
     type: int
-    label: Windows Code Page
-    description: Code page used by monitoring user account
   zWinRMClusterNodeClass:
     default: /Devices/Server/Microsoft/Windows
-    label: Windows Cluster Node Device Class
-    description: Path under which to create cluster nodes 
   zWinRMKrb5includedir:
     default: ''
-    label: Windows KRB5 Include Directory
-    description: Directory path for Kerberos config files
-
 
 class_relationships:
   - ZenPacks.zenoss.Microsoft.Windows.OperatingSystem.OperatingSystem(winrmservices) 1:MC (os)WinService


### PR DESCRIPTION
- ZenPackLib support for zproperty label/description is being pushed
back to 2.1.0, so migrating these YAML attributes to the ZenPack class
override, which will remove ZPL version specificity from this Windows
release.