### PR TITLE
ZPS-1014: update ds mocks according to the recent changes

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testEventLogDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testEventLogDataSource.py
@@ -30,7 +30,8 @@ class TestDataSourcePlugin(BaseTestCase):
              'UserName': u''}
         ], Mock(
             id=sentinel.id,
-            datasources=[Mock(params={'eventlog': sentinel.eventlog})],
+            datasources=[Mock(params={'eventlog': sentinel.eventlog},
+                              datasource='DataSource')],
         ))
 
         self.assertEquals(len(res['events']), 6)

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testIISSiteDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testIISSiteDataSource.py
@@ -22,7 +22,8 @@ class TestIISSiteDataSourcePlugin(BaseTestCase):
     def test_onSuccess(self):
         data = self.plugin.onSuccess({}, MagicMock(
             id=sentinel.id,
-            datasources=[MagicMock(params={'eventlog': sentinel.eventlog})],
+            datasources=[MagicMock(datasource='IISSiteDataSource',
+                                   params={'eventlog': sentinel.eventlog})],
         ))
         self.assertEquals(len(data['events']), 6)
         self.assertEquals("Monitoring ok", data['events'][1]['summary'])

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testServiceDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testServiceDataSource.py
@@ -36,7 +36,7 @@ class TestServiceDataSourcePlugin(BaseTestCase):
                                      'servicename': 'aspnet_state',
                                      'severity': 3,
                                      'alertifnot': 'Running'
-                                     })]
+                                     }, datasource='ServiceDataSource')]
 
     def test_onSuccess(self):
         data = self.plugin.onSuccess(self.success, MagicMock(


### PR DESCRIPTION
Fixes [https://jira.zenoss.com/browse/ZPS-1014](https://jira.zenoss.com/browse/ZPS-1014)

`datasource` attribute of Datasource instance have to be a string.