### PR TITLE
make sure error is string, not list

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1327,6 +1327,7 @@ Installing this ZenPack will add the following items to your Zenoss system.
 * Fix Not all bound monitoring templates listed on device overview page (ZPS-2187)
 * Fix cannot concatenate 'str' and 'NoneType' objects" during Lync modeling (ZPS-2203)
 * Fix collection hanging caused by network timeouts by applying fix for twisted bug. (ZPS-1765)
+* Fix 'list' object has no attribute 'lower' (ZPS-2242)
 
 ;2.8.0
 * Added SQL Server instance performance counters

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
@@ -646,14 +646,18 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
 
         retry, level, msg = (False, None, None)  # NOT USED.
 
-        if not errorMsgCheck(self.config, PERSISTER.get_events(self.config.id), e.message):
+        if isinstance(e.message, list):
+            errorMsg = ' '.join([str(i) for i in e.message])
+        else:
+            errorMsg = e.message
+        if not errorMsgCheck(self.config, PERSISTER.get_events(self.config.id), errorMsg):
             generateClearAuthEvents(self.config, PERSISTER.get_events(self.config.id))
         # Handle errors on which we should retry the receive.
         if 'OperationTimeout' in e.message:
             retry, level, msg = (
                 True,
                 logging.DEBUG,
-                "OperationTimeout on {}"
+                "OperationTimeout on {}.  This timeout is expected when zWinPerfmonInterval is >= 60s."
                 .format(self.config.id))
 
         elif isinstance(e, ConnectError):

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testAuthErrEvents.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testAuthErrEvents.py
@@ -59,6 +59,13 @@ class TestErrorEvents(BaseTestCase):
             self.assertTrue('eventClass' in events[k])
             self.assertRegexpMatches(events[k]['eventKey'], 'Kerberos|Authentication\|windows_test')
 
+        events = []
+        error = ['Connection Lost']
+        try:
+            errorMsgCheck(self.config, events, error)
+        except Exception:
+            self.fail('errorMsgCheck should handle a list as input for error')
+
 
 def test_suite():
     """Return test suite for this module."""

--- a/ZenPacks/zenoss/Microsoft/Windows/utils.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/utils.py
@@ -512,6 +512,8 @@ def append_event_datasource_plugin(datasources, events, event):
 
 def errorMsgCheck(config, events, error):
     """Check error message and generate an appropriate event."""
+    if isinstance(error, list):
+        error = ' '.join([str(i) for i in error])
     kerberos_messages = ['kerberos', 'kinit']
     wrongCredsMessages = ['Check username and password', 'Username invalid', 'Password expired']
 

--- a/docs/body.md
+++ b/docs/body.md
@@ -1819,6 +1819,7 @@ Changes
 -   Fix Not all bound monitoring templates listed on device overview page (ZPS-2187)
 -   Fix cannot concatenate 'str' and 'NoneType' objects" during Lync modeling (ZPS-2203)
 -   Fix collection hanging caused by network timeouts by applying fix for twisted bug. (ZPS-1765)
+-   Fix 'list' object has no attribute 'lower' (ZPS-2242)
 
 2.8.0
 


### PR DESCRIPTION
Fixes ZPS-2242

Certain twisted errors return a list of exceptions in a list as the message.
This will stringify them so we can check for kerberos or other specific errors.
Also added comment to OperationTimeout debug message to show that it's expected.