### PR TITLE
Reduce load on event server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ dist
 build
 eggs
 txwinrm
+*.bak
 
 # Packaged Libraries
 ZenPacks/zenoss/Microsoft/Windows/lib/*.pth
@@ -24,3 +25,5 @@ ZenPacks/zenoss/Microsoft/Windows/lib/*.egg-link
 .project
 
 src/txwinrm-*/
+
+.vscode

--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1270,6 +1270,7 @@ Installing this ZenPack will add the following items to your Zenoss system.
 
 ;2.7.9
 * Fix Microsoft Windows 2.7.8 pack install without RPS712 breaks zenpack command (ZPS-1729)
+* Fix Microsoft Windows ZenPack floods event server (ZPS-1752)
 
 ;2.7.8
 * Fix HardDisks with a size of 'None' cause unhandled exceptions in modeling (ZPS-1424)

--- a/ZenPacks/zenoss/Microsoft/Windows/__init__.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/__init__.py
@@ -17,6 +17,7 @@ import re
 import logging
 
 from Products.ZenUtils.Utils import zenPath
+from Products.ZenEvents import ZenEventClasses
 
 try:
     from ZenPacks.zenoss.Impact.impactd.relations import ImpactEdge, DSVRelationshipProvider, RelationshipEdgeError
@@ -231,24 +232,23 @@ class ZenPack(schema.ZenPack):
         """ZPL 2.0 doesn't support these attributes, so setting them here"""
         # clear classes for each failure type
         clear_class_mappings = {'AuthenticationFailure': ['/Status/Winrm/Auth/instances/AuthenticationSuccess'],
-                                'KerberosFailure': ['/Status/Kerberos/instances/KerberosSuccess'],
-                                'KerberosAuthenticationFailure': ['/Status/Kerberos/instances/KerberosAuthenticationSuccess'],
+                                'KerberosFailure': ['/Status/Kerberos/instances/KerberosSuccess']
                                 }
         for path in ['/Status/Winrm/Auth', '/Status/Kerberos']:
             org = dmd.Events.getOrganizer(path)
             if org:
-                for s in ['AuthenticationSuccess', 'KerberosSuccess', 'KerberosAuthenticationSuccess' ]:
+                for s in ['AuthenticationSuccess', 'KerberosSuccess']:
                     try:
                         success = org.findObject(s)
                         if success:
-                            success.setZenProperty('zEventSeverity', 0)
+                            success.setZenProperty('zEventSeverity', ZenEventClasses.Clear)
                     except AttributeError:
                         continue
-                for f in ['AuthenticationFailure', 'KerberosFailure', 'KerberosAuthenticationFailure']:
+                for f in ['AuthenticationFailure', 'KerberosFailure']:
                     try:
                         failure = org.findObject(f)
                         if failure:
-                            failure.setZenProperty('zEventSeverity', 5)
+                            failure.setZenProperty('zEventSeverity', ZenEventClasses.Error)
                             failure.setZenProperty('zEventClearClasses', clear_class_mappings.get(f, []))
                     except AttributeError:
                         continue

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/IISSiteDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/IISSiteDataSource.py
@@ -206,10 +206,16 @@ class IISSiteDataSourcePlugin(PythonDataSourcePlugin):
             sitestatus
         )
 
