### PR TITLE
remove duplicate label

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
+++ b/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
@@ -117,7 +117,6 @@ classes:
         default: None
         label: IP and Host Name
       domain_controller:
-        label: MS Exchange Version
         type: boolean
         default: false
       is_iis:


### PR DESCRIPTION
Fixes ZPS-2193

domain_controller doesn't need a label. probably from zpl conversion