### PR TITLE
Improve speed of migrate script

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1269,6 +1269,7 @@ Installing this ZenPack will add the following items to your Zenoss system.
 
 ;2.7.3
 * Fix MicrosoftWindows ZP has problems disks/mount points with "\U" in their name. (ZPS-1368)
+* Fix Microsoft Windows: Migrate script takes long time to run, no feedback (ZPS-1473)
 
 ;2.7.2
 * Fix WinRS: Failed collection local variable 'databasename' referenced before assignment on a.device.title (ZPS-1271)

--- a/docs/body.md
+++ b/docs/body.md
@@ -1744,6 +1744,7 @@ Changes
 2.7.3
 
 -   Fix MicrosoftWindows ZP has problems disks/mount points with "\U" in their name. (ZPS-1368)
+-   Fix Microsoft Windows: Migrate script takes long time to run, no feedback (ZPS-1473)
 
 2.7.2
 


### PR DESCRIPTION
Fixes ZPS-1473

Using catalog to find templates and only look at those with a targetPythonClass
of ZenPacks.zenoss.Microsoft.Windows.WinService.  Much faster than looking at
individual services