### PR TITLE
Make sure event gets posted so user knows device can't be reached

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1270,6 +1270,7 @@ Installing this ZenPack will add the following items to your Zenoss system.
 ;2.7.8
 * Fix WinRM ZP: HardDisks with a size of 'None' cause unhandled exceptions in modeling (ZPS-1424)
 * Fix Windows: log line in maintenance() function shows in incorrect logs (ZPS-1600)
+* Fix Windows: Failed model job does not result in event (ZPS-1608)
 
 ;2.7.7
 * Fix redundant publishing of service state datapoints (ZPS-1604)

--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/WinRMPlugin.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/WinRMPlugin.py
@@ -151,6 +151,7 @@ class WinRMPlugin(PythonPlugin):
         '''
         Log an approppriate message for error occurring on device.
         '''
+        severity = 4
         message, args = (None, [device.id])
         if isinstance(error, txwinrm.collect.RequestError):
             message = "Query error on %s: %s"
@@ -172,7 +173,7 @@ class WinRMPlugin(PythonPlugin):
             message = "Error on %s: Check WinRM AllowUnencrypted is set to true"
         elif type(error) == Exception and "Credentials cache file" in error.message:
             message = "Credentials cache file not found. Please make sure that this file exist and server has  access to it."
-        elif type(error) == Exception and error.message.startswith('kerberos authGSSClientStep failed'):
+        elif type(error) == Exception and 'kerberos' in error.message.lower():
             message = "Unable to connect to %s. Please make sure zWinKDC, zWinRMUser and zWinRMPassword property is configured correctly"
         elif isinstance(error, ResponseFailed):
             for reason in error.reasons:
@@ -192,7 +193,7 @@ class WinRMPlugin(PythonPlugin):
             args.append(error)
 
         log.error(message, *args)
-        self._send_event(message % tuple(args), device.id, 3, eventClass='/Status/Winrm')
+        self._send_event(message % tuple(args), device.id, severity, eventClass='/Status/Winrm')
 
     def _send_event(self, reason, id, severity, force=False,
                     key='ConnectionError', eventClass='/Status', summary=None):
@@ -242,7 +243,12 @@ class WinRMPlugin(PythonPlugin):
         This method can be overridden if more complex collection is
         required.
         '''
-        conn_info = self.conn_info(device)
+        try:
+            conn_info = self.conn_info(device)
+        except UnauthorizedError as e:
+            msg = "Error on {}: {}".format(device.id, e.message)
+            self._send_event(msg, device.id, 4, eventClass='/Status/Winrm', summary=msg)
+            raise e
         client = self.client(conn_info)
 
         results = {}

--- a/docs/body.md
+++ b/docs/body.md
@@ -1745,6 +1745,7 @@ Changes
 
 -   Fix WinRM ZP: HardDisks with a size of 'None' cause unhandled exceptions in modeling (ZPS-1424)
 -   Fix Windows: log line in maintenance() function shows in incorrect logs (ZPS-1600)
+-   Fix Windows: Failed model job does not result in event (ZPS-1608)
 
 2.7.7
 


### PR DESCRIPTION
Fixes ZPS-1608

Really draw attention to the fact that a device can't be modeled