### PR TITLE
Remove user visibility of fix for ZPS-1204

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -794,11 +794,6 @@ The [[#Adding a Windows Device]] steps shown above are for the simplest case of 
 
 {{note}} HyperV and MicrosoftWindows ZenPacks share krb5.conf file as well as tools for sending/receiving data. Therefore if either HyperV or Windows device has a correct zWinKDC setting, it will be used for another device as well.
 
-;zWinUseLegacyRRDPath
-: Whether to use older directory structure to manage RRD files.  Set this to True if upgrading directly from 2.5.x of this ZenPack if using Zenoss versions earlier than 5.x.  This setting has no effect on Zenoss versions 5.x and above.
-
-{{note}} The migration to ZenPackLib in version 2.6 of this ZenPack introduced an issue leading to apparent data loss in RRD graphs for filesystems, interfaces, and other components.  Since ZenPackLib uses a different directory heirarchy for RRD storage, component graphs after upgrade became empty (since the file paths changed).  This setting mitigates that issue for users upgrading directly from 2.5.x versions of this ZenPack.  The attempt is made during ZenPack installation to choose the correct version of this value.
-
 <br clear=all>
 
 === Configuring MSSQL Server Modeling/Monitoring ===

--- a/ZenPacks/zenoss/Microsoft/Windows/WinSQLDatabase.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/WinSQLDatabase.py
@@ -14,6 +14,7 @@ from zenoss.protocols.protobufs.zep_pb2 import (
     SEVERITY_CLEAR, SEVERITY_CRITICAL, SEVERITY_ERROR,
     SEVERITY_INFO, SEVERITY_WARNING
 )
+from utils import get_rrd_path
 
 
 class WinSQLDatabase(schema.WinSQLDatabase):
@@ -21,6 +22,7 @@ class WinSQLDatabase(schema.WinSQLDatabase):
     Base class for WinSQLDatabase classes.
 
     """
+    rrdPath = get_rrd_path
 
     def getDBStatus(self):
         """Return database state"""

--- a/ZenPacks/zenoss/Microsoft/Windows/__init__.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/__init__.py
@@ -137,9 +137,6 @@ class ZenPack(schema.ZenPack):
                             'zWinRMServerName': {'type': 'string',
                                                  'description': 'FQDN for domain authentication if resolution fails or different from AD',
                                                  'label': 'Server Fully Qualified Domain Name'},
-                            'zWinUseLegacyRRDPath': {'type': 'boolean',
-                                                 'description': 'Set this to True if upgrading directly from ZenPacks.zenoss.Microsoft.Windows 2.5.x',
-                                                 'label': 'Use Legacy style RRD filename path'}
                             }
 
     def install(self, app):

--- a/ZenPacks/zenoss/Microsoft/Windows/migrate/MigrateRRDPaths.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/migrate/MigrateRRDPaths.py
@@ -28,10 +28,11 @@ class MigrateRRDPaths(ZenPackMigration):
     version = Version(2, 7, 0)
 
     def migrate(self, pack):
+        # setting the default
+        pack.dmd.windows_using_legacy_rrd_paths = False
         if pack.prevZenPackVersion is None:
             return
         installed_version = pkg_resources.parse_version(pack.prevZenPackVersion)
         # we only want to set this if upgrading directly from 2.5.x
         if installed_version < pkg_resources.parse_version('2.6.0'):
-            LOG.info('Setting zWinUseLegacyRRDPath to True we are upgrading directly from 2.5.x')
-            pack.dmd.Devices.setZenProperty('zWinUseLegacyRRDPath', True)
+            pack.dmd.windows_using_legacy_rrd_paths = True

--- a/ZenPacks/zenoss/Microsoft/Windows/utils.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/utils.py
@@ -577,7 +577,8 @@ def get_rrd_path(obj):
         if not d:
             return "Devices/" + obj.id
         # revert to 2.5 behavior if True
-        if getattr(d, 'zWinUseLegacyRRDPath', False):
+        dmd_root = obj.getDmd()
+        if dmd_root and getattr(dmd_root, 'windows_using_legacy_rrd_paths', False):
             skip = len(d.getPrimaryPath()) - 1
             return 'Devices/' + '/'.join(obj.getPrimaryPath()[skip:])
         else:

--- a/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
+++ b/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
@@ -42,9 +42,6 @@ zProperties:
     default: /Devices/Server/Microsoft/Windows
   zWinRMKrb5includedir:
     default: ''
-  zWinUseLegacyRRDPath:
-    default: false
-    type: boolean
 
 class_relationships:
   - ZenPacks.zenoss.Microsoft.Windows.OperatingSystem.OperatingSystem(winrmservices) 1:MC (os)WinService


### PR DESCRIPTION
- Updated fix for ZPS-1204
- Changes previously introduced zProperty into an attribute stored on
dmd, set by install migration script that determines its value.
- Removes user visibility while still preventing the data loss
associated with rrdPath changes from zenpacklib conversion