+        if sitestatus == 'Running':
+            severity = ZenEventClasses.Clear
+        else:
+            severity = ds0.severity
+
         data['events'].append({
             'eventClassKey': 'IISSiteStatus',
             'eventKey': 'IISSite',
-            'severity': ZenEventClasses.Info,
+            'severity': severity,
+            'eventClass': ds0.eventClass,
             'summary': evtmessage.decode('UTF-8'),
             'component': prepId(ds0.component),
             'device': config.id,
@@ -237,7 +243,7 @@ class IISSiteDataSourcePlugin(PythonDataSourcePlugin):
         # only need the one event
         if not data['events']:
             data['events'].append({
-                'eventClass': event_class,
+                'eventClass': '/Status',
                 'severity': ZenEventClasses.Warning,
                 'eventClassKey': 'IISSiteStatusError',
                 'eventKey': 'IISSite',

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
@@ -842,6 +842,7 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
             'device': self.config.id,
             'eventClassKey': 'AuthenticationSuccess',
             'summary': 'Authentication Successful',
+            'severity': ZenEventClasses.Clear,
             'ipAddress': self.config.manageIp})
 
 

--- a/ZenPacks/zenoss/Microsoft/Windows/migrate/RemoveEventInst.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/migrate/RemoveEventInst.py
@@ -1,0 +1,31 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2017, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+import logging
+from Products.ZenModel.ZenPack import ZenPackMigration
+from Products.ZenModel.migrate.Migrate import Version
+from Products.Zuul.interfaces import ICatalogTool
+from Products.AdvancedQuery import Eq, Or
+from Products.ZenEvents.EventClassInst import EventClassInst
+
+log = logging.getLogger('zen.Microsoft.Windows.migrate.RemoveEventInst')
+
+
+class RemoveEventInst(ZenPackMigration):
+    # Main class that contains the migrate() method.
+    # Note version setting.
+    version = Version(2, 7, 9)
+
+    def migrate(self, dmd):
+        org = dmd.Events.getOrganizer('/Status/Kerberos')
+        query = Or(Eq('id', 'KerberosAuthenticationFailure'), Eq('id', 'KerberosAuthenticationSuccess'))
+        res = ICatalogTool(org).search(EventClassInst, query=query)
+        if res.total:
+            log.info('Removing unnecessary Event Class Instances')
+            org.removeInstances(['KerberosAuthenticationFailure', 'KerberosAuthenticationSuccess'])

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testAuthErrEvents.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testAuthErrEvents.py
@@ -45,16 +45,19 @@ class TestErrorEvents(BaseTestCase):
 
         event_class_keys = {0: 'AuthenticationFailure',
                             1: 'AuthenticationFailure',
-                            2: 'KerberosAuthenticationFailure',
+                            2: 'KerberosFailure',
                             3: 'KerberosFailure',
                             4: 'AuthenticationSuccess',
-                            5: 'KerberosAuthenticationSuccess',
-                            6: 'KerberosSuccess', }
+                            5: 'KerberosSuccess', }
         for k, v in event_class_keys.items():
             self.assertEquals(events[k]['eventClassKey'], v)
-        self.assertEquals(len(events), 7)
+        self.assertEquals(len(events), 6)
         for event in events:
             self.assertTrue('eventClass' not in event)
+        self.assertTrue('severity' in events[4])
+        self.assertEquals(events[4]['severity'], 0)
+        self.assertTrue('severity' in events[5])
+        self.assertEquals(events[5]['severity'], 0)
 
 
 def test_suite():

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testClusterDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testClusterDataSource.py
@@ -60,7 +60,7 @@ class TestClusterDataSourcePlugin(BaseTestCase):
         self.assertEquals(len(data['values']), 24)
         for comp, value in RESULTS.iteritems():
             self.assertEquals(data['values'][comp]['state'][0], cluster_state_value(value))
-        self.assertEquals(len(data['events']), 27)
+        self.assertEquals(len(data['events']), 26)
 
 
 def test_suite():

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testEventLogDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testEventLogDataSource.py
@@ -34,7 +34,7 @@ class TestDataSourcePlugin(BaseTestCase):
                               datasource='DataSource')],
         ))
 
-        self.assertEquals(len(res['events']), 5)
+        self.assertEquals(len(res['events']), 4)
         self.assertEquals(res['events'][0]['summary'], u'WinRM Event Message')
         self.assertEquals(res['events'][0]['eventGroup'], sentinel.eventlog)
 

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testIISSiteDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testIISSiteDataSource.py
@@ -1,12 +1,14 @@
+#!/usr/bin/env python
 ##############################################################################
 #
-# Copyright (C) Zenoss, Inc. 2015, all rights reserved.
+# Copyright (C) Zenoss, Inc. 2015-2017, all rights reserved.
 #
 # This content is made available according to terms specified in
 # License.zenoss under the directory where your Zenoss product is installed.
 #
 ##############################################################################
 
+import Globals  # noqa
 from twisted.python.failure import Failure
 from Products.ZenTestCase.BaseTestCase import BaseTestCase
 from ZenPacks.zenoss.Microsoft.Windows.tests.mock import MagicMock, sentinel
@@ -25,7 +27,7 @@ class TestIISSiteDataSourcePlugin(BaseTestCase):
             datasources=[MagicMock(datasource='IISSiteDataSource',
                                    params={'eventlog': sentinel.eventlog})],
         ))
-        self.assertEquals(len(data['events']), 5)
+        self.assertEquals(len(data['events']), 4)
         self.assertEquals("Monitoring ok", data['events'][1]['summary'])
         self.assertIn("is in Unknown state", data['events'][0]['summary'])
 
