### PR TITLE
surround counters with single quotes so they do not expand

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1333,6 +1333,7 @@ Installing this ZenPack will add the following items to your Zenoss system.
 * Fix 'list' object has no attribute 'lower' (ZPS-2242)
 * Fix Using the exit code for Windows Shell Datasource to generate events can result in a second error. (ZPS-2252)
 * Add an error event threshold added so that we can eliminate error noise on systems with poor connections (ZPS-2068)
+* Fix Windows - No perf data, see "The process cannot access the file because it is being used by another process." in debug log (ZPS-2298)
 
 ;2.8.0
 * Added SQL Server instance performance counters

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
@@ -871,8 +871,14 @@ def format_counters(ps_counters):
     """Convert a list of supplied counters into a string, which will
     be further used to cteate ps command line.
     """
-    return ','.join(
-        '(\\"{0}\\")'.format(counter) for counter in ps_counters)
+    counters = []
+    for counter in ps_counters:
+        # this will be the best we can do for some foreign language counters
+        if "'" in counter or u'\u2019' in counter:
+            counters.append('(\\"{0}\\")'.format(counter))
+        else:
+            counters.append("('{0}')".format(counter))
+    return ','.join(counters)
 
 
 def chunkify(lst, n):

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testPerfmonDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testPerfmonDataSource.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
+# coding=utf-8
+
 ##############################################################################
 #
-# Copyright (C) Zenoss, Inc. 2015, all rights reserved.
+# Copyright (C) Zenoss, Inc. 2015-2017, all rights reserved.
 #
 # This content is made available according to terms specified in
 # License.zenoss under the directory where your Zenoss product is installed.
@@ -83,7 +85,8 @@ class TestDataPersister(BaseTestCase):
 
 class TestFormat_counters(BaseTestCase):
     def test_format_counters(self):
-        self.assertEquals(format_counters(['a', 'b']), '(\\"a\\"),(\\"b\\")')
+        self.assertEquals(format_counters(['a', 'b']), "('a'),('b')")
+        self.assertEquals(format_counters(["\Système\Temps d’activité système"]), '(\\"\Système\Temps d’activité système\\")')
 
 
 class TestFormat_stdout(BaseTestCase):

--- a/docs/body.md
+++ b/docs/body.md
@@ -1825,6 +1825,7 @@ Changes
 -   Fix 'list' object has no attribute 'lower' (ZPS-2242)
 -   Fix Using the exit code for Windows Shell Datasource to generate events can result in a second error. (ZPS-2252)
 -   Add an error event threshold added so that we can eliminate error noise on systems with poor connections (ZPS-2068)
+-   Fix Windows - No perf data, see "The process cannot access the file because it is being used by another process." in debug log (ZPS-2298)
 
 2.8.0
 


### PR DESCRIPTION
Fixes ZPS-2298

Powershell expands text inside of double quotes, so for some Exchange Server
counters, '==>' was being evaluated as an expression which threw a strange error
stating a file was in use by another process.  Changing to use single quotes
so literal strings can be passed.  this could cause issue with some foreign
language counters because they may contain the unicode apostrophe u'\u2019' which
would act as a closing single quote, so we will surround them with double quotes.

update unit test for perfmon