### PR TITLE
remove test for unused convert_to_ps_counter function

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testPerfmonDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testPerfmonDataSource.py
@@ -15,7 +15,6 @@ from ZenPacks.zenoss.Microsoft.Windows.tests.mock import sentinel
 from ZenPacks.zenoss.Microsoft.Windows.datasources.PerfmonDataSource import (
     format_stdout,
     format_counters,
-    convert_to_ps_counter,
     DataPersister,
 )
 
@@ -74,14 +73,6 @@ class TestDataPersister(BaseTestCase):
         d0 = self.dp.pop(sentinel.device0)
         self.assertEquals(d0['maps'], [])
         self.assertEquals(len(self.dp.devices), 0)
-
-
-class TestConvert_to_ps_counter(BaseTestCase):
-    def test_convert_to_ps_counter(self):
-        self.assertEquals(convert_to_ps_counter("counter"), "counter")
-        self.assertEquals(convert_to_ps_counter(
-            u"\u0444(\u0444)".decode()
-        ), "\\u0444('+[char]0x0444+')")
 
 
 class TestFormat_counters(BaseTestCase):


### PR DESCRIPTION
Fixes ZPS-1493

removed the function as it is no longer necessary