### PR TITLE
Make sure that $s use the powershell escape(`) if in double quotes

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1260,6 +1260,7 @@ Installing this ZenPack will add the following items to your Zenoss system.
 ;2.7.2
 * Fix WinRS: Failed collection local variable 'databasename' referenced before assignment on a.device.title (ZPS-1271)
 * Fix ZP Microsoft Windows 2.7.0 - conhost.exe and winrshost.exe are opened without closing (ZPS-1354)
+* Fix Counters with $ in their name are being shown as missing (ZPS-1404)
 
 ;2.7.1
 * Fix Microsoft Windows: Honor template severity for MS SQL Instance events (ZPS-1323)

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
@@ -839,6 +839,7 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
 
 # Helper functions for PerfmonDataSource plugin.
 def convert_to_ps_counter(counter):
+    counter = counter.replace('$', '`$')
     esc_counter = counter.encode("unicode_escape")
     start_indx = esc_counter.find('(')
     end_indx = esc_counter.rfind(')')

--- a/docs/body.md
+++ b/docs/body.md
@@ -1736,6 +1736,7 @@ Changes
 
 -   Fix WinRS: Failed collection local variable 'databasename' referenced before assignment on a.device.title (ZPS-1271)
 -   Fix ZP Microsoft Windows 2.7.0 - conhost.exe and winrshost.exe are opened without closing (ZPS-1354)
+-   Fix Counters with $ in their name are being shown as missing (ZPS-1404)
 
 2.7.1
 


### PR DESCRIPTION
Fixes ZPS-1404

we surround a counter with double quotes.  powershell attempts to
evaluate the $ in some counters the same as bash.  use the powershell
escape char (`) so that we can poll these counters