### PR TITLE
WinSQLInstance events should honor template severity (ZPS-1323)

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1250,6 +1250,9 @@ Installing this ZenPack will add the following items to your Zenoss system.
 * ClusterInterface (in /Server/Microsoft/Cluster)
 
 == Changes ==
+;2.7.1
+*- Honor template severity for MS SQL Instance events (ZPS-1323)
+*- Honor template severity for MS SQL Job events (ZPS-1322)
 
 ;2.7.0
 * Added support for Hard Disk association with storage servers

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
@@ -1355,7 +1355,7 @@ class ShellDataSourcePlugin(PythonDataSourcePlugin):
             for dsconf, value in strategy.parse_result(dsconfs, result):
                 currentstate = {
                     'Running': ZenEventClasses.Clear,
-                    'Stopped': ZenEventClasses.Critical
+                    'Stopped': dsconf.severity
                 }.get(value[1], ZenEventClasses.Info)
 
                 summary = 'MSSQL Instance {0} is {1}.'.format(

--- a/docs/body.md
+++ b/docs/body.md
@@ -1721,6 +1721,9 @@ Monitoring Templates
 
 Changes
 -------
+2.7.1
+-   Honor template severity for MS SQL Instance events (ZPS-1323)
+-   Honor template severity for MS SQL Job events (ZPS-1322)
 
 2.7.0
 


### PR DESCRIPTION
Update ShellDataSource WinSQL Instance to reflect template severity
choice instead of hard-coded value