### PR TITLE
Speed up loading of database components in 5.2.x+ grid

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1271,7 +1271,7 @@ Installing this ZenPack will add the following items to your Zenoss system.
 
 == Changes ==
 
-;2.7.9
+;2.8.0
 * Fix Microsoft Windows 2.7.8 pack install without RPS712 breaks zenpack command (ZPS-1729)
 * Fix Microsoft Windows ZenPack floods event server (ZPS-1752)
 * Fix Windows ZenPack: IISSiteStatus transform can result in AttributeError (ZPS-490)
@@ -1284,6 +1284,7 @@ Installing this ZenPack will add the following items to your Zenoss system.
 * Fix ZP Microsoft Windows 2.7.0 - conhost.exe and winrshost.exe are opened without closing (ZPS-1354)
 * Fix zenjobs consumes excessive memory for some actions (ZPS-1783)
 * Fix Windows link to device with no ip instead of cluster node is present in grid of Cluster Nodes component (ZPS-1852)
+* Fix Windows - Loading of SQL Databases is worse in comparison with Zenoss 4.2.5 and Windows 2.6.4 on Zenoss 5.2.1 (ZPS-1154)
 
 ;2.7.8
 * Fix HardDisks with a size of 'None' cause unhandled exceptions in modeling (ZPS-1424)

--- a/ZenPacks/zenoss/Microsoft/Windows/migrate/AddDPToIISDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/migrate/AddDPToIISDataSource.py
@@ -21,7 +21,7 @@ log = logging.getLogger('zen.Microsoft.Windows.migrate.AddDPToIISDataSource')
 class AddDPToIISDataSource(ZenPackMigration):
     # Main class that contains the migrate() method.
     # Note version setting.
-    version = Version(2, 7, 9)
+    version = Version(2, 8, 0)
 
     def add_status_dp(self, datasource):
         if not datasource:

--- a/ZenPacks/zenoss/Microsoft/Windows/migrate/AddDPToWinDatabaseTemplate.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/migrate/AddDPToWinDatabaseTemplate.py
@@ -1,0 +1,58 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2017, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+import logging
+from Products.ZenModel.ZenPack import ZenPackMigration
+from Products.ZenModel.migrate.Migrate import Version
+from Products.Zuul.interfaces import ICatalogTool
+from ZenPacks.zenoss.Microsoft.Windows import progresslog
+PROGRESS_LOG_INTERVAL = 10
+
+log = logging.getLogger('zen.Microsoft.Windows.migrate.AddDPToWinDatabaseTemplate')
+
+
+class AddDPToWinDatabaseTemplate(ZenPackMigration):
+    # Main class that contains the migrate() method.
+    # Note version setting.
+    version = Version(2, 8, 0)
+
+    def add_status_ds_dp(self, template):
+        if 'status' not in [ds.id for ds in template.datasources()]:
+            ds = template.manage_addRRDDataSource('status', 'ShellDataSource.Windows Shell')
+            ds.component = '${here/id}'
+            ds.resource = 'status'
+            ds.strategy = 'powershell MSSQL'
+            ds.eventClass = '/Status'
+            ds.manage_addRRDDataPoint('status')
+
+    def migrate(self, dmd):
+        # Add state datasource/datapoint to subclasses
+        # This will catch any device specific templates and make this migration quicker
+        results = ICatalogTool(dmd.Devices.Server.Microsoft).search('Products.ZenModel.RRDTemplate.RRDTemplate')
+        if results.total == 0:
+            return
+        log.info('Searching for WinService templates.')
+        templates = []
+        for result in results:
+            try:
+                template = result.getObject()
+            except Exception:
+                continue
+            if getattr(template, 'targetPythonClass', '') == 'ZenPacks.zenoss.Microsoft.Windows.WinSQLDatabase':
+                templates.append(template)
+
+        progress = progresslog.ProgressLogger(
+            log,
+            prefix="WinService state",
+            total=len(templates),
+            interval=PROGRESS_LOG_INTERVAL)
+
+        for template in templates:
+            progress.increment()
+            self.add_status_ds_dp(template)

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testShellDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testShellDataSource.py
@@ -119,7 +119,7 @@ class TestShellDataSourcePlugin(BaseTestCase):
         sql_config.id = sql_config.datasources[0].device
         results = (parms[0], parms[1], CommandResponse(stdout, [], 0))
         data = self.plugin.onSuccess(results, sql_config)
