### PR TITLE
Add link to storage disk/lun for hard disk

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/HardDisk.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/HardDisk.py
@@ -6,6 +6,9 @@
 # License.zenoss under the directory where your Zenoss product is installed.
 #
 ##############################################################################
+from Products.Zuul.interfaces import ICatalogTool
+from Products.AdvancedQuery import Eq, Or
+
 from . import schema
 
 
@@ -35,3 +38,17 @@ class HardDisk(schema.HardDisk):
         if self.size == 0 and self.partitions == 0:
             return False
         return self.monitor and True
+
+    def storage_disk_lun(self):
+        # return the UCS storage disk/virtual drive
+        # if disk_ids contains the IDs of disk/virtual drive
+        if self.disk_ids:
+            results = ICatalogTool(self.getDmdRoot('Devices')).search(
+                query=Or(*[Eq('searchKeywords', id)
+                           for id in self.disk_ids]))
+
+            for brain in results:
+                try:
+                    yield brain.getObject()
+                except Exception:
+                    continue

--- a/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
+++ b/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
@@ -448,6 +448,15 @@ classes:
         type: int
       instance_name:
         details_display: false
+      storage_disk_lun:
+        # link to storage disk/virtual drive
+        # if the hard disk is actually mapped to it
+        label: Storage Disk/LUN
+        type: entity
+        grid_display: false
+        api_only: true
+        api_backendtype: method
+
     impacts: []
     impacted_by: [device]
     dynamicview_views: [service_view]

--- a/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
+++ b/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
@@ -453,7 +453,6 @@ classes:
         # if the hard disk is actually mapped to it
         label: Storage Disk/LUN
         type: entity
-        grid_display: false
         api_only: true
         api_backendtype: method
 


### PR DESCRIPTION
Fixes ZPS-939

If the link to the storage disk/lun can be found, add the link
to hard disk details.