### PR TITLE
Add note to readme to disable snmp monitoring

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1162,6 +1162,8 @@ If you see an event stating that a plugin was disabled due to blocking, see the 
 
 {{note}} Starting with v2.7.0, this should not occur for Windows data source plugins.
 
+If you see 'SNMP agent down - no response received' events and would like not to see them, set zSnmpMonitorIgnore to true on the /Server/Microsoft or lower device class, depending on your configuration.
+
 === Troubleshooting modeling/monitoring ===
 
 Version 2.6.0 introduces a command line option to save modeling/monitoring results for troubleshooting.  This option will save the results returned from a Windows server from a modeler or datasource plugin.  This data can then be viewed/tested using unit tests to determine issues.

--- a/docs/body.md
+++ b/docs/body.md
@@ -1637,6 +1637,8 @@ Configuration for <device> unavailable -- is that the correct name?
 
 If you see an event stating that a plugin was disabled due to blocking, see the [PythonCollector ZenPack](/product/zenpacks/pythoncollector) documentation for steps to remedy this.
 
+If you see 'SNMP agent down - no response received' events and would like not to see them, set zSnmpMonitorIgnore to true on the /Server/Microsoft or lower device class, depending on your configuration.
+
 ### Troubleshooting modeling/monitoring
 
 Version 2.6.0 introduces a command line option to save


### PR DESCRIPTION
Fixes ZPS-2108

ZPL 2.0 will not overwrite zprops in existing device classes.  Add
comment noting how to disable snmp monitoring for microsoft device class.