### PR TITLE
Reduce verbosity in event summary field (ZPS-1231)

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
@@ -290,7 +290,8 @@ class DCDiagStrategy(object):
                         'severity': dsconf.severity,
                         'eventClassKey': 'WindowsActiveDirectoryStatus',
                         'eventKey': eventkey,
-                        'summary': msg,
+                        'summary': msg.split('.')[0],
+                        'message': msg,
                         'device': config.id})
                     error_str = ''
                 else:
@@ -310,7 +311,8 @@ class DCDiagStrategy(object):
                 'severity': ZenEventClasses.Clear,
                 'eventClassKey': 'WindowsActiveDirectoryStatus',
                 'eventKey': eventkey,
-                'summary': msg,
+                'summary': msg.split('.')[0],
+                'message': msg,
                 'device': config.id})
         return collectedResults
 


### PR DESCRIPTION
- Fixes ZPS-1231
- Although technically this is not from the EventLogDataSource, this
particular ShellDataSource event was updated to use the first sentence
only for event summary, while keeping the entire output for the message
field.