### PR TITLE
Fixes ZPS-1810

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ClusterDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ClusterDataSource.py
@@ -72,6 +72,7 @@ class ClusterDataSource(PythonDataSource):
     ZENPACKID = ZENPACKID
     component = '${here/id}'
     cycletime = 300
+    eventClass = '/Status'
 
     sourcetypes = (WINRS_SOURCETYPE,)
     sourcetype = sourcetypes[0]

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
@@ -69,6 +69,7 @@ class PerfmonDataSource(PythonDataSource):
 
     sourcetype = SOURCETYPE
     sourcetypes = (SOURCETYPE,)
+    eventClass = '/Status'
 
     plugin_classname = (
         ZENPACKID + '.datasources.PerfmonDataSource.PerfmonDataSourcePlugin')


### PR DESCRIPTION
Event Class now displayed in data source template config and events default to /Status.

Fixes ZPS-1810

the eventclass object was set to '/Status' in ClusterDataSource and PerfmonDataSource classes.