@@ -42,3 +44,17 @@ class TestIISSiteDataSourcePlugin(BaseTestCase):
         self.assertEquals(len(data['events']), 1)
         self.assertEquals(data['events'][0]['device'], sentinel.id)
         self.assertIn("IISSite: Failed collection", data['events'][0]['summary'])
+
+
+def test_suite():
+    """Return test suite for this module."""
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    suite.addTest(makeSuite(TestIISSiteDataSourcePlugin))
+    return suite
+
+
+if __name__ == "__main__":
+    from zope.testrunner.runner import Runner
+    runner = Runner(found_suites=[test_suite()])
+    runner.run()

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testPerfmonDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testPerfmonDataSource.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 ##############################################################################
 #
 # Copyright (C) Zenoss, Inc. 2015, all rights reserved.
@@ -7,6 +8,7 @@
 #
 ##############################################################################
 
+import Globals
 from itertools import repeat
 from collections import namedtuple
 
@@ -84,3 +86,19 @@ class TestFormat_stdout(BaseTestCase):
     def test_format_stdout(self):
         self.assertEquals(format_stdout([]), ([], False))
         self.assertEquals(format_stdout(["Readings : "]), ([""], True))
+
+
+def test_suite():
+    """Return test suite for this module."""
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    suite.addTest(makeSuite(TestFormat_stdout))
+    suite.addTest(makeSuite(TestFormat_counters))
+    suite.addTest(makeSuite(TestDataPersister))
+    return suite
+
+
+if __name__ == "__main__":
+    from zope.testrunner.runner import Runner
+    runner = Runner(found_suites=[test_suite()])
+    runner.run()

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testProcessDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testProcessDataSource.py
@@ -10,7 +10,7 @@
 from twisted.python.failure import Failure
 from Products.ZenTestCase.BaseTestCase import BaseTestCase
 
-from ZenPacks.zenoss.Microsoft.Windows.tests.mock import sentinel, patch, Mock, MagicMock
+from ZenPacks.zenoss.Microsoft.Windows.tests.mock import sentinel, patch, Mock
 from ZenPacks.zenoss.Microsoft.Windows.tests.utils import load_pickle
 
 from ZenPacks.zenoss.Microsoft.Windows.datasources.ProcessDataSource import ProcessDataSourcePlugin
@@ -40,8 +40,7 @@ class TestProcessDataSourcePlugin(BaseTestCase):
         self.assertItemsEqual(
             (x['summary'] for x in data['events']),
             (
-                'matching processes running', 'process scan successful', 
-                'Authentication Successful', 'No Kerberos auth failures',
-                'No Kerberos failures'
+                'matching processes running', 'process scan successful',
+                'Authentication Successful', 'No Kerberos failures'
             )
         )

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testServiceDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testServiceDataSource.py
@@ -43,15 +43,15 @@ class TestServiceDataSourcePlugin(BaseTestCase):
                                      id=sentinel.id,
                                      datasources=self.ds,
                                      ))
-        self.assertEquals(len(data['events']), 5)
+        self.assertEquals(len(data['events']), 4)
         self.assertEquals(data['events'][0]['summary'],
                           'Service Alert: aspnet_state has changed to Stopped state')
         self.assertEquals(data['events'][1]['summary'],
                           'Windows Service Check: successful service collection')
-        self.assertEquals(data['events'][2]['summary'], 
+        self.assertEquals(data['events'][2]['summary'],
                           'Authentication Successful')
         self.assertEquals(data['events'][3]['summary'],
-                          'No Kerberos auth failures')
+                          'No Kerberos failures')
 
     @patch('ZenPacks.zenoss.Microsoft.Windows.datasources.ServiceDataSource.log', Mock())
     def test_onError(self):

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testShellDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testShellDataSource.py
@@ -31,7 +31,7 @@ class TestShellDataSourcePlugin(BaseTestCase):
     def test_onSuccess(self):
         data = self.plugin.onSuccess(self.success, self.config)
         self.assertEquals(len(data['values']), 12)
-        self.assertEquals(len(data['events']), 30)
+        self.assertEquals(len(data['events']), 29)
         self.assertFalse(all(e['severity'] for e in data['events']))
 
     @patch('ZenPacks.zenoss.Microsoft.Windows.datasources.ShellDataSource.log', Mock())
