### PR TITLE
Advise users to remove non-cluster components from Cluster device

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -953,6 +953,7 @@ This ZenPack functionally supersedes ''ZenPacks.zenoss.WindowsMonitor'' for Wind
 
 The current release is known to have the following limitations.
 
+* Non-Cluster components are no longer valid on a Cluster device.  Cluster devices should only use the OperatingSystem, WinCluster, and WinMSSQL modeler plugins because the nodes of a cluster may have differing components such as Interfaces, FileSystems and Processors.  If you have upgraded from a version previous to 2.5.0, and you still have the following components you should remove them from your Cluster device:  Interfaces/WindowsInterfaces, FileSystems, Processors, Services/Windows Services, Processes.
 * Support for team NICs is limited to Intel and Broadcom interfaces.
 * The custom widget for MSSQL Server credentials is not compatible with Zenoss 4.1.x, therefore the ''zDBInstances'' property in this version should be set as a valid JSON list (e.g. ''[{"instance": "MSSQLSERVER", "user": "", "passwd": ""}]'' ).
 * When upgrading to version 2.2.0, you may see a segmentation fault during the install.  This occurs when upgrading from versions 2.1.3 and previous.  To ensure a successful installation, run the install once more and restart Zenoss.

--- a/docs/body.md
+++ b/docs/body.md
@@ -1287,6 +1287,14 @@ the move.
 
 The current release is known to have the following limitations.
 
+-   Non-Cluster components are no longer valid on a Cluster device.  
+    Cluster devices should only use the OperatingSystem, WinCluster, 
+    and WinMSSQL modeler plugins because the nodes of a cluster may 
+    have differing components such as Interfaces, FileSystems and 
+    Processors.  If you have upgraded from a version previous to 2.5.0, 
+    and you still have the following components you should remove 
+    them from your Cluster device:  Interfaces/WindowsInterfaces, 
+    FileSystems, Processors, Services/Windows Services, Processes.
 -   Support for team NICs is limited to Intel and Broadcom interfaces.
 -   The custom widget for MSSQL Server credentials is not compatible
     with Zenoss 4.1.x, therefore the *zDBInstances* property in this


### PR DESCRIPTION
Fixes ZPS-1853

Because the other modeler plugins are not run, we can't send in empty ObjectMaps to remove components.