### PR TITLE
Logging should include device and component where relevant (ZPS-573)

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/IISSiteDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/IISSiteDataSource.py
@@ -160,6 +160,7 @@ class IISSiteDataSourcePlugin(PythonDataSourcePlugin):
 
         iis_version = ds0.params['iis_version']
 
+        id_string = "device ({}) component ({})".format(config.id, ds0.component)
         if not iis_version:
             winrs = IISCommander(conn_info)
             version = yield winrs.get_iis_version()
@@ -169,9 +170,9 @@ class IISSiteDataSourcePlugin(PythonDataSourcePlugin):
                 iis_version = re.match('Version (\d).*', version.stdout[0]).group(1)
             except (IndexError, AttributeError):
                 if version.stdout:
-                    log.error("Malformed version information: {}".format(version.stdout[0]))
+                    log.error("Malformed version information on {}: {}".format(id_string, version.stdout[0]))
                 if version.stderr:
-                    log.error("Error retrieving IIS Version: {}".format(version.stderr[0]))
+                    log.error("Error retrieving IIS version on {}: {}".format(id_string, version.stderr[0]))
                 defer.returnValue(None)
 
         if iis_version == 6:

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
@@ -129,14 +129,14 @@ class DataPersister(object):
 
     def start(self, result=None):
         if result:
-            LOG.debug("Windows Perfmon data maintenance failed: %s", result)
+            LOG.debug("{}: Windows Perfmon data maintenance failed: {}".format(self.config.id, result))
 
-        LOG.debug("Windows Perfmon starting data maintenance")
+        LOG.debug("{}: Windows Perfmon starting data maintenance".format(self.config.id))
         d = LoopingCall(self.maintenance).start(self.maintenance_interval)
         d.addBoth(self.start)
 
     def maintenance(self):
-        LOG.debug("Windows Perfmon performing periodic data maintenance")
+        LOG.debug("{}: Windows Perfmon performing periodic data maintenance".format(self.config.id))
         for device, data in self.devices.items():
             data_age = time.time() - data['last']
             if data_age > self.max_data_age:
@@ -293,7 +293,7 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
         # counters of the device equals to floor division of the current
         # counters_line length by the calculated limit, incremented by 1.
         self.num_commands = len(format_counters(counters)) // counters_limit + 1
