### PR TITLE
write ConnectionLost errors to debug

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1274,6 +1274,7 @@ Installing this ZenPack will add the following items to your Zenoss system.
 * Fix Windows ZenPack: IISSiteStatus transform can result in AttributeError (ZPS-490)
 * Removed WindowsServiceLog, IISSiteStatus, Kerberos, and Authentication event class mappings.
 * Fix collection hanging caused by network timeouts. (ZPS-1765)
+* Fix Shutting down the Zenpython daemon creates unnecessary and or mis-catagorized logging connection failure events in zenpython.log (ZPS-1693, ZPS-1692)
 
 ;2.7.8
 * Fix HardDisks with a size of 'None' cause unhandled exceptions in modeling (ZPS-1424)

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ClusterDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ClusterDataSource.py
@@ -36,6 +36,7 @@ from ..txwinrm_utils import ConnectionInfoProperties, createConnectionInfo
 from ..utils import (
     check_for_network_error, pipejoin, cluster_state_value,
     save, errorMsgCheck, generateClearAuthEvents, get_dsconf)
+from . import send_to_debug
 
 
 # Requires that txwinrm_utils is already imported.
@@ -271,6 +272,8 @@ class ClusterDataSourcePlugin(PythonDataSourcePlugin):
                 args = result.value.args
                 msg = args[0] if args else format_exc(result.value)
                 event_class = '/Status'
+            elif send_to_debug(result):
+                logg = log.debug
             else:
                 eventKey = 'datasourceWarning_{0}'.format(
                     config.datasources[0].datasource

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/IISSiteDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/IISSiteDataSource.py
@@ -35,6 +35,7 @@ from ..utils import (
 # Requires that txwinrm_utils is already imported.
 from txwinrm.collect import create_enum_info
 from txwinrm.WinRMClient import SingleCommandClient, EnumerateClient
+from . import send_to_debug
 
 
 log = logging.getLogger("zen.MicrosoftWindows")
@@ -239,7 +240,10 @@ class IISSiteDataSourcePlugin(PythonDataSourcePlugin):
 
     def onError(self, result, config):
         msg, event_class = check_for_network_error(result, config)
-        log.error("IISSiteDataSource error on %s: %s", config.id, msg)
+        logg = log.error
+        if send_to_debug(result):
+            logg = log.debug
+        logg("IISSiteDataSource error on %s: %s", config.id, msg)
         data = self.new_data()
         errorMsgCheck(config, data['events'], result.value.message)
         # only need the one event

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
@@ -21,11 +21,6 @@ import time
 
 from twisted.internet import defer, reactor
 from twisted.internet.error import ConnectError, TimeoutError
-try:
-    from twisted.web._newclient import ResponseNeverReceived
-except ImportError:
-    ResponseNeverReceived = str
-    pass
 
 from twisted.internet.task import LoopingCall
 
@@ -54,6 +49,7 @@ from txwinrm.shell import create_long_running_command
 from txwinrm.WinRMClient import SingleCommandClient
 from txwinrm.util import UnauthorizedError, RequestError
 import codecs
+from . import send_to_debug
 
 LOG = logging.getLogger('zen.MicrosoftWindows')
 
@@ -667,7 +663,7 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
         # Handle errors on which we should start over.
         else:
             level = logging.WARN
-            if isinstance(e, ResponseNeverReceived):
+            if send_to_debug(failure):
                 level = logging.DEBUG
             retry, msg = (
                 False,

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ProcessDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ProcessDataSource.py
@@ -49,6 +49,7 @@ from ZenPacks.zenoss.PythonCollector.datasources.PythonDataSource \
     import PythonDataSource, PythonDataSourcePlugin
 
 from .. import ZENPACK_NAME
+from . import send_to_debug
 from ..txwinrm_utils import ConnectionInfoProperties, createConnectionInfo
 from ..utils import (
     get_processNameAndArgs, get_processText, save, errorMsgCheck,
@@ -462,14 +463,18 @@ class ProcessDataSourcePlugin(PythonDataSourcePlugin):
             'severity': Event.Clear,
             'eventClass': Status_OSProcess,
             'summary': 'process scan successful',
-            })
+        })
 
         generateClearAuthEvents(config, data['events'])
 
         return data
 
     def onError(self, error, config):
-        LOG.error("%s process scan error: %s", config.id, error.value)
+        logg = LOG.error
+        if send_to_debug(error):
+            logg = LOG.debug
+        msg = "{} process scan error: {}".format(config.id, error.value)
+        logg(msg)
 
         data = self.new_data()
         errorMsgCheck(config, data['events'], error.value.message)
