### PR TITLE
use component for component datasources, contextcompname for device

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1314,6 +1314,7 @@ Installing this ZenPack will add the following items to your Zenoss system.
 * Fix Multiple zenpython instances on a collector sometimes results in incomplete krb5.conf (ZPS-2072)
 * Added Windows Shell Custom Command datasources usage with Nagios parser limitations (ZPS-1286).
 * Fix malformed sql job results show 'too many values to unpack' error (ZPS-2143)
+* Fix Windows Shell Data Source Sets the Component to an Unconventional Value (ZPS-2055)
 
 ;2.7.8
 * Fix HardDisks with a size of 'None' cause unhandled exceptions in modeling (ZPS-1424)

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
@@ -345,7 +345,10 @@ class CustomCommandStrategy(object):
 
         cmd.ds = dsconf.datasource
         cmd.device = dsconf.params['servername']
-        cmd.component = dsconf.component
+        if dsconf.component is not None and len(dsconf.component):
+            cmd.component = dsconf.component
+        else:
+            cmd.component = dsconf.params['contextcompname']
 
         # Pass the severity from the datasource to the command parsers
         # If Nagios, check the status for severity

--- a/docs/body.md
+++ b/docs/body.md
@@ -1806,6 +1806,7 @@ Changes
 -   Added Windows Shell Custom Command datasources usage with Nagios parser limitations (ZPS-1286).
 -   Fix events for IIS Site components (ZPS-2126)
 -   Fix malformed sql job results show 'too many values to unpack' error (ZPS-2143)
+-   Fix Windows Shell Data Source Sets the Component to an Unconventional Value (ZPS-2055)
 
 2.7.8
 


### PR DESCRIPTION
Fixes ZPS-2142

This will allow users to specify ${here/id} tales expression for a component
datasource.