### PR TITLE
Change is_iis to a boolean, apply during modeling iis components

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1267,6 +1267,9 @@ Installing this ZenPack will add the following items to your Zenoss system.
 
 == Changes ==
 
+;2.7.5
+* Fix Windows ZP uses a lot of RAM when it contains hundreds of components due to checking for IIS (ZPS-1576)
+
 ;2.7.3
 * Fix MicrosoftWindows ZP has problems disks/mount points with "\U" in their name. (ZPS-1368)
 * Fix Microsoft Windows: Migrate script takes long time to run, no feedback (ZPS-1473)

--- a/ZenPacks/zenoss/Microsoft/Windows/Device.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/Device.py
@@ -107,15 +107,6 @@ class Device(schema.Device):
                     clusterdnsname))
         return _clusterdevices
 
-    def is_iis(self):
-        '''Return True if an IIS server'''
-        # if we have IIS components, then we are IIS server
-        from ZenPacks.zenoss.Microsoft.Windows.WinIIS import WinIIS
-        for component in self.getDeviceComponents():
-            if isinstance(component, WinIIS):
-                return True
-        return False
-
     def is_ntds(self):
         '''Return True if an NTDS/AD server'''
         # redundancy check domain_controller in case of LPU not returning NTDS or no services modeled
@@ -137,7 +128,7 @@ class Device(schema.Device):
         templates = []
         for template in super(Device, self).getRRDTemplates():
             # skip IIS template if not installed
-            if 'IIS' in template.id and not self.is_iis():
+            if 'IIS' in template.id and not self.is_iis:
                 continue
             if 'Active Directory' in template.id:
                 # skip Active Director template if not installed

--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/IIS.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/IIS.py
@@ -18,6 +18,7 @@ namespace:
 '''
 
 from Products.ZenEvents import ZenEventClasses
+from Products.DataCollector.plugins.DataMaps import ObjectMap
 from ZenPacks.zenoss.Microsoft.Windows.modeler.WinRMPlugin import WinRMPlugin
 from ZenPacks.zenoss.Microsoft.Windows.utils import save
 from txwinrm.collect import create_enum_info
@@ -105,6 +106,9 @@ class IIS(WinRMPlugin):
             "Modeler %s processing data for device %s",
             self.name(), device.id)
 
+        device_om = ObjectMap()
+        device_om.is_iis = True
+        maps = [device_om]
         rm = self.relMap()
         if results.get('IIsWebServerSetting'):
             for iisSite in results.get('IIsWebServerSetting', ()):
@@ -140,4 +144,5 @@ class IIS(WinRMPlugin):
                 except AttributeError:
                     pass
 
-        return rm
+        maps.append(rm)
+        return maps

--- a/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
+++ b/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
@@ -119,6 +119,10 @@ classes:
         label: MS Exchange Version
         type: boolean
         default: false
+      is_iis:
+        type: boolean
+        default: false
+        display: false
     impacts:
       - all_filesystems
       - all_processes

--- a/docs/body.md
+++ b/docs/body.md
@@ -1741,6 +1741,10 @@ Monitoring Templates
 Changes
 -------
 
+2.7.5
+
+-   Fix Windows ZP uses a lot of RAM when it contains hundreds of components due to checking for IIS (ZPS-1576)
+
 2.7.3
 
 -   Fix MicrosoftWindows ZP has problems disks/mount points with "\U" in their name. (ZPS-1368)


### PR DESCRIPTION
Fixes ZPS-1576

move is_iis to a boolean device property.  set this when IIS
modeler plugin is used