### PR TITLE
Revert to legacy rrdPath (ZPS-292)

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/FileSystem.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/FileSystem.py
@@ -7,12 +7,15 @@
 #
 ##############################################################################
 from . import schema
+from utils import get_rrd_path
 
 
 class FileSystem(schema.FileSystem):
     '''
     Model class for FileSystem.
     '''
+    # preserve the old style path
+    rrdPath = get_rrd_path
 
     def monitored(self):
         '''

--- a/ZenPacks/zenoss/Microsoft/Windows/OSProcess.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/OSProcess.py
@@ -8,6 +8,7 @@
 ##############################################################################
 from . import schema
 from Products.ZenModel.OSProcess import OSProcess as BaseOSProcess
+from utils import get_rrd_path
 
 
 class OSProcess(schema.OSProcess):
@@ -18,6 +19,9 @@ class OSProcess(schema.OSProcess):
     Depending on the version of Windows there are different per-process
     counters available.
     '''
+
+    # preserve the old style path
+    rrdPath = get_rrd_path
 
     def getRRDTemplateName(self):
         '''

--- a/ZenPacks/zenoss/Microsoft/Windows/TeamInterface.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/TeamInterface.py
@@ -9,6 +9,7 @@
 from . import schema
 from zope.event import notify
 from Products.Zuul.catalog.events import IndexingEvent
+from utils import get_rrd_path
 
 
 class TeamInterface(schema.TeamInterface):
@@ -16,6 +17,8 @@ class TeamInterface(schema.TeamInterface):
     Model class for TeamInterface.
     '''
 
+    # preserve the old style path
+    rrdPath = get_rrd_path
 
     def monitored(self):
         '''

--- a/ZenPacks/zenoss/Microsoft/Windows/WinIIS.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/WinIIS.py
@@ -9,20 +9,10 @@
 from . import schema
 from utils import get_rrd_path
 
-class Interface(schema.Interface):
-    '''
-    Model class for Interface
-    '''
-    portal_type = meta_type = 'IpInterface'
 
+class WinIIS(schema.WinIIS):
+    '''
+    Model class for WinIIS.
+    '''
     # preserve the old style path
     rrdPath = get_rrd_path
-
-    def monitored(self):
-        '''
-        Return the monitored status of this component.
-
-        Overridden from IpInterface to prevent monitoring
-        administratively down interfaces.
-        '''
-        return self.monitor and self.adminStatus == 1

--- a/ZenPacks/zenoss/Microsoft/Windows/utils.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/utils.py
@@ -555,3 +555,27 @@ def get_dsconf(dsconfs, component, param=None):
         elif component == dsconf.params.get(param, None):
             return dsconf
     return None
+
+def has_metricfacade():
+    '''return True if metricfacade can be imported'''
+    try:
+        from Products.Zuul.facades import metricfacade
+    except ImportError:
+        pass
+    else:
+        return True
+    return False
+
+HAS_METRICFACADE = has_metricfacade()
+
+def get_rrd_path(obj):
+    """Preserve old-style RRD paths"""
+    if HAS_METRICFACADE:
+        return super(obj.__class__, obj).rrdPath()
+    else:
+        d = obj.device()
+        if not d:
+            return "Devices/" + obj.id
+        skip = len(d.getPrimaryPath()) - 1
+        return 'Devices/' + '/'.join(obj.getPrimaryPath()[skip:])
+


### PR DESCRIPTION
- Fixes ZPS-292
- changes rrdPath method on some component classes to revert to older
behavior for Zenoss 4.x
- Since issue affects multiple classes besides interface, these were
updated as well
- Although this update does not recover lost data, it will prevent
further loss while eliminating it altogether for direct upgrades from
2.6.2