### PR TITLE
Possible fix for data gaps

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1131,10 +1131,6 @@ If there are existing SQL server instances being monitored, make sure to reconfi
 
 === Troubleshooting Services ===
 
-If you see an event error that shows "The maximum number of concurrent operations for this user has been exceeded", you will need to increase the number of concurrent operations per user in the winrm config.
-For example:
-* winrm set winrm/config/service '@{MaxConcurrentOperationsPerUser="5000"}'
-
 If you see an "Index out of range" error, this could indicate a low number of available file handles in Linux.  The default is 1024.  To view this information on your system, enter 'ulimit -n'.  To increase this limit, edit your /etc/sysctl.conf file and set fs.file-max to a sufficiently large number.
 For example:
 * vi /etc/sysctl.conf
@@ -1144,8 +1140,7 @@ For example:
 
 The first step in troubleshooting any monitoring issues is to scan the zenpython log for errors.
 
-While monitoring, possible network connectivity issues may occur while trying to complete the Get-Counter command.
-If you experience OperationTimeout errors, it may be a solution to decrease value of ''zWinPerfmonInterval'' property to 30 seconds.
+If you see OperationTimeout errors in the zenpython log, this is normal.  The reason for this is that we run the Get-Counter PowerShell cmdlet over the course of two polling cycles and pull 2 samples by default.  There is a 60 second timeout when attempting to receive data.  If the receive request does not finish within 60 seconds, you will see an OperationTimeout.  You can decrease zWinPerfmonInterval to a lower value, which will pull samples more frequently.
 
 Other timeout issues on a domain could involve having a large Kerberos token.  This could be caused by the user belonging to a large number of groups.  See https://support.microsoft.com/en-us/kb/970875 for more information on the cause and resolution.  Possible side effects of a large token include high CPU usage on the Windows server.
 
@@ -1172,6 +1167,10 @@ export ZP_DUMP=1;zenmodeler run -d server1.example.com --collect=Interfaces; uns
 This will unload a pickle of the results to a file in the /tmp folder called Interfaces_process_XXXXXX.pickle.
 
 {{note}} Be sure to unset the environment variable to avoid unwanted pickle files.
+
+If you see an event error that shows "The maximum number of concurrent operations for this user has been exceeded", you will need to increase the number of concurrent operations per user in the winrm config to the maximum.
+For example:
+* winrm set winrm/config/service '@{MaxConcurrentOperationsPerUser="4294967295"}'
 
 == Zenoss Analytics ==
 

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
@@ -280,7 +280,7 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
         # Define SampleInterval and MaxSamples arguments for ps commands.
         if self.cycling:
             self.sample_interval = self.cycletime
-            self.max_samples = max(3600 / self.sample_interval, 1)
+            self.max_samples = max(600 / self.sample_interval, 1)
         else:
             self.sample_interval = 1
             self.max_samples = 1

--- a/docs/body.md
+++ b/docs/body.md
@@ -1584,15 +1584,6 @@ The following are the most common errors:
 
 ### Troubleshooting Services
 
-If you see an event error that shows "The maximum number of concurrent
-operations for this user has been exceeded", you will need to increase
-the number of concurrent operations per user in the winrm config. For
-example: 
-
-```
-winrm set winrm/config/service '@{MaxConcurrentOperationsPerUser="5000"}'
-```
-
 If you see an "Index out of range" error, this could indicate a low
 number of available file handles in Linux. The default is 1024. To view
 this information on your system, enter 'ulimit -n'. To increase this
@@ -1609,10 +1600,13 @@ fs.file-max=10000
 The first step in troubleshooting any monitoring issues is to scan the
 zenpython log for errors.
 
-While monitoring, possible network connectivity issues may occur while
-trying to complete the Get-Counter command. If you experience
-OperationTimeout errors, it may be a solution to decrease value of
-*zWinPerfmonInterval* property to 30 seconds.
+If you see OperationTimeout errors in the zenpython log, this is normal.  
+The reason for this is that we run the Get-Counter PowerShell cmdlet 
+over the course of two polling cycles and pull 2 samples by default.  
+There is a 60 second timeout when attempting to receive data.  If the 
+receive request does not finish within 60 seconds, you will see an 
+OperationTimeout.  You can decrease zWinPerfmonInterval to a lower 
+value, which will pull samples more frequently.
 
 Other timeout issues on a domain could involve having a large Kerberos
 token. This could be caused by the user belonging to a large number of
@@ -1652,6 +1646,15 @@ called Interfaces_process_XXXXXX.pickle.
 
 Note: Be sure to unset the environment variable to avoid unwanted
 pickle files.
+
+If you see an event error that shows "The maximum number of concurrent
+operations for this user has been exceeded", you will need to increase
+the number of concurrent operations per user in the winrm config. For
+example: 
+
+```
+winrm set winrm/config/service '@{MaxConcurrentOperationsPerUser="4294967295"}'
+```
 
 ## Zenoss Analytics
 


### PR DESCRIPTION
Possibly Fixes ZPS-2075

Revert perfmondatasource run time for get-counter to 10 minutes.
This could make a difference so that we restart the command sooner.