### PR TITLE
Default zDBInstances user and password should be None by default

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
+++ b/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
@@ -13,7 +13,7 @@ zProperties:
     default: '5985'
   zDBInstances:
     type: instancecredentials
-    default: '[{"instance": "MSSQLSERVER", "user": "", "passwd": ""}]'
+    default: '[{"instance": "MSSQLSERVER", "user": None , "passwd": None}]'
     category: 'Misc'
   zWinKDC:
     default: ''


### PR DESCRIPTION
- Changed user/pass to None instead of "" (empty string), so that
default credentials are used