### PR TITLE
Make getAffectedServices smarter

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1261,6 +1261,7 @@ Installing this ZenPack will add the following items to your Zenoss system.
 * Fix Microsoft Windows: Graphs missing datapoints every other zenpython cycle (ZPS-1321)
 * Fix Microsoft Windows: datasource in event details can make the event unreadable on one screen(ZPS-1293)
 * Fix Microsoft Windows: service datapoint should provide timestamp (ZPS-1341)
+* Fix Editing a Windows Service (WinService) Locks Up Zope and Times Out (ZPS-1342)
 
 ;2.7.0
 * Added support for Hard Disk association with storage servers

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ServiceDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ServiceDataSource.py
@@ -13,6 +13,7 @@ A datasource that uses WinRS to collect Windows Service Status
 """
 import logging
 import time
+import re
 
 from zope.component import adapts
 from zope.interface import implements
@@ -28,6 +29,7 @@ from Products.Zuul.utils import severityId
 from Products.ZenEvents import ZenEventClasses
 from Products.ZenUtils.Utils import prepId
 from Products.ZenRRD.zencommand import DataPointConfig
+from Products.AdvancedQuery import MatchRegexp
 
 from ZenPacks.zenoss.PythonCollector.datasources.PythonDataSource \
     import PythonDataSource, PythonDataSourcePlugin
@@ -57,6 +59,7 @@ MODE_AUTO = 'Auto'
 MODE_DISABLED = 'Disabled'
 MODE_MANUAL = 'Manual'
 MODE_ANY = 'Any'
+INVALID_REGEX = 'Ignoring invalid regular expression found in WinService datasource {}: {}'
 
 
 def string_to_lines(string):
@@ -105,7 +108,27 @@ class ServiceDataSource(PythonDataSource):
 
         # Template is in a device class.
         else:
-            results = ICatalogTool(deviceclass.primaryAq()).search(WinService)
+            query = None
+            # Let's be smart and get only what will be affected
+            if template.id == 'WinService':
+                for exp in self.in_exclusions.split(','):
+                    regex = exp.strip().lstrip('+-')
+                    try:
+                        re.compile(regex)
+                    except re.error:
+                        log.debug(INVALID_REGEX.format(self.id, regex))
+                        continue
+                    if not query:
+                        query = MatchRegexp('id', regex)
+                    else:
+                        query |= MatchRegexp('id', regex)
+                # this should not occur, but just in case
+                if not query:
+                    query = MatchRegexp('id', '.*')
+            else:
+                # component template for specific service
+                query = MatchRegexp('id', template.id)
+            results = ICatalogTool(deviceclass.primaryAq()).search(WinService, query=query)
             for result in results:
                 try:
                     service = result.getObject()

--- a/ZenPacks/zenoss/Microsoft/Windows/jobs.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/jobs.py
@@ -57,6 +57,7 @@ class ReindexWinServices(Job):
         template = self.dmd.unrestrictedTraverse(uid)
 
         for service in template.getAffectedServices():
+            self.log.info('Indexing service {} on {}'.format(service.serviceName, service.device().id))
             service.index_object()
 
 

--- a/docs/body.md
+++ b/docs/body.md
@@ -1737,6 +1737,7 @@ Changes
 -   Fix Microsoft Windows: Graphs missing datapoints every other zenpython cycle (ZPS-1321)
 -   Fix Microsoft Windows: datasource in event details can make the event unreadable on one screen(ZPS-1293)
 -   Fix Microsoft Windows: service datapoint should provide timestamp (ZPS-1341)
+-   Fix Editing a Windows Service (WinService) Locks Up Zope and Times Out (ZPS-1342)
 
 2.7.0
 


### PR DESCRIPTION
Fixes ZPS-1342

This should reduce the overall number of services that need to be
reindexed.  We'll look at the template id to see if it is an actual
Service Name.  Next we'll make a query out of the in_exclusions regex
to send into ICatalogTool.  There's no need to index services that
would not be affected.