### PR TITLE
Suppress uncatalog errors during upgrade (ZPS-984)

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/migrate/RemoveWinRMServices.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/migrate/RemoveWinRMServices.py
@@ -36,5 +36,5 @@ class RemoveWinRMServices(ZenPackMigration):
             LOG.info('Attempting to remove incompatible Windows Services from {} device{}.'
                      .format(device_count, 's' if device_count > 1 else ''))
             for device in devices:
-                device.os.removeRelation('winrmservices')
+                device.os.removeRelation('winrmservices', suppress_events=True)
                 device.os.buildRelations()


### PR DESCRIPTION
- Fixes ZPS-984
- These errors occur as a downstream effect of "winrmservices" component
removal via relation deletion during migration.  Since deleting the
relation causes the related components to deleted simultaneously, this
causes a spurious uncatalogObject warning that can be disregarded.  The
"suppress_events" flag has been added, which should prevent these
warnings from being seen by the user.