### PR TITLE
Add in txcoroutine as replacement for inlineCallbacks

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1325,6 +1325,7 @@ Installing this ZenPack will add the following items to your Zenoss system.
 * Fix "Error in zenoss.winrm.WinMSSQL: too many values to unpack" (ZPS-2206)
 * Fix Not all bound monitoring templates listed on device overview page (ZPS-2187)
 * Fix cannot concatenate 'str' and 'NoneType' objects" during Lync modeling (ZPS-2203)
+* Fix collection hanging caused by network timeouts by applying fix for twisted bug. (ZPS-1765)
 
 ;2.8.0
 * Added SQL Server instance performance counters

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ClusterDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ClusterDataSource.py
@@ -31,6 +31,7 @@ from Products.Zuul.infos.template import RRDDataSourceInfo
 from Products.ZenEvents import ZenEventClasses
 from ZenPacks.zenoss.PythonCollector.datasources.PythonDataSource \
     import PythonDataSource, PythonDataSourcePlugin
+from ..txcoroutine import coroutine
 
 from ..txwinrm_utils import ConnectionInfoProperties, createConnectionInfo
 from ..utils import (
@@ -38,7 +39,6 @@ from ..utils import (
     save, errorMsgCheck, generateClearAuthEvents, get_dsconf,
     cluster_disk_state_string)
 from . import send_to_debug
-
 
 # Requires that txwinrm_utils is already imported.
 from txwinrm.util import RequestError
@@ -193,7 +193,7 @@ class ClusterDataSourcePlugin(PythonDataSourcePlugin):
         script = "\"& {{{}}}\"".format(''.join(psClusterCommands))
         return pscommand, script
 
-    @defer.inlineCallbacks
+    @coroutine
     def collect(self, config):
         conn_info = createConnectionInfo(config.datasources[0])
         command = SingleCommandClient(conn_info)

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/EventLogDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/EventLogDataSource.py
@@ -18,7 +18,7 @@ from xml.parsers.expat import ExpatError
 import xml.dom.minidom
 from xml.dom.ext import PrettyPrint
 from StringIO import StringIO
-
+from twisted.internet.defer import returnValue
 from zope.component import adapts
 from zope.interface import implements
 from Products.Zuul.infos import InfoBase
@@ -30,6 +30,8 @@ from Products.ZenEvents import ZenEventClasses
 
 from ZenPacks.zenoss.PythonCollector.datasources.PythonDataSource \
     import PythonDataSource, PythonDataSourcePlugin
+
+from ..txcoroutine import coroutine
 
 from ..utils import save, errorMsgCheck, generateClearAuthEvents
 
@@ -87,7 +89,7 @@ class IEventLogInfo(IInfo):
         xtype='eventclass'
     )
     component = schema.TextLine(
-       title=_t(u'Component')
+        title=_t(u'Component')
     )
     cycletime = schema.TextLine(
         title=_t(u'Cycle Time (seconds)')
@@ -230,6 +232,7 @@ class EventLogPlugin(PythonDataSourcePlugin):
             eventClass=datasource.eventClass
         )
 
+    @coroutine
     def collect(self, config):
         log.info('{} Start Collection of Events'.format(config.id))
 
@@ -250,7 +253,8 @@ class EventLogPlugin(PythonDataSourcePlugin):
         eventid = ds0.params['eventid']
         isxml = ds0.params['use_xml']
 
-        return query.run(eventlog, select, max_age, eventid, isxml)
+        results = yield query.run(eventlog, select, max_age, eventid, isxml)
+        returnValue(results)
 
     @save
     def onSuccess(self, results, config):

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/IISSiteDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/IISSiteDataSource.py
@@ -33,6 +33,8 @@ from ..utils import (
     check_for_network_error, save, errorMsgCheck, generateClearAuthEvents,
     APP_POOL_STATUSES)
 
+from ..txcoroutine import coroutine
+
 # Requires that txwinrm_utils is already imported.
 from txwinrm.collect import create_enum_info
 from txwinrm.WinRMClient import SingleCommandClient, EnumerateClient
@@ -151,7 +153,7 @@ class IISSiteDataSourcePlugin(PythonDataSourcePlugin):
 
         return params
 
-    @defer.inlineCallbacks
+    @coroutine
     def collect(self, config):
         log.debug('{0}:Start Collection of IIS Sites'.format(config.id))
         ds0 = config.datasources[0]

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
@@ -44,6 +44,8 @@ from ..twisted_utils import add_timeout
 from ..txwinrm_utils import ConnectionInfoProperties, createConnectionInfo
 from ..utils import append_event_datasource_plugin, errorMsgCheck, generateClearAuthEvents
 
+from ..txcoroutine import coroutine
+
 # Requires that txwinrm_utils is already imported.
 from txwinrm.shell import create_long_running_command
 from txwinrm.WinRMClient import SingleCommandClient
