### PR TITLE
Remove 'datasources' field from event details (ZPS-1293)

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/utils.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/utils.py
@@ -454,7 +454,6 @@ Common datasource utilities.
 
 def append_event_datasource_plugin(datasources, events, event):
     event['plugin_classname'] = datasources[0].plugin_classname
-    event['datasources'] = ','.join([ds.datasource for ds in datasources])
     if event not in events:
         events.append(event)
 


### PR DESCRIPTION
- Fixes ZPS-1293
- Remove 'datasources' field from generic events, since it occupies too
much screen real estate in the event details GUI