### PR TITLE
remove winrmservices relation from OperatingSystem

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -957,9 +957,19 @@ The current release is known to have the following limitations.
 * Payload encryption is not supported on EL5 systems.  This is due to the fact that the default kerberos library on EL5 systems does not contain the necessary functionality.
 * Current functionality for monitoring Server 2003 has not been removed from the ZenPack, but no future development will be done for Server 2003.
 * Starting with version 2.6.0 of the ZenPack, existing Windows Service components are no longer compatible.  These will be removed upon installation.  Once the device is modeled with the Services plugin enabled, Windows Service components will be discovered.  Any existing monitoring templates will still apply.  Any services that were manually selected to be monitored will not.  See the section on [[#Configuring Service Monitoring|Configuring Service Monitoring]].
-* The current release of this ZenPack uses the ZenPack SDK.  Some component classes have changed from pre-2.6.x versions of the ZenPack. During installation, the ZenPack will create a job that will update the Windows Devices and Components class types used by the SDK. Depending on your Zenoss instance resources, this job could take quite a while to complete.
+* The current release of this ZenPack uses the ZenPack SDK.  Some component classes have changed from pre-2.6.x versions of the ZenPack. During installation, the ZenPack will create a job that will update the Windows Devices and Components class types used by the SDK. Depending on your Zenoss instance resources, this job could take a very long time to complete.  If the job, ResetClassTypes, was not added during installation, it can be added manually using zendmd:
+
+<console>
+In [1]: from ZenPacks.zenoss.Microsoft.Windows.jobs import ResetClassTypes
+
+In [2]: dmd.JobManager.addJob(ResetClassTypes)
+
+In [3]: commit()
+</console>
+
 * This is the last version of the Microsoft Windows ZenPack where we provide fixes for Windows 2008.
 * When removing a Windows device or the Microsoft.Windows ZenPack, you may see errors in the event.log.  This is expected and is a known defect in ZenPackLib.
+* If upgrading from a version prior to 2.6.3 to 2.7.x, you may not be able to view your Windows services until the device is remodeled.
 
 A current list of known issues related to this ZenPack can be found with [https://jira.zenoss.com/issues/?jql=%22Affected%20Zenpack(s)%22%20%3D%20MicrosoftWindows%20AND%20status%20not%20in%20(closed%2C%20%22awaiting%20verification%22)%20ORDER%20BY%20priority%20DESC%2C%20id this JIRA query]. You must be logged into JIRA to run this query. If you don't already have a JIRA account, you can [https://jira.zenoss.com/secure/Signup!default.jspa create one here].
 
@@ -1261,6 +1271,7 @@ Installing this ZenPack will add the following items to your Zenoss system.
 * Fix WinRS: Failed collection local variable 'databasename' referenced before assignment on a.device.title (ZPS-1271)
 * Fix ZP Microsoft Windows 2.7.0 - conhost.exe and winrshost.exe are opened without closing (ZPS-1354)
 * Fix Counters with $ in their name are being shown as missing (ZPS-1404)
+* Fix Microsoft Windows: v2.7.x shows errors in zenrelationscan, zenchkrels (ZPS-1442)
 
 ;2.7.1
 * Fix Microsoft Windows: Honor template severity for MS SQL Instance events (ZPS-1323)

--- a/ZenPacks/zenoss/Microsoft/Windows/OperatingSystem.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/OperatingSystem.py
@@ -6,35 +6,15 @@
 # License.zenoss under the directory where your Zenoss product is installed.
 #
 ##############################################################################
+
 from Globals import InitializeClass
 
-from Products.ZenRelations.RelSchema import ToOne, ToManyCont
 from Products.ZenModel.OperatingSystem import OperatingSystem as BaseOS
 
 
 class OperatingSystem(BaseOS):
-    '''
-        Provides common functionality for OperatingSystem
-    '''
-    _relations = BaseOS._relations + (
-        ("winrmservices", ToManyCont(ToOne,
-         "ZenPacks.zenoss.Microsoft.Windows.WinService",
-          "os")),
-        ("winrmiis", ToManyCont(ToOne,
-         "ZenPacks.zenoss.Microsoft.Windows.WinIIS",
-          "os")),
-        ("winsqlinstances", ToManyCont(ToOne,
-         "ZenPacks.zenoss.Microsoft.Windows.WinSQLInstance",
-          "os")),
-        ("clusterservices", ToManyCont(ToOne,
-         "ZenPacks.zenoss.Microsoft.Windows.ClusterService",
-          "os")),
-        ("clusternodes", ToManyCont(ToOne,
-         "ZenPacks.zenoss.Microsoft.Windows.ClusterNode",
-         "os")),
-        ("clusternetworks", ToManyCont(ToOne,
-         "ZenPacks.zenoss.Microsoft.Windows.ClusterNetwork",
-         "os")),
-        )
+    """For relationships"""
+    pass
+
 
 InitializeClass(OperatingSystem)

--- a/ZenPacks/zenoss/Microsoft/Windows/migrate/ResetClassTypes.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/migrate/ResetClassTypes.py
@@ -23,6 +23,7 @@ log = logging.getLogger('zen.Microsoft.Windows.migrate.ResetClassTypes')
 WARNING_MESSAGE = 'zenjobs must be stopped in order to fully complete the '\
                   'upgrade to version {} of the Microsoft Windows ZenPack! '\
                   'Please stop zenjobs and run the installation once more.  '\
+                  'Alternatively, you can add the job manually.  '\
                   'This is necessary when upgrading from previous versions due to'\
                   ' the fact that the ZenPack is now based off of '\
                   'ZenPacks.zenoss.ZenPacklib.  If you have previously successfully'\
@@ -34,7 +35,7 @@ class ResetClassTypes(ZenPackMigration):
     version = Version(2, 7, 0)
 
     def migrate(self, pack):
-        log.info('Adding job to remove any leftover winrmservices and reset class types for Windows devices and components.')
+        log.info('Adding job to reset class types for Windows devices and components.')
         if 'applications' in listFacades():
             from Products.ZenUtils.application import ApplicationState
             facade = getFacade('applications')

--- a/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
+++ b/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
@@ -47,6 +47,7 @@ zProperties:
     default: false
 
 class_relationships:
+  - ZenPacks.zenoss.Microsoft.Windows.OperatingSystem.OperatingSystem(winservices) 1:MC (os)WinService
   - ZenPacks.zenoss.Microsoft.Windows.OperatingSystem.OperatingSystem(winrmservices) 1:MC (os)WinService
   - ZenPacks.zenoss.Microsoft.Windows.OperatingSystem.OperatingSystem(winrmiis) 1:MC (os)WinIIS
   - ZenPacks.zenoss.Microsoft.Windows.OperatingSystem.OperatingSystem(winsqlinstances) 1:MC (os)WinSQLInstance

--- a/docs/body.md
+++ b/docs/body.md
@@ -1304,10 +1304,19 @@ The current release is known to have the following limitations.
     component classes have changed from pre-2.6.x versions of the ZenPack.
     During installation, the ZenPack will create a job that will update
     the Windows Devices and Components class types used by the SDK.
-    Depending on your Zenoss instance resources, this job could take
-    quite a while to complete.
+    Depending on your Zenoss instance resources, this job could take a very long time to complete.  If the job, ResetClassTypes, was not added during installation, it can be added manually using zendmd:
+
+```
+In [1]: from ZenPacks.zenoss.Microsoft.Windows.jobs import ResetClassTypes
+
+In [2]: dmd.JobManager.addJob(ResetClassTypes)
+
+In [3]: commit()
+```
+
 -   This is the last version of the Microsoft Windows ZenPack where we provide fixes for Windows 2008.
 -    When removing a Windows device or the Microsoft.Windows ZenPack, you may see errors in the event.log.  This is expected and is a known defect in ZenPackLib.
+-   If upgrading from a version prior to 2.6.3 to 2.7.x, you may not be able to view your Windows services until the device is remodeled.
 
 A current list of known issues related to this ZenPack can be found with
 [this JIRA query](https://jira.zenoss.com/issues/?jql=%22Affected%20Zenpack%28s%29%22%20%3D%20MicrosoftWindows%20AND%20status%20not%20in%20%28closed%2C%20%22awaiting%20verification%22%29%20ORDER%20BY%20priority%20DESC%2C%20id). You must be logged into JIRA to run this query. If you don't already have a JIRA account, you can [create one here](https://jira.zenoss.com/secure/Signup!default.jspa).
@@ -1737,6 +1746,7 @@ Changes
 -   Fix WinRS: Failed collection local variable 'databasename' referenced before assignment on a.device.title (ZPS-1271)
 -   Fix ZP Microsoft Windows 2.7.0 - conhost.exe and winrshost.exe are opened without closing (ZPS-1354)
 -   Fix Counters with $ in their name are being shown as missing (ZPS-1404)
+-   Fix Microsoft Windows: v2.7.x shows errors in zenrelationscan, zenchkrels (ZPS-1442)
 
 2.7.1
 


### PR DESCRIPTION
fixes ZPS-1442

* winrmservices should no longer be a relationship on a windows device
* remove it from the os and from the modeler plugin.
* also no need to try and remove in migrate script