-        self.assertEquals(len(data['values']), 0)
+        self.assertEquals(len(data['values']), 5)
         self.assertEquals(len(data['events']), 15)
         # we should see status of databases even if no counters are returned.
         for x in xrange(5):

--- a/ZenPacks/zenoss/Microsoft/Windows/utils.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/utils.py
@@ -13,6 +13,20 @@ Basic utilities that doesn't cause any Zope stuff to be imported.
 
 import json
 
+DB_STATUSES = {
+    1: 'AutoClosed',
+    2: 'EmergencyMode',
+    4: 'Inaccessible',
+    8: 'Normal',
+    16: 'Offline',
+    32: 'Recovering',
+    64: 'RecoveryPending',
+    128: 'Restoring',
+    256: 'Shutdown',
+    512: 'Standby',
+    1024: 'Suspect'
+}
+
 
 def addLocalLibPath():
     """
@@ -40,6 +54,22 @@ def lookup_databasesummary(value):
         'Suspect': 'The database has been marked as suspect. You will have '
         'to check the data, and the database might have to be restored from a backup.',
     }.get(value, '')
+
+
+def lookup_database_status(value):
+    return {
+        'AutoClosed': 1,
+        'EmergencyMode': 2,
+        'Inaccessible': 4,
+        'Normal': 8,
+        'Offline': 16,
+        'Recovering': 32,
+        'RecoveryPending': 64,
+        'Restoring': 128,
+        'Shutdown': 256,
+        'Standby': 512,
+        'Suspect': 1024
+    }.get(value.strip(), 0)
 
 
 def lookup_adminpasswordstatus(value):

--- a/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
+++ b/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
@@ -2309,6 +2309,15 @@ device_classes:
             cycletime: '300'
             resource: Log Cache Hit Ratio Base
             strategy: powershell MSSQL
+          status:
+            type: Windows Shell
+            datapoints:
+              status:
+                rrdtype: GAUGE
+                rrdmin: 0
+            cycletime: '300'
+            resource: status
+            strategy: powershell MSSQL
         graphs:
           Transactions:
             units: transactions

--- a/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
+++ b/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
@@ -2311,6 +2311,7 @@ device_classes:
             strategy: powershell MSSQL
           status:
             type: Windows Shell
+            eventClass: /Status
             datapoints:
               status:
                 rrdtype: GAUGE

--- a/docs/body.md
+++ b/docs/body.md
@@ -1759,7 +1759,7 @@ Monitoring Templates
 Changes
 -------
 
-2.7.9
+2.8.0
 
 -   Fix Microsoft Windows 2.7.8 pack install without RPS712 breaks zenpack command (ZPS-1729)
 -   Fix Microsoft Windows ZenPack floods event server (ZPS-1752)
@@ -1773,6 +1773,8 @@ Changes
 -   Fix ZP Microsoft Windows 2.7.0 - conhost.exe and winrshost.exe are opened without closing (ZPS-1354)
 -   Fix zenjobs consumes excessive memory for some actions (ZPS-1783)
 -   Fix Windows link to device with no ip instead of cluster node is present in grid of Cluster Nodes component (ZPS-1852)
+-   Fix Windows - Loading of SQL Databases is worse in comparison with Zenoss 4.2.5 and Windows 2.6.4 on Zenoss 5.2.1 (ZPS-1154)
+
 
 
 2.7.8


### PR DESCRIPTION
Fixes ZPS-1154

Change how we are saving and displaying status for a sql database.
Connecting to zep and searching was taking too much time. Now we'll
use a bitmask to find and display the statuses from a datapoint.