### PR TITLE
Add kerberos error event threshold for false negative events

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -853,6 +853,9 @@ The [[#Adding a Windows Device]] steps shown above are for the simplest case of 
 ;zWinRMClusterNodeClass
 : Path under which to create cluster nodes.  If you need to add cluster nodes to a specific class under the /Server/Microsoft/Windows device class, specify it with this property.  The default is /Server/Microsoft/Windows
 
+;zWinRMKRBErrorThreshold
+:  Having a poor network connection can cause erroneous kerberos error events to be sent which could cause confusion or false alarms.  The default value is 1, which will always send an event on the first occurrence of an error.  You can increase this value to send an event only when there have been x amount of occurrences of an error during collection, where x denotes the threshold number.
+
 {{note}} HyperV and MicrosoftWindows ZenPacks share krb5.conf file as well as tools for sending/receiving data. Therefore if either HyperV or Windows device has a correct zWinKDC setting, it will be used for another device as well.
 
 <br clear=all>
@@ -1329,6 +1332,7 @@ Installing this ZenPack will add the following items to your Zenoss system.
 * Fix collection hanging caused by network timeouts by applying fix for twisted bug. (ZPS-1765)
 * Fix 'list' object has no attribute 'lower' (ZPS-2242)
 * Fix Using the exit code for Windows Shell Datasource to generate events can result in a second error. (ZPS-2252)
+* Add an error event threshold added so that we can eliminate error noise on systems with poor connections (ZPS-2068)
 
 ;2.8.0
 * Added SQL Server instance performance counters

--- a/ZenPacks/zenoss/Microsoft/Windows/__init__.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/__init__.py
@@ -140,7 +140,10 @@ class ZenPack(schema.ZenPack):
                                                  'label': 'Server Fully Qualified Domain Name'},
                             'zWinRMKrb5DisableRDNS': {'type': 'boolean',
                                                       'description': 'Set to true to disable reverse DNS lookups by kerberos.  Only set at /Server/Microsoft level!',
-                                                      'label': 'Disable kerberos reverse DNS'}
+                                                      'label': 'Disable kerberos reverse DNS'},
+                            'zWinRMKRBErrorThreshold': {'type': 'int',
+                                                        'description': 'When network connections are poor, send fewer error events.',
+                                                        'label': 'Connection error event threshold'}
                             }
 
     def install(self, app):

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ClusterDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ClusterDataSource.py
@@ -291,8 +291,7 @@ class ClusterDataSourcePlugin(PythonDataSourcePlugin):
 
         logg(msg)
         data = self.new_data()
