### PR TITLE
Index services on model update no matter

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/WinService.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/WinService.py
@@ -68,6 +68,7 @@ class WinService(schema.WinService):
     def monitored(self):
         # Determine whether or not to monitor this service
         # Set necessary defaults
+        self.index_service = False
         self.alertifnot = 'Running'
         self.failSeverity = ZenEventClasses.Error
         self.monitoredStartModes = []

--- a/ZenPacks/zenoss/Microsoft/Windows/info.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/info.py
@@ -34,8 +34,16 @@ class WinServiceInfo(schema.WinServiceInfo, WinServiceInfo):
         return '<div style="white-space: normal;">{}</div>'.format(
             self._object.description)
 
+    @property
+    def monitored(self):
+        return self.getMonitor()
+
     def getMonitor(self):
-        return self._object.isMonitored()
+        try:
+            is_monitored = self._object.device().componentSearch.getIndexDataForUID(self._object.getPrimaryId())['monitored']
+        except (KeyError, Exception):
+            is_monitored = self.isMonitored()
+        return is_monitored
 
     def setMonitor(self, value):
         self._object.usermonitor = True

--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/Services.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/Services.py
@@ -46,6 +46,7 @@ class Services(WinRMPlugin):
             om.startMode = service.StartMode
             om.startName = service.StartName
             om.description = service.Description
+            om.index_service = True
             rm.append(om)
 
         maps = []

--- a/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
+++ b/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
@@ -387,8 +387,6 @@ classes:
         default: None
       cores:
         label: Cores
-      cores:
-        label: Cores
       threads:
         label: Threads
       cacheSpeedL2:
@@ -592,6 +590,8 @@ classes:
       usermonitor:
         label: Manually Selected Monitor State
         type: boolean
+      index_service:
+        details_display: false
 
   WinIIS:
     label: IIS Site
@@ -782,16 +782,12 @@ device_classes:
       zPythonClass: ZenPacks.zenoss.Microsoft.Windows.Device
       zCollectorPlugins: [zenoss.winrm.OperatingSystem, zenoss.winrm.CPUs, zenoss.winrm.FileSystems, zenoss.winrm.Interfaces, zenoss.winrm.Services, zenoss.winrm.Processes, zenoss.winrm.Software, zenoss.winrm.HardDisks]
       zDeviceTemplates: [Device, Active Directory, IIS, MSExchange2010IS]
-      zDBInstances:
-      - {instance: MSSQLSERVER, passwd: '', user: ''}
   /Server/Microsoft/Cluster:
     remove: true
     description: Windows Cluster
     protocol: WinRM
     zProperties:
       zCollectorPlugins: [zenoss.winrm.OperatingSystem, zenoss.winrm.WinCluster]
-      zDBInstances:
-      - {instance: MSSQLSERVER, passwd: '', user: ''}
       zDeviceTemplates: [Cluster, Active Directory, IIS, MSExchange2010IS]
       zPythonClass: ZenPacks.zenoss.Microsoft.Windows.ClusterDevice
     templates:


### PR DESCRIPTION
Fixes ZPS-1005

* Add flag so that we index services on a remodel
* Override monitored property for info so that we can pull the current
  indexed values of the service.  Gives visual confirmation that a service
  is monitored or not.
* Remove unecessary/invalid class props/zprops from yaml