@@ -479,6 +484,6 @@ class ProcessDataSourcePlugin(PythonDataSourcePlugin):
                 'severity': Event.Error,
                 'eventClass': Status_OSProcess,
                 'summary': 'process scan error: {}'.format(error.value),
-                })
+            })
 
         return data

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ServiceDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ServiceDataSource.py
@@ -38,7 +38,8 @@ from ..WinService import WinService
 
 from ..jobs import ReindexWinServices
 from ..txwinrm_utils import ConnectionInfoProperties, createConnectionInfo
-from ..utils import errorMsgCheck, generateClearAuthEvents, get_dummy_dpconfig, get_dsconf
+from ..utils import errorMsgCheck, generateClearAuthEvents, get_dummy_dpconfig
+from . import send_to_debug
 
 # Requires that txwinrm_utils is already imported.
 from txwinrm.collect import create_enum_info
@@ -391,7 +392,10 @@ class ServicePlugin(PythonDataSourcePlugin):
                 result.message = 'Timeout while connecting to host'
                 prefix = ''
         msg = 'WindowsServiceLog: {0}{1} {2}'.format(prefix, result, config)
-        log.error(msg)
+        logg = log.error
+        if send_to_debug(result):
+            logg = log.debug
+        logg(msg)
         data = self.new_data()
         errorMsgCheck(config, data['events'], result.message)
         if not data['events']:

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
@@ -51,6 +51,7 @@ from ..utils import (
     save, errorMsgCheck, generateClearAuthEvents, get_dsconf,
     lookup_databasesummary)
 from EventLogDataSource import string_to_lines
+from . import send_to_debug
 
 
 # Requires that txwinrm_utils is already imported.
@@ -1113,6 +1114,8 @@ class ShellDataSourcePlugin(PythonDataSourcePlugin):
                 args = result.value.args
                 msg = args[0] if args else format_exc(result.value)
                 event_class = '/Status'
+            elif send_to_debug(result):
+                logg = log.debug
 
         logg(msg)
         data = self.new_data()

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/WinRMPingDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/WinRMPingDataSource.py
@@ -32,6 +32,7 @@ from ..utils import errorMsgCheck, generateClearAuthEvents
 # Requires that txwinrm_utils is already imported.
 from txwinrm.collect import create_enum_info
 from txwinrm.WinRMClient import EnumerateClient
+from . import send_to_debug
 
 log = logging.getLogger('zen.MicrosoftWindows')
 ZENPACKID = 'ZenPacks.zenoss.Microsoft.Windows'
@@ -153,7 +154,10 @@ class WinRMPingDataSourcePlugin(PythonDataSourcePlugin):
 
     def onError(self, results, config):
         data = self.new_data()
-        log.error('WinRMPing collection: {} on {}'.format(results.value.message, config.id))
+        logg = log.error
+        if send_to_debug(results):
+            logg = log.debug
+        logg('WinRMPing collection: {} on {}'.format(results.value.message, config.id))
 
         errorMsgCheck(config, data['events'], results.value.message)
 

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/__init__.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/__init__.py
@@ -1,0 +1,32 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2017, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+# twisted 11 doesn't have this error
+try:
+    from twisted.web._newclient import ResponseNeverReceived
+except ImportError:
+    ResponseNeverReceived = str
+    pass
+from twisted.internet.error import ConnectionLost
+
+
+def send_to_debug(error):
+    try:
+        reason = error.value.reasons[0].value
+    except Exception:
+        reason = ''
+    # if ConnectionLost or ResponseNeverReceived, more than
+    # likely zenpython stopping.  throw messages to debug
+    try:
+        if isinstance(reason, ConnectionLost) or\
+           isinstance(error.value, ResponseNeverReceived):
+            return True
+    except AttributeError:
+        pass
+    return False

--- a/docs/body.md
+++ b/docs/body.md
@@ -1749,6 +1749,7 @@ Changes
 -   Fix Windows ZenPack: IISSiteStatus transform can result in AttributeError (ZPS-490)
 -   Removed WindowsServiceLog, IISSiteStatus, Kerberos, and Authentication event class mappings.
 -   Fix collection hanging caused by network timeouts. (ZPS-1765)
+-   Fix Shutting down the Zenpython daemon creates unnecessary and or mis-catagorized logging connection failure events in zenpython.log (ZPS-1693, ZPS-1692)
 
 2.7.8
 


### PR DESCRIPTION
Fixes ZPS-1692, ZPS-1693

twisted 11 doesn't have ResponseNeverReceived error.  check for both
ResponseNeverReceived and ConnectionLost so that we don't log unnecessarily.
