### PR TITLE
Make expected receive failure logs debug instead of warning

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1273,7 +1273,8 @@ Installing this ZenPack will add the following items to your Zenoss system.
 * Fix Failed model job does not result in event (ZPS-1608)
 * Fix Performance tables are not created even though performance batch is successful (ZPS-1605)
 * Fix Traceback modelling with WinMSSQL plugin (ZPS-1676)
-* Fix Custom command needs to allow datapoints with non-zero exit codes
+* Fix Custom command needs to allow datapoints with non-zero exit codes (ZPS-1366)
+* Fix Shutting down the Zenpython daemon creates unnecessary and or mis-catagorized logging connection failure events in zenpython.log (ZPS-1693)
 
 ;2.7.7
 * Fix redundant publishing of service state datapoints (ZPS-1604)

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
@@ -21,6 +21,7 @@ import time
 
 from twisted.internet import defer, reactor
 from twisted.internet.error import ConnectError, TimeoutError
+from twisted.web._newclient import ResponseNeverReceived
 from twisted.internet.task import LoopingCall
 
 from zope.component import adapts, queryUtility
@@ -643,9 +644,11 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
                 self.network_failures += 1
         # Handle errors on which we should start over.
         else:
-            retry, level, msg = (
+            level = logging.WARN
+            if isinstance(e, ResponseNeverReceived):
+                level = logging.DEBUG
+            retry, msg = (
                 False,
-                logging.WARN,
                 "receive failure on {}: {}"
                 .format(self.config.id, e))
 

--- a/docs/body.md
+++ b/docs/body.md
@@ -1748,7 +1748,8 @@ Changes
 -   Fix Failed model job does not result in event (ZPS-1608)
 -   Fix Performance tables are not created even though performance batch is successful (ZPS-1605)
 -   Fix Traceback modelling with WinMSSQL plugin (ZPS-1676)
--   Fix Custom command needs to allow datapoints with non-zero exit codes
+-   Fix Custom command needs to allow datapoints with non-zero exit codes (ZPS-1366)
+-   Fix Shutting down the Zenpython daemon creates unnecessary and or mis-catagorized logging connection failure events in zenpython.log (ZPS-1693)
 
 
 2.7.7


### PR DESCRIPTION
Fixes ZPS-1693

If we know the failures are expected, there's no need for a warning