@@ -84,7 +84,7 @@ class TestShellDataSourcePlugin(BaseTestCase):
         data = self.plugin.onSuccess(win_results, nagios_ok)
         self.assertEquals(len(data['values'][None]), 4)
         self.assertEquals(data['values'][None]['default_criticals'], (0.0, 'N'))
-        self.assertEquals(len(data['events']), 9)
+        self.assertEquals(len(data['events']), 8)
         self.assertEquals(data['events'][0]['severity'], 0)
         # now test nagios with a CRITICAL return code and exit_code of 2
         # CRITICAL - (11 errors) - testing ...|default_lines=12 default_warnings=0 default_criticals=11 default_unknowns=0
@@ -97,7 +97,7 @@ class TestShellDataSourcePlugin(BaseTestCase):
         data = self.plugin.onSuccess(win_results, nagios_critical)
         self.assertEquals(len(data['values'][None]), 4)
         self.assertEquals(data['values'][None]['default_criticals'], (11.0, 'N'))
-        self.assertEquals(len(data['events']), 9)
+        self.assertEquals(len(data['events']), 8)
         self.assertEquals(data['events'][0]['severity'], 5)
         self.assertEquals(data['events'][0]['eventClass'], '/Status/Nagios/Test')
 
@@ -120,7 +120,7 @@ class TestShellDataSourcePlugin(BaseTestCase):
         results = (parms[0], parms[1], CommandResponse(stdout, [], 0))
         data = self.plugin.onSuccess(results, sql_config)
         self.assertEquals(len(data['values']), 0)
-        self.assertEquals(len(data['events']), 16)
+        self.assertEquals(len(data['events']), 15)
         # we should see status of databases even if no counters are returned.
         for x in xrange(5):
             self.assertEquals('The database is available.', data['events'][x]['message'])

--- a/ZenPacks/zenoss/Microsoft/Windows/utils.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/utils.py
@@ -461,24 +461,15 @@ def append_event_datasource_plugin(datasources, events, event):
 def errorMsgCheck(config, events, error):
     """Check error message and generate an appropriate event."""
     kerberos_messages = ['kerberos', 'kinit']
-    kerberos_auth_messages = ['initial credentials', 'authGSSClientStep failed']
     wrongCredsMessages = ['Check username and password', 'Username invalid', 'Password expired']
 
     # see if this a kerberos issue
     if any(x in error for x in kerberos_messages):
-        # if so, is it authentication or general failure
-        if any(y in error for y in kerberos_auth_messages):
-            append_event_datasource_plugin(config.datasources, events, {
-                'eventClassKey': 'KerberosAuthenticationFailure',
-                'summary': error,
-                'ipAddress': config.manageIp,
-                'device': config.id})
-        else:
-            append_event_datasource_plugin(config.datasources, events, {
-                'eventClassKey': 'KerberosFailure',
-                'summary': error,
-                'ipAddress': config.manageIp,
-                'device': config.id})
+        append_event_datasource_plugin(config.datasources, events, {
+            'eventClassKey': 'KerberosFailure',
+            'summary': error,
+            'ipAddress': config.manageIp,
+            'device': config.id})
     # otherwise check if this is a typical authentication failure
     else:
         if any(x in error for x in wrongCredsMessages):
@@ -494,14 +485,12 @@ def generateClearAuthEvents(config, events):
     append_event_datasource_plugin(config.datasources, events, {
         'eventClassKey': 'AuthenticationSuccess',
         'summary': 'Authentication Successful',
-        'device': config.id})
-    append_event_datasource_plugin(config.datasources, events, {
-        'eventClassKey': 'KerberosAuthenticationSuccess',
-        'summary': 'No Kerberos auth failures',
+        'severity': 0,
         'device': config.id})
     append_event_datasource_plugin(config.datasources, events, {
         'eventClassKey': 'KerberosSuccess',
         'summary': 'No Kerberos failures',
+        'severity': 0,
         'device': config.id})
 
 

--- a/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
+++ b/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
@@ -3937,8 +3937,6 @@ event_classes:
   /Status/Kerberos:
     remove: true
     mappings:
-      KerberosAuthenticationSuccess: {}
-      KerberosAuthenticationFailure: {}
       KerberosSuccess: {}
       KerberosFailure: {}
   /Status/Winrm:


### PR DESCRIPTION
Fixes ZPS-1752

Consolidate kerberos errors into one event.
Add Clear severity to clear events so event server does not need to process them
Update unit tests
IISSiteDataSource should send a clear for sitecheck Running and use the ds severity for not running or unknown
Remove superfluous KerberosAuthenticaion event instances