### PR TITLE
Make sure we show default sql server instance

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -281,8 +281,23 @@ The following metrics are collected directly via WMI.
 {{note}} IIS 6 Management compatibility role no longer needs to be installed on the server side in order to use the IIS Sites component.
 
 
-=== SQL Server ===
-The following performance counters are monitored via Powershell script per database:
+=== SQL Server Instances ===
+
+* \SQLServer:Buffer Manager\Buffer cache hit ratio
+* \SQLServer:Buffer Manager\Page life expectancy
+* \SQLServer:SQL Statistics\Batch Requests/Sec
+* \SQLServer:SQL Statistics\SQL Compilations/Sec
+* \SQLServer:SQL Statistics\SQL Re-Compilations/Sec
+* \SQLServer:General Statistics\User Connections
+* \SQLServer:Locks(_Total)\Lock Waits/Sec
+* \SQLServer:Access Methods\Page Splits/Sec
+* \SQLServer:General Statistic\Processes Blocked
+* \SQLServer:Buffer Manager\Checkpoint Pages/Sec
+* \SQLServer:Locks(_Total)\Number of Deadlocks/sec
+
+{{note}} For a named instance, the counter instance will be `\\MSSQL$INSTANCE_NAME`.  To add custom SQL Server instance counters, create a Windows Perfmon datasource and datapoint with matching names and specify the counter as `\\${here/perfmon_instance}\counter name`.  During modeling, the plugin will assign the correct counter name.
+
+=== SQL Server Databases ===
 
 * \SQLServer:Databases(<dbname>)\Active Transactions
 * \SQLServer:Databases(<dbname>)\Backup/Restore Throughput/sec
@@ -1291,6 +1306,8 @@ Installing this ZenPack will add the following items to your Zenoss system.
 * Fix zenjobs consumes excessive memory for some actions (ZPS-1783)
 * Fix Windows link to device with no ip instead of cluster node is present in grid of Cluster Nodes component (ZPS-1852)
 * Fix Windows - Loading of SQL Databases is worse in comparison with Zenoss 4.2.5 and Windows 2.6.4 on Zenoss 5.2.1 (ZPS-1154)
+* Fix Windows ZenPack does not show the default sql server name as MSSQLSERVER (ZPS-2031)
+* Added SQL Server instance performance counters
 
 ;2.7.8
 * Fix HardDisks with a size of 'None' cause unhandled exceptions in modeling (ZPS-1424)

--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinMSSQL.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinMSSQL.py
@@ -223,7 +223,7 @@ class WinMSSQL(WinRMPlugin):
 
             if instance not in dblogins:
                 self.log.info("DB Instance {0} found but was not set in zDBInstances.  "
-                         "Using default credentials.".format(instance))
+                              "Using default credentials.".format(instance))
 
             instance_title = instance
             if instance == 'MSSQLSERVER':
@@ -239,8 +239,13 @@ class WinMSSQL(WinRMPlugin):
 
             om_instance = ObjectMap()
             om_instance.id = self.prepId(instance_title)
-            om_instance.title = instance_title
-            om_instance.instancename = instance_title
+            if instance == 'MSSQLSERVER':
+                om_instance.perfmon_instance = 'SQLServer'
+                om_instance.title = '{}(MSSQLSERVER)'.format(instance_title)
+            else:
+                om_instance.perfmon_instance = 'MSSQL${}'.format(instance)
+                om_instance.title = instance_title
+            om_instance.instancename = instance
             om_instance.sql_server_version = version
             om_instance.cluster_node_server = '{0}//{1}'.format(
                 owner_node.strip(), sqlserver)

--- a/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
+++ b/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
@@ -742,6 +742,8 @@ classes:
         label: Roles
       cluster_node_server:
         label: Cluster Node Server
+      perfmon_instance:
+        label: Perfmon Counter Instance Name
     monitoring_templates: [WinDBInstance]
     impacts: [backups, databases, jobs]
     impacted_by: [device]
@@ -1575,6 +1577,180 @@ device_classes:
             cycletime: '300'
             resource: status
             strategy: powershell MSSQL Instance
