### PR TITLE
RRDPath migration issue should depend on upgrade path (ZPS-1204)

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -794,6 +794,11 @@ The [[#Adding a Windows Device]] steps shown above are for the simplest case of 
 
 {{note}} HyperV and MicrosoftWindows ZenPacks share krb5.conf file as well as tools for sending/receiving data. Therefore if either HyperV or Windows device has a correct zWinKDC setting, it will be used for another device as well.
 
+;zWinUseLegacyRRDPath
+: Whether to use older directory structure to manage RRD files.  Set this to True if upgrading directly from 2.5.x of this ZenPack if using Zenoss versions earlier than 5.x.  This setting has no effect on Zenoss versions 5.x and above.
+
+{{note}} The migration to ZenPackLib in version 2.6 of this ZenPack introduced an issue leading to apparent data loss in RRD graphs for filesystems, interfaces, and other components.  Since ZenPackLib uses a different directory heirarchy for RRD storage, component graphs after upgrade became empty (since the file paths changed).  This setting mitigates that issue for users upgrading directly from 2.5.x versions of this ZenPack.  The attempt is made during ZenPack installation to choose the correct version of this value.
+
 <br clear=all>
 
 === Configuring MSSQL Server Modeling/Monitoring ===
@@ -1292,6 +1297,7 @@ Installing this ZenPack will add the following items to your Zenoss system.
 * Fix Windows ZP Does not allow compatible ports of 80/443 to be used (ZPS-622)
 * Fix Windows Zenpack may not properly detect IIS on 2012 servers. (ZPS-719)
 * Fix Long MSSQL Database names aren't parsed correctly because they exceed the powershell shell width (ZPS-944)
+* Mitigate RRD data losses associated with ZPL conversion (ZPS-1204)
 
 ;2.6.12
 * Fix ZenPack throws traceback when non windows data source is added (ZPS-661)

--- a/ZenPacks/zenoss/Microsoft/Windows/__init__.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/__init__.py
@@ -136,7 +136,10 @@ class ZenPack(schema.ZenPack):
                                                      'label': 'Windows KRB5 Include Directory'},
                             'zWinRMServerName': {'type': 'string',
                                                  'description': 'FQDN for domain authentication if resolution fails or different from AD',
-                                                 'label': 'Server Fully Qualified Domain Name'}
+                                                 'label': 'Server Fully Qualified Domain Name'},
+                            'zWinUseLegacyRRDPath': {'type': 'boolean',
+                                                 'description': 'Set this to True if upgrading directly from ZenPacks.zenoss.Microsoft.Windows 2.5.x',
+                                                 'label': 'Use Legacy style RRD filename path'}
                             }
 
     def install(self, app):

--- a/ZenPacks/zenoss/Microsoft/Windows/migrate/MigrateRRDPaths.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/migrate/MigrateRRDPaths.py
@@ -1,0 +1,37 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2016, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+"""Remove Windows services.
+ZPS-1204
+Prevent data loss due to rrdPath changes between ZPL and non-ZPL-based versions
+of this zenpack
+
+"""
+
+# Logging
+import logging
+import pkg_resources
+# Zenoss Imports
+from Products.ZenModel.migrate.Migrate import Version
+from Products.ZenModel.ZenPack import ZenPackMigration
+
+LOG = logging.getLogger('zen.MicrosoftWindows')
+
+
+class MigrateRRDPaths(ZenPackMigration):
+    version = Version(2, 7, 0)
+
+    def migrate(self, pack):
+        if pack.prevZenPackVersion is None:
+            return
+        installed_version = pkg_resources.parse_version(pack.prevZenPackVersion)
+        # we only want to set this if upgrading directly from 2.5.x
+        if installed_version < pkg_resources.parse_version('2.6.0'):
+            LOG.info('Setting zWinUseLegacyRRDPath to True we are upgrading directly from 2.5.x')
+            pack.dmd.Devices.setZenProperty('zWinUseLegacyRRDPath', True)

--- a/ZenPacks/zenoss/Microsoft/Windows/utils.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/utils.py
@@ -576,6 +576,9 @@ def get_rrd_path(obj):
         d = obj.device()
         if not d:
             return "Devices/" + obj.id
-        skip = len(d.getPrimaryPath()) - 1
-        return 'Devices/' + '/'.join(obj.getPrimaryPath()[skip:])
-
+        # revert to 2.5 behavior if True
+        if getattr(d, 'zWinUseLegacyRRDPath', False):
+            skip = len(d.getPrimaryPath()) - 1
+            return 'Devices/' + '/'.join(obj.getPrimaryPath()[skip:])
+        else:
+            return super(obj.__class__, obj).rrdPath()

--- a/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
+++ b/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
@@ -42,6 +42,9 @@ zProperties:
     default: /Devices/Server/Microsoft/Windows
   zWinRMKrb5includedir:
     default: ''
+  zWinUseLegacyRRDPath:
+    default: false
+    type: boolean
 
 class_relationships:
   - ZenPacks.zenoss.Microsoft.Windows.OperatingSystem.OperatingSystem(winrmservices) 1:MC (os)WinService


### PR DESCRIPTION
Goal is to minimize data loss resulting from zenpacklib conversion
within different upgrade scenarios

- Fixes ZPS-1204
- Adds zWinUseLegacyRRDPath zProperty to control whether old or
new-style (ZPL) rrdPath is used for RRD storage
- Added MigrateRRDPaths migrate script to auto-determine this behavior
- updated rrd_path method to choose conditionally based on
zWinUseLegacyRRDPath
- Updated readme.mediawiki with documentation regarding new zProperty
and the related issues