-        errorMsgCheck(config, data['events'], result.value.message)
-        if not data['events']:
+        if not errorMsgCheck(config, data['events'], result.value.message):
             data['events'].append(dict(
                 eventClass=event_class,
                 severity=ZenEventClasses.Warning,

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/EventLogDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/EventLogDataSource.py
@@ -181,6 +181,7 @@ def string_to_lines(string):
     log.warn('Could not convert string to lines: %s' % str(string))
     return []
 
+
 def prettify_xml(xml):
     '''preserve XML formatting'''
     iostream = StringIO()
@@ -385,8 +386,7 @@ class EventLogPlugin(PythonDataSourcePlugin):
             logg = log.debug
         logg("{}: {}".format(config.id, msg))
         data = self.new_data()
-        errorMsgCheck(config, data['events'], result.value.message)
-        if not data['events']:
+        if not errorMsgCheck(config, data['events'], result.value.message):
             for ds in config.datasources:
                 data['events'].append({
                     'severity': severity,

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/IISSiteDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/IISSiteDataSource.py
@@ -295,9 +295,8 @@ class IISSiteDataSourcePlugin(PythonDataSourcePlugin):
             logg = log.debug
         logg("IISSiteDataSource error on %s: %s", config.id, msg)
         data = self.new_data()
-        errorMsgCheck(config, data['events'], result.value.message)
-        # only need the one event
-        if not data['events']:
+        if not errorMsgCheck(config, data['events'], result.value.message):
+            # only need the one event
             data['events'].append({
                 'eventClass': event_class,
                 'severity': ZenEventClasses.Warning,

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ProcessDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ProcessDataSource.py
@@ -481,8 +481,7 @@ class ProcessDataSourcePlugin(PythonDataSourcePlugin):
         logg(msg)
 
         data = self.new_data()
-        errorMsgCheck(config, data['events'], error.value.message)
-        if not data['events']:
+        if not errorMsgCheck(config, data['events'], error.value.message):
             data['events'].append({
                 'device': config.id,
                 'severity': Event.Error,

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ServiceDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ServiceDataSource.py
@@ -397,8 +397,7 @@ class ServicePlugin(PythonDataSourcePlugin):
             logg = log.debug
         logg(msg)
         data = self.new_data()
-        errorMsgCheck(config, data['events'], result.message)
-        if not data['events']:
+        if not errorMsgCheck(config, data['events'], result.message):
             data['events'].append({
                 'eventClass': "/Status/WinService",
                 'severity': ZenEventClasses.Error,

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
@@ -689,7 +689,7 @@ class ShellDataSourcePlugin(PythonDataSourcePlugin):
 
     proxy_attributes = ConnectionInfoProperties + (
         'sqlhostname',
-        'cluster_node_server',
+        'cluster_node_server'
     )
 
     @classmethod
@@ -1079,8 +1079,7 @@ class ShellDataSourcePlugin(PythonDataSourcePlugin):
 
         logg(msg)
         data = self.new_data()
-        errorMsgCheck(config, data['events'], result.value.message)
-        if not data['events']:
+        if not errorMsgCheck(config, data['events'], result.value.message):
             data['events'].append(dict(
                 eventClass=event_class,
                 severity=ZenEventClasses.Warning,

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/WinRMPingDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/WinRMPingDataSource.py
@@ -161,9 +161,7 @@ class WinRMPingDataSourcePlugin(PythonDataSourcePlugin):
             logg = log.debug
         logg('WinRMPing collection: {} on {}'.format(results.value.message, config.id))
 
-        errorMsgCheck(config, data['events'], results.value.message)
-
-        if not data['events']:
+        if not errorMsgCheck(config, data['events'], results.value.message):
             data['events'].append({
                 'eventClass': '/Status/Winrm/Ping',
                 'severity': ZenEventClasses.Critical,

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testAuthErrEvents.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testAuthErrEvents.py
@@ -16,7 +16,7 @@ from Products.ZenTestCase.BaseTestCase import BaseTestCase
 from ZenPacks.zenoss.Microsoft.Windows.utils import errorMsgCheck, generateClearAuthEvents
 
 
-class DataSource(namedtuple('DataSource', ['plugin_classname', 'datasource'])):
+class DataSource(namedtuple('DataSource', ['plugin_classname', 'datasource', 'zWinRMKRBErrorThreshold'])):
     pass
 
 
@@ -27,7 +27,7 @@ class Config(namedtuple('Config', ['manageIp', 'id', 'datasources'])):
 class TestErrorEvents(BaseTestCase):
     def setUp(self):
         datasources = DataSource('ZenPacks.zenoss.Microsoft.Windows.datasources.TestDataSource',
-                                 'test_error_event')
+                                 'test_error_event', 1)
         self.config = Config('10.10.10.10', 'windows_test', [datasources])
 
     def testErrorMsgCheck(self):
@@ -41,6 +41,7 @@ class TestErrorEvents(BaseTestCase):
         error = 'kinit error server not in database'
         errorMsgCheck(self.config, events, error)
         self.assertEquals(len(events), 4)
+
         generateClearAuthEvents(self.config, events)
 
         self.assertEquals(len(events), 6)
@@ -65,6 +66,19 @@ class TestErrorEvents(BaseTestCase):
             errorMsgCheck(self.config, events, error)
         except Exception:
             self.fail('errorMsgCheck should handle a list as input for error')
+
+    def testErrorThreshold(self):
+        datasources = DataSource('ZenPacks.zenoss.Microsoft.Windows.datasources.TestDataSource',
+                                 'test_error_event', 2)
+        config = Config('10.10.10.10', 'windows_test', [datasources])
+        events = []
+        error = 'kinit error getting initial credentials'
+        rtn = errorMsgCheck(config, events, error)
+        self.assertTrue(rtn)
+        self.assertEquals(len(events), 0)
+
+        errorMsgCheck(config, events, error)
+        self.assertEquals(len(events), 1)
 
 
 def test_suite():

--- a/ZenPacks/zenoss/Microsoft/Windows/txwinrm_utils.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/txwinrm_utils.py
@@ -38,6 +38,7 @@ ConnectionInfoProperties = (
     'zWinRMEncoding',
     'zWinRSCodePage',
     'zWinRMKrb5includedir',
+    'zWinRMKRBErrorThreshold',
     'kerberos_rdns'
 )
 

--- a/ZenPacks/zenoss/Microsoft/Windows/utils.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/utils.py
@@ -510,6 +510,10 @@ def append_event_datasource_plugin(datasources, events, event):
         events.append(event)
 
 
+# used to keep track of the number of kerberos error events per device
+krb_error_events = {}
+
+
 def errorMsgCheck(config, events, error):
     """Check error message and generate an appropriate event."""
     if isinstance(error, list):
@@ -519,14 +523,24 @@ def errorMsgCheck(config, events, error):
 
     # see if this a kerberos issue
     if any(x in error.lower() for x in kerberos_messages):
-        append_event_datasource_plugin(config.datasources, events, {
-            'eventClass': '/Status/Kerberos',
-            'eventClassKey': 'KerberosFailure',
-            'eventKey': '|'.join(('Kerberos', config.id)),
-            'summary': error,
-            'ipAddress': config.manageIp,
-            'severity': 4,
-            'device': config.id})
+        try:
+            threshold = getattr(config.datasources[0], 'zWinRMKRBErrorThreshold', 0)
+        except Exception:
+            threshold = -1
+        global krb_error_events
+        if config.id not in krb_error_events:
+            krb_error_events[config.id] = 0
+        krb_error_events[config.id] += 1
+        if krb_error_events[config.id] >= threshold:
+            append_event_datasource_plugin(config.datasources, events, {
+                'eventClass': '/Status/Kerberos',
+                'eventClassKey': 'KerberosFailure',
+                'eventKey': '|'.join(('Kerberos', config.id)),
+                'summary': error,
+                'ipAddress': config.manageIp,
+                'severity': 4,
+                'device': config.id})
+            krb_error_events[config.id] = 0
         return True
     # otherwise check if this is a typical authentication failure
     elif any(x in error for x in wrongCredsMessages):
@@ -544,6 +558,8 @@ def errorMsgCheck(config, events, error):
 
 def generateClearAuthEvents(config, events):
     """Generate clear authentication events."""
+    # reset event counter
+    krb_error_events[config.id] = 0
     append_event_datasource_plugin(config.datasources, events, {
         'eventClass': '/Status/Winrm/Auth',
         'eventClassKey': 'AuthenticationSuccess',

--- a/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
+++ b/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
@@ -46,6 +46,9 @@ zProperties:
   zWinRMKrb5DisableRDNS:
     type: boolean
     default: false
+  zWinRMKRBErrorThreshold:
+    type: int
+    default: 1
 
 class_relationships:
   - ZenPacks.zenoss.Microsoft.Windows.OperatingSystem.OperatingSystem(winservices) 1:MC (os)WinService

--- a/docs/body.md
+++ b/docs/body.md
@@ -1101,6 +1101,9 @@ important.
 -   zWinRMClusterNodeClass
     :   Path under which to create cluster nodes.  If you need to add cluster nodes to a specific class under the /Server/Microsoft/Windows device class, specify it with this property.  The default is /Server/Microsoft/Windows
 
+-   zWinRMKRBErrorThreshold
+    :  Having a poor network connection can cause erroneous kerberos error events to be sent which could cause confusion or false alarms.  The default value is 1, which will always send an event on the first occurrence of an error.  You can increase this value to send an event only when there have been x amount of occurrences of an error during collection, where x denotes the threshold number.
+
 
 Note: HyperV and MicrosoftWindows ZenPacks share krb5.conf file as
 well as tools for sending/receiving data. Therefore if either HyperV or
@@ -1821,6 +1824,7 @@ Changes
 -   Fix collection hanging caused by network timeouts by applying fix for twisted bug. (ZPS-1765)
 -   Fix 'list' object has no attribute 'lower' (ZPS-2242)
 -   Fix Using the exit code for Windows Shell Datasource to generate events can result in a second error. (ZPS-2252)
+-   Add an error event threshold added so that we can eliminate error noise on systems with poor connections (ZPS-2068)
 
 2.8.0
 


### PR DESCRIPTION
Fixes ZPS-2068

since kerberos events are reported from a central location in utils.py,
we can keep track of how many times a false event is going to be sent.
if the number of events exceeds this threshold, we'll send an event.
if a connection succeeds while checking the count, then we can reset
the counter.