### PR TITLE
Explicit timestamp for WinService state datapoint (ZPS-1341)

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1260,6 +1260,7 @@ Installing this ZenPack will add the following items to your Zenoss system.
 * Fix Microsoft Windows: Honor template severity for MS SQL Job events (ZPS-1322)
 * Fix Microsoft Windows: Graphs missing datapoints every other zenpython cycle (ZPS-1321)
 * Fix Microsoft Windows: datasource in event details can make the event unreadable on one screen(ZPS-1293)
+* Fix Microsoft Windows: service datapoint should provide timestamp (ZPS-1341)
 
 ;2.7.0
 * Added support for Hard Disk association with storage servers

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ServiceDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ServiceDataSource.py
@@ -12,6 +12,7 @@ A datasource that uses WinRS to collect Windows Service Status
 
 """
 import logging
+import time
 
 from zope.component import adapts
 from zope.interface import implements
@@ -293,6 +294,7 @@ class ServicePlugin(PythonDataSourcePlugin):
 
         # build dictionary of datasource service info
         services = self.buildServicesDict(config.datasources)
+        timestamp = int(time.mktime(time.localtime()))
         for index, svc_info in enumerate(serviceinfo):
             if svc_info.Name not in services.keys():
                 continue
@@ -319,11 +321,11 @@ class ServicePlugin(PythonDataSourcePlugin):
                 dp.metadata = dsconf.params.get('metricmetadata', None)
                 dsconf.points.append(get_dummy_dpconfig(dp, 'state'))
                 if svc_info.State.lower() == STATE_RUNNING.lower():
-                    data['values'][svc_info.Name]['state'] = 0
+                    data['values'][svc_info.Name]['state'] = (0, timestamp)
                 elif svc_info.State.lower() == STATE_STOPPED.lower():
-                    data['values'][svc_info.Name]['state'] = 1
+                    data['values'][svc_info.Name]['state'] = (1, timestamp)
                 elif svc_info.State.lower() == STATE_PAUSED.lower():
-                    data['values'][svc_info.Name]['state'] = 2
+                    data['values'][svc_info.Name]['state'] = (2, timestamp)
 
             # event for the service
             data['events'].append({

--- a/docs/body.md
+++ b/docs/body.md
@@ -1736,6 +1736,7 @@ Changes
 -   Fix Microsoft Windows: Honor template severity for MS SQL Job events (ZPS-1322)
 -   Fix Microsoft Windows: Graphs missing datapoints every other zenpython cycle (ZPS-1321)
 -   Fix Microsoft Windows: datasource in event details can make the event unreadable on one screen(ZPS-1293)
+-   Fix Microsoft Windows: service datapoint should provide timestamp (ZPS-1341)
 
 2.7.0
 


### PR DESCRIPTION
- Fixes ZPS-1341
- Update ServiceDataSource to provide timestamp along with status
datapoint.