### PR TITLE
Add migrate script for cluster datasource

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -970,6 +970,7 @@ In [3]: commit()
 * This is the last version of the Microsoft Windows ZenPack where we provide fixes for Windows 2008.
 * When removing a Windows device or the Microsoft.Windows ZenPack, you may see errors in the event.log.  This is expected and is a known defect in ZenPackLib.
 * If upgrading from a version prior to 2.6.3 to 2.7.x, you may not be able to view your Windows services until the device is remodeled.
+* The "powershell Cluster" strategies in the Windows Shell datasource are deprecated.  Cluster component status is now collected via the "Windows Cluster" datasource.
 
 A current list of known issues related to this ZenPack can be found with [https://jira.zenoss.com/issues/?jql=%22Affected%20Zenpack(s)%22%20%3D%20MicrosoftWindows%20AND%20status%20not%20in%20(closed%2C%20%22awaiting%20verification%22)%20ORDER%20BY%20priority%20DESC%2C%20id this JIRA query]. You must be logged into JIRA to run this query. If you don't already have a JIRA account, you can [https://jira.zenoss.com/secure/Signup!default.jspa create one here].
 

--- a/ZenPacks/zenoss/Microsoft/Windows/migrate/RenameClusterDatasource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/migrate/RenameClusterDatasource.py
@@ -1,0 +1,90 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2017, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+import logging
+from Products.ZenModel.ZenPack import ZenPackMigration
+from Products.ZenModel.migrate.Migrate import Version
+from Products.Zuul.interfaces import ICatalogTool
+from Products.ZenModel.RRDTemplate import RRDTemplate
+from ZenPacks.zenoss.Microsoft.Windows import progresslog
+PROGRESS_LOG_INTERVAL = 10
+
+log = logging.getLogger('zen.Microsoft.Windows.migrate.RenameClusterDatasource')
+
+
+class RenameClusterDatasource(ZenPackMigration):
+    # Main class that contains the migrate() method.
+    # Note version setting.
+    version = Version(2, 7, 8)
+
+    def migrate(self, dmd):
+        # Add state datasource/datapoint to subclasses
+        # This will catch any device specific templates and make this migration quicker
+        results = ICatalogTool(dmd.Devices.Server.Microsoft).search(RRDTemplate)
+        if results.total == 0:
+            return
+        log.info('Searching for Cluster templates to update.')
+        templates = []
+        cluster_templates = (
+            'Cluster',
+            'ClusterNode',
+            'ClusterDisk',
+            'ClusterNetwork',
+            'ClusterResource',
+            'ClusterInterface',
+            'ClusterService')
+        for result in results:
+            try:
+                template = result.getObject()
+            except Exception:
+                continue
+            if template.id in cluster_templates:
+                templates.append(template)
+
+        progress = progresslog.ProgressLogger(
+            log,
+            prefix="Cluster template",
+            total=len(templates),
+            interval=PROGRESS_LOG_INTERVAL)
+
+        for template in templates:
+            progress.increment()
+            for ds in template.datasources():
+                if ds.sourcetype == 'Windows Shell' and 'powershell Cluster' in ds.strategy:
+                    # 2.7.0 introduced unnecessary template/ds, just remove it
+                    if template.id == 'Cluster':
+                        template.manage_deleteRRDDataSources(['state', ])
+                    else:
+                        self.replaceDataSource(template, ds)
+            # if the Cluster template is empty then remove it
+            if template.id == 'Cluster' and len(template.datasources()) == 0:
+                template.deviceClass().manage_deleteRRDTemplates((template.id,))
+
+    def replaceDataSource(self, template, ds):
+        cycletime = ds.cycletime
+        severity = ds.severity
+        eventClass = ds.eventClass
+        eventKey = ds.eventKey
+        enabled = ds.enabled
+        try:
+            description = ds.datapoints()[0].description
+        except Exception:
+            pass
+        if 'description' not in locals() or len(description) == 0:
+            description = 'Used to monitor the state of the Cluster Nodes.'
+        template.manage_deleteRRDDataSources(['state', ])
+        newds = template.manage_addRRDDataSource('state', 'ClusterDataSource.ClusterDataSource')
+        newds.sourcetype = 'Windows Cluster'
+        newds.cycletime = cycletime
+        newds.severity = severity
+        newds.eventClass = eventClass
+        newds.eventKey = eventKey
+        newds.enabled = enabled
+        dp = newds.manage_addRRDDataPoint('state')
+        dp.description = description

--- a/docs/body.md
+++ b/docs/body.md
@@ -1315,8 +1315,9 @@ In [3]: commit()
 ```
 
 -   This is the last version of the Microsoft Windows ZenPack where we provide fixes for Windows 2008.
--    When removing a Windows device or the Microsoft.Windows ZenPack, you may see errors in the event.log.  This is expected and is a known defect in ZenPackLib.
+-   When removing a Windows device or the Microsoft.Windows ZenPack, you may see errors in the event.log.  This is expected and is a known defect in ZenPackLib.
 -   If upgrading from a version prior to 2.6.3 to 2.7.x, you may not be able to view your Windows services until the device is remodeled.
+-   The "powershell Cluster" strategies in the Windows Shell datasource are deprecated.  Cluster component status is now collected via the "Windows Cluster" datasource.
 
 A current list of known issues related to this ZenPack can be found with
 [this JIRA query](https://jira.zenoss.com/issues/?jql=%22Affected%20Zenpack%28s%29%22%20%3D%20MicrosoftWindows%20AND%20status%20not%20in%20%28closed%2C%20%22awaiting%20verification%22%29%20ORDER%20BY%20priority%20DESC%2C%20id). You must be logged into JIRA to run this query. If you don't already have a JIRA account, you can [create one here](https://jira.zenoss.com/secure/Signup!default.jspa).


### PR DESCRIPTION
Fixes ZPS-1697

Replace any subclassed "powershell Cluster" datasources with the new
ClusterDataSource.  Also remove errant Cluster template that was
introduced in 2.7.0.