### PR TITLE
use component name, not contextcompname for component

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
@@ -345,7 +345,7 @@ class CustomCommandStrategy(object):
 
         cmd.ds = dsconf.datasource
         cmd.device = dsconf.params['servername']
-        cmd.component = dsconf.params['contextcompname']
+        cmd.component = dsconf.component
 
         # Pass the severity from the datasource to the command parsers
         # If Nagios, check the status for severity


### PR DESCRIPTION
Fixes ZPS-2055

contextcompname is only used for sql instances.  we should have been
using dsconf.component