### PR TITLE
Ensure EventClass set for Interface template threshold (ZEN-26853)

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
+++ b/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
@@ -3979,3 +3979,8 @@ event_classes:
       Password Expired Default:
         eventClassKey: MW|PasswordExpired
         sequence: 1001
+  /Status/OSProcess:
+    remove: false
+  /Status/Interface:
+    remove: false
+


### PR DESCRIPTION
- Fixes ZEN-26853
- Issue reproducable if target eventClass doesn't exist
(/Status/Interface)
- Added YAML event class for /Status/Interface with remove equal to
False
- Did the same for /Status/OSProcess