@@ -223,7 +225,7 @@ class ComplexLongRunningCommand(object):
 
         return commands
 
-    @defer.inlineCallbacks
+    @coroutine
     def start(self, command_lines):
         """Start a separate command for each command line.
         If the number of commands has changed since the last start,
@@ -237,7 +239,7 @@ class ComplexLongRunningCommand(object):
             if command is not None:
                 yield command.start(self.ps_command, ps_script=command_line)
 
-    @defer.inlineCallbacks
+    @coroutine
     def stop(self):
         """Stop all started commands."""
         for command in self.commands:
@@ -349,7 +351,7 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
 
         return {'counter': counter}
 
-    @defer.inlineCallbacks
+    @coroutine
     def collect(self, config):
         """Collect for config.
 
@@ -360,7 +362,7 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
         data = yield self.get_data()
         defer.returnValue(data)
 
-    @defer.inlineCallbacks
+    @coroutine
     def start(self):
         """Start the continuous command."""
         if self.state != PluginStates.STOPPED:
@@ -407,7 +409,7 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
         PERSISTER.start()
         defer.returnValue(None)
 
-    @defer.inlineCallbacks
+    @coroutine
     def get_data(self):
         """Wait for data to arrive if necessary, then return it."""
         data = PERSISTER.pop(self.config.id)
@@ -429,7 +431,7 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
 
         defer.returnValue(PERSISTER.pop(self.config.id))
 
-    @defer.inlineCallbacks
+    @coroutine
     def stop(self):
         """Stop the continuous command."""
         if self.state != PluginStates.STARTED:
@@ -480,7 +482,7 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
 
         defer.returnValue(None)
 
-    @defer.inlineCallbacks
+    @coroutine
     def restart(self):
         """Stop then start the long-running command."""
         yield self.stop()
@@ -534,7 +536,7 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
 
         return failures, results
 
-    @defer.inlineCallbacks
+    @coroutine
     def onReceive(self, result):
         """Group the result of all commands into a single result."""
         failures, results = self._parse_deferred_result(result)
@@ -635,7 +637,7 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
             'ipAddress': self.config.manageIp})
         defer.returnValue(None)
 
-    @defer.inlineCallbacks
+    @coroutine
     def onReceiveFail(self, failure):
         e = failure.value
 
@@ -686,7 +688,7 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
 
         defer.returnValue(None)
 
-    @defer.inlineCallbacks
+    @coroutine
     def search_corrupt_counters(self, winrs, counter_list, corrupt_list):
         """Bisect the counters to determine which of them are corrupt."""
         ps_command = "powershell -NoLogo -NonInteractive -NoProfile -Command"
@@ -712,7 +714,7 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
 
         defer.returnValue(corrupt_list)
 
-    @defer.inlineCallbacks
+    @coroutine
     def remove_corrupt_counters(self):
         """Remove counters which return an error."""
         LOG.debug('{}: Performing check for corrupt counters'.format(self.config.id))

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ServiceDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ServiceDataSource.py
@@ -44,7 +44,7 @@ from . import send_to_debug
 # Requires that txwinrm_utils is already imported.
 from txwinrm.collect import create_enum_info
 from txwinrm.WinRMClient import EnumerateClient
-
+from ..txcoroutine import coroutine
 
 log = logging.getLogger("zen.MicrosoftWindows")
 ZENPACKID = 'ZenPacks.zenoss.Microsoft.Windows'
@@ -276,7 +276,7 @@ class ServicePlugin(PythonDataSourcePlugin):
             dp.metadata = datasource.params.get('metricmetadata', None)
             datasource.points.append(get_dummy_dpconfig(dp, 'state'))
 
-    @defer.inlineCallbacks
+    @coroutine
     def collect(self, config):
 
         log.debug('{0}:Start Collection of Services'.format(config.id))

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
@@ -43,6 +43,8 @@ from Products.ZenRRD.CommandParser import ParsedResults
 from ZenPacks.zenoss.PythonCollector.datasources.PythonDataSource \
     import PythonDataSource, PythonDataSourcePlugin
 
+from ..txcoroutine import coroutine
+
 from ..txwinrm_utils import ConnectionInfoProperties, createConnectionInfo
 from ZenPacks.zenoss.Microsoft.Windows.utils import filter_sql_stdout, \
     parseDBUserNamePass, getSQLAssembly
@@ -828,7 +830,7 @@ class ShellDataSourcePlugin(PythonDataSourcePlugin):
                                       dsconf.params['version'])
         return sqlConnection, conn_info
 
