### PR TITLE
Make sure we're using unicode strings for counters

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -975,6 +975,7 @@ The current release is known to have the following limitations.
 * Payload encryption is not supported on EL5 systems.  This is due to the fact that the default kerberos library on EL5 systems does not contain the necessary functionality.
 * Current functionality for monitoring Server 2003 has not been removed from the ZenPack, but no future development will be done for Server 2003.
 * Starting with version 2.6.0 of the ZenPack, existing Windows Service components are no longer compatible.  These will be removed upon installation.  Once the device is modeled with the Services plugin enabled, Windows Service components will be discovered.  Any existing monitoring templates will still apply.  Any services that were manually selected to be monitored will not.  See the section on [[#Configuring Service Monitoring|Configuring Service Monitoring]].
+* Some languages, such as French, contain elided words in performance counters.  e.g. ''d’utilisation''.  If you are seeing missing or corrupt counters for languages other than English, check that the unicode apostrophe is being used in the counter name.
 
 A current list of known issues related to this ZenPack can be found with [https://jira.zenoss.com/issues/?jql=%22Affected%20Zenpack(s)%22%20%3D%20MicrosoftWindows%20AND%20status%20not%20in%20(closed%2C%20%22awaiting%20verification%22)%20ORDER%20BY%20priority%20DESC%2C%20id this JIRA query]. You must be logged into JIRA to run this query. If you don't already have a JIRA account, you can [https://jira.zenoss.com/secure/Signup!default.jspa create one here].
 

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
@@ -268,7 +268,7 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
         self.counter_map = {}
         self.ps_counter_map = {}
         for dsconf in self.config.datasources:
-            counter = dsconf.params['counter'].lower()
+            counter = dsconf.params['counter'].decode('utf-8').lower()
             ps_counter = convert_to_ps_counter(counter)
             self.counter_map[counter] = (dsconf.component, dsconf.datasource, dsconf.eventClass)
             self.ps_counter_map[ps_counter] = (dsconf.component, dsconf.datasource)
@@ -523,7 +523,7 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
                 #   '\\\\amazona-q2r281f\\web service(another web site)\\move requests/sec'
                 #   '\\web service(another web site)\\move requests/sec'
                 counter = '\\{}'.format(
-                    self.sample_buffer.popleft().strip(' :').split('\\', 3)[3])
+                    self.sample_buffer.popleft().strip(' :').split('\\', 3)[3]).decode('utf-8')
 
                 value = self.sample_buffer.popleft()
 


### PR DESCRIPTION
Fixes ZPS-955

* Decode counters to utf-8 when building counter map
* Decode counter names from output of get-counter command to utf-8
  to match with our counter map