### PR TITLE
Revise and simplify auth-related event handling (ZPS-562)

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testAuthErrEvents.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testAuthErrEvents.py
@@ -41,16 +41,18 @@ class TestErrorEvents(BaseTestCase):
         error = 'kinit error server not in database'
         errorMsgCheck(self.config, events, error)
         self.assertEquals(len(events), 4)
-        event_class_keys = {0: 'MW_PasswordExpired',
-                            1: 'MW_WrongCredentials',
-                            2: 'MW_Kerberos_Auth_Failure',
-                            3: 'MW_Kerberos_Failure'}
-        for i in xrange(3):
-            self.assertEquals(events[i]['eventClassKey'], event_class_keys[i])
         generateClearAuthEvents(self.config, events)
-        self.assertEquals(len(events), 8)
-        for i in xrange(4, 7):
-            self.assertEquals(events[i]['eventClassKey'], event_class_keys[i - 4])
+
+        event_class_keys = {0: 'AuthenticationFailure',
+                            1: 'AuthenticationFailure',
+                            2: 'KerberosAuthenticationFailure',
+                            3: 'KerberosFailure',
+                            4: 'AuthenticationSuccess',
+                            5: 'KerberosAuthenticationSuccess',
+                            6: 'KerberosSuccess', }
+        for k, v in event_class_keys.items():
+            self.assertEquals(events[k]['eventClassKey'], v)
+        self.assertEquals(len(events), 7)
         for event in events:
             self.assertTrue('eventClass' not in event)
 

--- a/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
+++ b/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
@@ -3955,34 +3955,20 @@ event_classes:
         remove: true
   /Status/Kerberos:
     remove: true
-  /Status/Kerberos/Auth:
-    remove: true
-  /Status/Kerberos/Auth/Failure:
     mappings:
-      Failure Default:
-        eventClassKey: MW_Kerberos_Auth_Failure
-        sequence: 1111
-  /Status/Kerberos/Failure:
-    mappings:
-      Failure Default:
-        eventClassKey: MW_Kerberos_Failure
-        sequence: 1101
+      KerberosAuthenticationSuccess: {}
+      KerberosAuthenticationFailure: {}
+      KerberosSuccess: {}
+      KerberosFailure: {}
   /Status/Winrm:
     remove: true
   /Status/Winrm/Ping:
     remove: true
   /Status/Winrm/Auth:
     remove: true
-  /Status/Winrm/Auth/WrongCredentials:
     mappings:
-      Wrong Credentials Default:
-        eventClassKey: MW_WrongCredentials
-        sequence: 1002
-  /Status/Winrm/Auth/PasswordExpired:
-    mappings:
-      Password Expired Default:
-        eventClassKey: MW_PasswordExpired
-        sequence: 1001
+      AuthenticationSuccess: {}
+      AuthenticationFailure: {}
   /Status/OSProcess:
     remove: false
   /Status/Interface:


### PR DESCRIPTION
- Fixes ZPS-562
- Ensure that authentication-related console events are cleared
- Revised structure of event classes and mappings to more simply handle
various use cases
- Prevent and ensure removal of duplicate clear events (which was the
root of the problem)
- Updated testAuthErrEvents unit test