+          BufferCacheHitRatio:
+            type: Windows Perfmon
+            component: ${here/id}
+            datapoints:
+              BufferCacheHitRatio:
+                rrdtype: GAUGE
+                rrdmin: 0
+                aliases: {buffer_cache_hit_ratio: null}
+            counter: \${here/perfmon_instance}:Buffer Manager\Buffer cache hit ratio
+          PageLifeExpectancy:
+            type: Windows Perfmon
+            component: ${here/id}
+            datapoints:
+              PageLifeExpectancy:
+                rrdtype: GAUGE
+                rrdmin: 0
+                aliases: {page_life_expectancy: null}
+            counter: \${here/perfmon_instance}:Buffer Manager\Page life expectancy
+          BatchRequestsPerSec:
+            type: Windows Perfmon
+            component: ${here/id}
+            datapoints:
+              BatchRequestsPerSec:
+                rrdtype: GAUGE
+                rrdmin: 0
+                aliases: {batch_requests__sec: null}
+            counter: \${here/perfmon_instance}:SQL Statistics\Batch Requests/Sec
+          SQLCompilationsPerSec:
+            type: Windows Perfmon
+            component: ${here/id}
+            datapoints:
+              SQLCompilationsPerSec:
+                rrdtype: GAUGE
+                rrdmin: 0
+                aliases: {sql_compilations__sec: null}
+            counter: \${here/perfmon_instance}:SQL Statistics\SQL Compilations/Sec
+          SQLReCompilationsPerSec:
+            type: Windows Perfmon
+            component: ${here/id}
+            datapoints:
+              SQLReCompilationsPerSec:
+                rrdtype: GAUGE
+                rrdmin: 0
+                aliases: {sql_recompilations__sec: null}
+            counter: \${here/perfmon_instance}:SQL Statistics\SQL Re-Compilations/Sec
+          UserConnections:
+            type: Windows Perfmon
+            component: ${here/id}
+            datapoints:
+              UserConnections:
+                rrdtype: GAUGE
+                rrdmin: 0
+                aliases: {user_connections: null}
+            counter: \${here/perfmon_instance}:General Statistics\User Connections
+          LockWaitsPerSec:
+            type: Windows Perfmon
+            component: ${here/id}
+            datapoints:
+              LockWaitsPerSec:
+                rrdtype: GAUGE
+                rrdmin: 0
+                aliases: {lock_waits__sec: null}
+            counter: \${here/perfmon_instance}:Locks(_Total)\Lock Waits/Sec
+          PageSplitsPerSec:
+            type: Windows Perfmon
+            component: ${here/id}
+            datapoints:
+              PageSplitsPerSec:
+                rrdtype: GAUGE
+                rrdmin: 0
+                aliases: {page_splits__sec: null}
+            counter: \${here/perfmon_instance}:Access Methods\Page Splits/Sec
+          ProcessesBlocked:
+            type: Windows Perfmon
+            component: ${here/id}
+            datapoints:
+              ProcessesBlocked:
+                rrdtype: GAUGE
+                rrdmin: 0
+                aliases: {processes_blocked: null}
+            counter: \${here/perfmon_instance}:General Statistics\Processes Blocked
+          CheckpointPagesPerSec:
+            type: Windows Perfmon
+            component: ${here/id}
+            datapoints:
+              CheckpointPagesPerSec:
+                rrdtype: GAUGE
+                rrdmin: 0
+                aliases: {checkpoint_pages__sec: null}
+            counter: \${here/perfmon_instance}:Buffer Manager\Checkpoint Pages/Sec
+          DeadlocksPerSec:
+            type: Windows Perfmon
+            component: ${here/id}
+            datapoints:
+              DeadlocksPerSec:
+                rrdtype: GAUGE
+                rrdmin: 0
+                aliases: {deadlocks__sec: null}
+            counter: \${here/perfmon_instance}:Locks(_Total)\Number of Deadlocks/sec
+        graphs:
+          Buffer Cache Hit Ratio:
+            units: percent
+            miny: 0
+            maxy: 100
+            graphpoints:
+              Cache Hit Ratio:
+                dpName: BufferCacheHitRatio_BufferCacheHitRatio
+                format: '%7.2lf%%'
+          Page Life Expectancy:
+            units: seconds
+            miny: 0
+            graphpoints:
+              Page Life:
+                dpName: PageLifeExpectancy_PageLifeExpectancy
+                format: '%7.21f%'
+          Batch Requests:
+            units: batches/sec
+            miny: 0
+            graphpoints:
+              Batches:
+                dpName: BatchRequestsPerSec_BatchRequestsPerSec
+                format: '%7.21f%'
+          Compilations:
+            units: compilatios/sec
+            miny: 0
+            graphpoints:
+              Compilations:
+                dpName: SQLCompilationsPerSec_SQLCompilationsPerSec
+                format: '%7.21f%'
+              Re-Compilations:
+                dpName: SQLReCompilationsPerSec_SQLReCompilationsPerSec
+                format: '%7.21f%'
+          Connections:
+            units: connections
+            miny: 0
+            graphpoints:
+              User Connections:
+                dpName: UserConnections_UserConnections
+                format: '%7.21f%'
+          Lock Waits:
+            units: lock waits/sec
+            miny: 0
+            graphpoints:
+              Locks:
+                dpName: LockWaitsPerSec_LockWaitsPerSec
+                format: '%7.21f%'
+          Page Splits:
+            units: page splits/sec
+            miny: 0
+            graphpoints:
+              Splits:
+                dpName: PageSplitsPerSec_PageSplitsPerSec
+                format: '%7.21f%'
+          Processes Blocked:
+            units: processes
+            miny: 0
+            graphpoints:
+              Processes:
+                dpName: ProcessesBlocked_ProcessesBlocked
+                format: '%7.21f%'
+          Checkpoint Pages:
+            units: checkpoint pages/sec
+            miny: 0
+            graphpoints:
+              Pages:
+                dpName: CheckpointPagesPerSec_CheckpointPagesPerSec
+                format: '%7.21f%'
+          Deadlocks:
+            units: deadlocks/sec
+            miny: 0
+            graphpoints:
+              Deadlocks:
+                dpName: DeadlocksPerSec_DeadlocksPerSec
+                format: '%7.21f%'
       Active Directory 2003:
         description: Microsoft Active Directory
         thresholds:

