### PR TITLE
Remove unnecessary event/log message

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1328,6 +1328,7 @@ Installing this ZenPack will add the following items to your Zenoss system.
 * Fix cannot concatenate 'str' and 'NoneType' objects" during Lync modeling (ZPS-2203)
 * Fix collection hanging caused by network timeouts by applying fix for twisted bug. (ZPS-1765)
 * Fix 'list' object has no attribute 'lower' (ZPS-2242)
+* Fix Using the exit code for Windows Shell Datasource to generate events can result in a second error. (ZPS-2252)
 
 ;2.8.0
 * Added SQL Server instance performance counters

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
@@ -896,11 +896,6 @@ class ShellDataSourcePlugin(PythonDataSourcePlugin):
                 dsconf = dsconfs[0]
                 for dp, value in cmdResult.values:
                     data['values'][dsconf.component][dp.id] = value, 'N'
-            else:
-                msg = 'No output from script for {0} on {1}'.format(
-                    dsconf0.datasource, config)
-                log.warn(msg)
-                severity = ZenEventClasses.Warning
         elif strategy.key == 'DCDiag':
             diagResult = strategy.parse_result(config, result)
             dsconf = dsconfs[0]

--- a/docs/body.md
+++ b/docs/body.md
@@ -1820,6 +1820,7 @@ Changes
 -   Fix cannot concatenate 'str' and 'NoneType' objects" during Lync modeling (ZPS-2203)
 -   Fix collection hanging caused by network timeouts by applying fix for twisted bug. (ZPS-1765)
 -   Fix 'list' object has no attribute 'lower' (ZPS-2242)
+-   Fix Using the exit code for Windows Shell Datasource to generate events can result in a second error. (ZPS-2252)
 
 2.8.0
 


### PR DESCRIPTION
Fixes ZPS-2252

There's no need for the no output message.  Any issues with a custom
datasource will be reported anyway.  Some custom commands may not return
datapoints and are working as expected.