### PR TITLE
Fix redundant service state metric publishing

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1267,6 +1267,9 @@ Installing this ZenPack will add the following items to your Zenoss system.
 
 == Changes ==
 
+;2.7.7
+* Fix redundant publishing of service state datapoints (ZPS-1604)
+
 ;2.7.6
 * Fix traceback during modeling (ZPS-1599)
 

--- a/docs/body.md
+++ b/docs/body.md
@@ -1741,6 +1741,10 @@ Monitoring Templates
 Changes
 -------
 
+2.7.7
+
+-   Fix redundant publishing of service state datapoints (ZPS-1604)
+
 2.7.6
 
 -   Fix traceback during modeling (ZPS-1599)


### PR DESCRIPTION
Add the state datapoint in the plugin's constructor when the task is
built instead of on each collection cycle.

Fixes ZPS-1604.