--- a/docs/body.md
+++ b/docs/body.md
@@ -341,10 +341,22 @@ Processes (Win32\_PerfFormattedData\_PerfProc\_Process)
 Note: IIS 6 Management compatibility role no longer needs to be
 installed on the server side in order to use the IIS Sites component.
 
-SQL Server
+SQL Server Instance
+:   \\SQLServer:Buffer Manager\\Buffer cache hit ratio
+:   \\SQLServer:Buffer Manager\\Page life expectancy
+:   \\SQLServer:SQL Statistics\\Batch Requests/Sec
+:   \\SQLServer:SQL Statistics\\SQL Compilations/Sec
+:   \\SQLServer:SQL Statistics\\SQL Re-Compilations/Sec
+:   \\SQLServer:General Statistics\\User Connections
+:   \\SQLServer:Locks(_Total)\\Lock Waits/Sec
+:   \\SQLServer:Access Methods\\Page Splits/Sec
+:   \\SQLServer:General Statistic\\Processes Blocked
+:   \\SQLServer:Buffer Manager\\Checkpoint Pages/Sec
+:   \\SQLServer:Locks(_Total)\\Number of Deadlocks/sec
 
-The following performance counters are monitored via Powershell script per database:
+Note: For a named instance, the counter instance will be `\\MSSQL$INSTANCE_NAME`.  To add custom SQL Server instance counters, create a Windows Perfmon datasource and datapoint with matching names and specify the counter as `\\${here/perfmon_instance}\counter name`.  During modeling, the plugin will assign the correct counter name.
 
+SQL Server Database
 :   \\Active Transactions
 :   \\Backup/Restore Throughput/sec
 :   \\Bulk Copy Rows/sec
@@ -373,9 +385,6 @@ The following performance counters are monitored via Powershell script per datab
 :   \\Repl. Trans. Rate
 :   \\Shrink Data Movement Bytes/sec
 :   \\Transactions/sec
-
-You can enable/disable any of these or change the cycle time by editing
-the WinDatabase monitoring template.
 
 Database Statuses
 
@@ -1781,6 +1790,8 @@ Changes
 -   Fix zenjobs consumes excessive memory for some actions (ZPS-1783)
 -   Fix Windows link to device with no ip instead of cluster node is present in grid of Cluster Nodes component (ZPS-1852)
 -   Fix Windows - Loading of SQL Databases is worse in comparison with Zenoss 4.2.5 and Windows 2.6.4 on Zenoss 5.2.1 (ZPS-1154)
+-   Fix Windows ZenPack does not show the default sql server name as MSSQLSERVER (ZPS-2031)
+-   Added SQL Server instance performance counters
 
 
 


### PR DESCRIPTION
Fixes ZPS-2031

Show MSSQLSERVER as the instance name.  Add new perfmon_instance
attribute to hold the perf counter instance name.  \SQLServer for
default MSSQLSERVER, \MSSQL${instance_name} for a named instance.
Also added in some default instance counters out of the box.