-        LOG.debug('Windows Perfmon Creating {0} long running command(s)'.format(
+        LOG.debug('{}: Windows Perfmon Creating {} long running command(s)'.format(self.config.id,
             self.num_commands))
 
         # Chunk a counter list into num_commands equal parts.
@@ -348,7 +348,7 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
             errorMessage = "Windows Perfmon Error on {}: {}".format(
                 self.config.id,
                 e.message or "timeout")
-            LOG.warn(errorMessage)
+            LOG.warn("{}: {}".format(self.config.id, errorMessage))
 
             PERSISTER.add_event(self.config.id, self.config.datasources, {
                 'device': self.config.id,
@@ -461,7 +461,7 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
             try:
                 deferreds.append(cmd.receive())
             except Exception as err:
-                LOG.error('Windows Perfmon receive error {0}'.format(err))
+                LOG.error('{}: Windows Perfmon receive error {0}'.format(self.config.id, err))
 
         self.receive_deferreds = add_timeout(
             defer.DeferredList(deferreds, consumeErrors=True),
@@ -546,7 +546,7 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
                     PERSISTER.add_value(
                         self.config.id, component, datasource, value, collect_time)
             except Exception, err:
-                LOG.debug('Windows Perfmon could not process a sample. Error: {}'.format(err))
+                LOG.debug('{}: Windows Perfmon could not process a sample. Error: {}'.format(self.config.id, err))
 
         if self.data_deferred and not self.data_deferred.called:
             self.data_deferred.callback(None)
@@ -581,7 +581,7 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
                 self.reportCorruptCounters(self.counter_map)
         else:
             if self.cycling:
-                LOG.debug('Windows Perfmon Result: {0}'.format(result))
+                LOG.debug('{}: Windows Perfmon Result: {}'.format(self.config.id, result))
                 yield self.restart()
 
         self._generateClearAuthEvents()
@@ -673,7 +673,7 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
     @defer.inlineCallbacks
     def remove_corrupt_counters(self):
         """Remove counters which return an error."""
-        LOG.debug('Performing check for corrupt counters')
+        LOG.debug('{}: Performing check for corrupt counters'.format(self.config.id))
         dsconf0 = self.config.datasources[0]
         winrs = SingleCommandClient(createConnectionInfo(dsconf0))
 

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/PortCheckDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/PortCheckDataSource.py
@@ -65,7 +65,7 @@ class IPortCheckDataSourceInfo(IRRDDataSourceInfo):
         group=_t('Port Check'),
         title=_t('Port Check'),
         xtype='portcheck')
-    
+
 class PortCheckDataSourceInfo(RRDDataSourceInfo):
     """
     Pull in proxy values so they can be utilized within the PortCheck plugin.
@@ -105,23 +105,23 @@ class PortCheckDataSourcePlugin(PythonDataSourcePlugin):
     def params(cls, datasource, context):
         return dict(
             ports=datasource.ports)
-        
-    #@defer.inlineCallbacks
+
+    # @defer.inlineCallbacks
     def collect(self, config):
         dsconf0 = config.datasources[0]
 
         try:
             self.json_ports = json.loads(dsconf0.params['ports'])
         except:
-            log.error('Unable to load ports.  Check configuration')
-        
+            log.error('{}: Unable to load ports.  Check configuration'.format(config.id))
+
         self.portDict = {}
         for port in self.json_ports:
             self.portDict[int(port['port'])] = port['desc']
-        self.scanner = PortCheckScanner(config.manageIp,portList=self.portDict.keys())
+        self.scanner = PortCheckScanner(config.manageIp, portList=self.portDict.keys())
         dl = self.scanner.prepare()
         return dl
-        
+
     def onSuccess(self, results, config):
         data = self.new_data()
         dsconf0 = config.datasources[0]
@@ -163,11 +163,11 @@ class PortCheckDataSourcePlugin(PythonDataSourcePlugin):
             pass
         # send clear events
         return data
-    
+
     def onError(self, results, config):
         data = self.new_data()
         dsconf0 = config.datasources[0]
-        
+
         # send error event
         eventClass = dsconf0.eventClass if dsconf0.eventClass else "/Status"
         eventkey = 'WindowsPortCheckError'

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ServiceDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ServiceDataSource.py
@@ -278,7 +278,7 @@ class ServicePlugin(PythonDataSourcePlugin):
                 'Status': 'OK'}
         '''
         data = self.new_data()
-        log.debug('Windows services query results: {}'.format(results))
+        log.debug('{}: Windows services query results: {}'.format(config.id, results))
         try:
             serviceinfo = results[results.keys()[0]]
         except:

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
@@ -331,7 +331,7 @@ class CustomCommandStrategy(object):
     def parse_result(self, config, result):
         dsconf = config.datasources[0]
         parserLoader = dsconf.params['parser']
-        log.debug('Trying to use the %s parser' % parserLoader.pluginName)
+        log.debug('{}: Trying to use the {} parser'.format(config.id, parserLoader.pluginName))
 
         # Build emulated Zencommand Cmd object
         cmd = WinCmd()
@@ -708,7 +708,7 @@ class PowershellClusterServiceStrategy(object):
         # Parse values
         stdout = parse_stdout(result, check_stderr=True)
         if stdout:
-            name, iscoregroup, ownernode, state, description, nodeid,\
+            name, iscoregroup, ownernode, state, description, nodeid, \
                 priority = stdout
             dsconf0 = dsconfs[0]
 


### PR DESCRIPTION
- Fixes ZPS-573
- Updated log messaging for custom datasources to include the
device/component ids where available.