-    @defer.inlineCallbacks
+    @coroutine
     def collect(self, config):
         dsconf0 = config.datasources[0]
         conn_info = createConnectionInfo(dsconf0)

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/WinRMPingDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/WinRMPingDataSource.py
@@ -29,6 +29,8 @@ from twisted.internet import defer
 from ..txwinrm_utils import ConnectionInfoProperties, createConnectionInfo
 from ..utils import errorMsgCheck, generateClearAuthEvents
 
+from ..txcoroutine import coroutine
+
 # Requires that txwinrm_utils is already imported.
 from txwinrm.collect import create_enum_info
 from txwinrm.WinRMClient import EnumerateClient
@@ -118,7 +120,7 @@ class WinRMPingDataSourcePlugin(PythonDataSourcePlugin):
 
         return params
 
-    @defer.inlineCallbacks
+    @coroutine
     def collect(self, config):
 
         ds0 = config.datasources[0]

--- a/ZenPacks/zenoss/Microsoft/Windows/txcoroutine.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/txcoroutine.py
@@ -1,0 +1,229 @@
+################################################################################
+# Copyright (c) 2012, Erik Allik
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+################################################################################
+
+from __future__ import print_function
+
+import types
+import warnings
+from sys import exc_info
+
+from twisted.internet.defer import Deferred, _DefGen_Return, CancelledError
+from twisted.python import failure
+from twisted.python.util import mergeFunctionMetadata
+
+
+def _inlineCallbacks(result, g, deferred):
+    """
+    See L{inlineCallbacks}.
+    """
+    # This function is complicated by the need to prevent unbounded recursion
+    # arising from repeatedly yielding immediately ready deferreds.  This while
+    # loop and the waiting variable solve that by manually unfolding the
+    # recursion.
+
+    waiting = [True,  # waiting for result?
+               None]  # result
+
+    while 1:
+        try:
+            # Send the last result back as the result of the yield expression.
+            isFailure = isinstance(result, failure.Failure)
+            if isFailure:
+                if deferred.cancelling:  # must be that CancelledError that we want to ignore
+                    return
+                result = result.throwExceptionIntoGenerator(g)
+            else:
+                result = g.send(result)
+        except _NoReturn as e:
+            if isinstance(e._gen, Deferred):
+                e._gen.chainDeferred(deferred)
+                break
+            elif isinstance(e._gen, types.GeneratorType):
+                g = e._gen
+                result = None
+                continue
+            else:
+                retval = e._gen
+                deferred.callback(retval)
+                return deferred
+        except StopIteration:
+            # fell off the end, or "return" statement
+            deferred.callback(None)
+            return deferred
+        except _DefGen_Return, e:
+            # returnValue() was called; time to give a result to the original
+            # Deferred.  First though, let's try to identify the potentially
+            # confusing situation which results when returnValue() is
+            # accidentally invoked from a different function, one that wasn't
+            # decorated with @inlineCallbacks.
+
+            # The traceback starts in this frame (the one for
+            # _inlineCallbacks); the next one down should be the application
+            # code.
+            appCodeTrace = exc_info()[2].tb_next
+            if isFailure:
+                # If we invoked this generator frame by throwing an exception
+                # into it, then throwExceptionIntoGenerator will consume an
+                # additional stack frame itself, so we need to skip that too.
+                appCodeTrace = appCodeTrace.tb_next
+            # Now that we've identified the frame being exited by the
+            # exception, let's figure out if returnValue was called from it
+            # directly.  returnValue itself consumes a stack frame, so the
+            # application code will have a tb_next, but it will *not* have a
+            # second tb_next.
+            if appCodeTrace.tb_next.tb_next and appCodeTrace.tb_next.tb_next.tb_next:
+                # If returnValue was invoked non-local to the frame which it is
+                # exiting, identify the frame that ultimately invoked
+                # returnValue so that we can warn the user, as this behavior is
+                # confusing.
+                ultimateTrace = appCodeTrace
+                while ultimateTrace.tb_next.tb_next:
+                    ultimateTrace = ultimateTrace.tb_next
+                filename = ultimateTrace.tb_frame.f_code.co_filename
+                lineno = ultimateTrace.tb_lineno
+                warnings.warn_explicit(
+                    "returnValue() in %r causing %r to exit: "
+                    "returnValue should only be invoked by functions decorated "
+                    "with inlineCallbacks" % (
+                        ultimateTrace.tb_frame.f_code.co_name,
+                        appCodeTrace.tb_frame.f_code.co_name),
+                    DeprecationWarning, filename, lineno)
+            deferred.callback(e.value)
+            return deferred
+        except:
+            deferred.errback()
+            return deferred
+
+        if isinstance(result, Deferred):
+            deferred.depends_on = result
+
+            # a deferred was yielded, get the result.
+            def gotResult(r):
+                if waiting[0]:
+                    waiting[0] = False
+                    waiting[1] = r
+                else:
+                    _inlineCallbacks(r, g, deferred)
+
+            result.addBoth(gotResult)
+            if waiting[0]:
+                # Haven't called back yet, set flag so that we get reinvoked
+                # and return from the loop
+                waiting[0] = False
+                return deferred
+
+            result = waiting[1]
+            # Reset waiting to initial values for next loop.  gotResult uses
+            # waiting, but this isn't a problem because gotResult is only
+            # executed once, and if it hasn't been executed yet, the return
+            # branch above would have been taken.
+
+            waiting[0] = True
+            waiting[1] = None
+
+    return deferred
+
+
+def coroutine(f):  # originally inlineCallbacks
+    """Enhanced version of twisted.internet.defer.inlineCallbacks with fuller support coroutine functionality.
+
+    Please see the documentation for twisted.internet.defer.inlineCallbacks for more information.
+
+    See also: txcoroutine.noreturn for information on how to use optimized tail recursion with this decorator.
+
+    """
+    def unwindGenerator(*args, **kwargs):
+        try:
+            gen = f(*args, **kwargs)
+        except (_DefGen_Return, _NoReturn) as e:
+            badUsage = 'returnValue' if isinstance(e, _DefGen_Return) else 'noreturn'
+            raise TypeError(
+                "inlineCallbacks requires %r to produce a generator; instead "
+                "caught %s being used in a non-generator" % (f, badUsage,))
+        if not isinstance(gen, types.GeneratorType):
+            raise TypeError(
+                "inlineCallbacks requires %r to produce a generator; "
+                "instead got %r" % (f, gen))
+
+        return _inlineCallbacks(None, gen, Coroutine(canceller=lambda _: gen.close()))
+
+    return mergeFunctionMetadata(f, unwindGenerator)
+
+
+_swallow_cancelled_error = lambda f: f.trap(CancelledError)
+
+
+class Coroutine(Deferred):
+    # this is something like chaining, but firing of the other deferred does not cause this deferred to fire.
+    # also, we manually unchain and rechain as the coroutine yields new Deferreds.
+    cancelling = False
+    depends_on = None
+
+    def pause(self):
+        if self.depends_on:
+            self.depends_on.pause()
+        return Deferred.pause(self)
+
+    def unpause(self):
+        if self.depends_on:
+            self.depends_on.unpause()
+        return Deferred.unpause(self)
+
+    def cancel(self):
+        # to signal _inlineCallbacks to not fire self.errback with CancelledError;
+        # otherwise we'd have to call `Deferred.cancel(self)` immediately, but it
+        # would be semantically unnice if, by the time the coroutine is told to do
+        # its clean-up routine, the inner Deferred hadn't yet actually been cancelled.
+        self.cancelling = True
+
+        # the _swallow_cancelled_error errback is added as the last one, so anybody else who is already listening for
+        # CancelledError will still get it.
+
+        if self.depends_on:
+            self.depends_on.addErrback(_swallow_cancelled_error)
+            self.depends_on.cancel()
+            del self.depends_on
+
+        self.addErrback(_swallow_cancelled_error)
+        Deferred.cancel(self)
+
+
+class _NoReturn(BaseException):
+    """Uused internally in the cooperation between noreturn and the customized inlineCallbacks in util._defer."""
+    def __init__(self, gen):
+        self._gen = gen
+
+
+def noreturn(gen):
+    """Marks a function call that does not return to the current caller.
+
+    Can only be used within generators wrapped with `@inlineCallbacks`. Supports calling of regular functions, and
+    functions that either return a generator or a Deferred.
+
+    When used with a function `foo` that returns a `Deferred`, it is functionally equivalent to but more memory
+    efficient than `returnValue((yield foo()))`.
+
+    """
+    raise _NoReturn(gen)

--- a/docs/body.md
+++ b/docs/body.md
@@ -1814,6 +1814,7 @@ Changes
 -   Fix "Error in zenoss.winrm.WinMSSQL: too many values to unpack" (ZPS-2206)
 -   Fix Not all bound monitoring templates listed on device overview page (ZPS-2187)
 -   Fix cannot concatenate 'str' and 'NoneType' objects" during Lync modeling (ZPS-2203)
+-   Fix collection hanging caused by network timeouts by applying fix for twisted bug. (ZPS-1765)
 
 2.8.0
 


### PR DESCRIPTION
Fixes ZPS-1765

This will add in a replacement for defer.inlineCallbacks so that
deferreds that need to be cancelled will be cancelled in the callback
tree.  code is BSD from https://github.com/eallik/txcoroutine

Found in twisted bug conversation https://twistedmatrix.com/trac/ticket/4632

Also, add the decorators to EventLogDataSource, PortCheckDataSource, ProcessDataSource,
which were not using inlineCallback.

update txcoroutine pieces in GNUmakefile

update readme