### PR TITLE
found better way to allow for unicode apostrophe u'\u2019'

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
@@ -873,11 +873,9 @@ def format_counters(ps_counters):
     """
     counters = []
     for counter in ps_counters:
-        # this will be the best we can do for some foreign language counters
-        if "'" in counter or u'\u2019' in counter:
-            counters.append('(\\"{0}\\")'.format(counter))
-        else:
-            counters.append("('{0}')".format(counter))
+        # check for unicode apostrophe present in foreign langs
+        counter = counter.replace(u'\u2019', "'+[char]8217+'")
+        counters.append("('{0}')".format(counter))
     return ','.join(counters)
 
 

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testPerfmonDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testPerfmonDataSource.py
@@ -86,7 +86,7 @@ class TestDataPersister(BaseTestCase):
 class TestFormat_counters(BaseTestCase):
     def test_format_counters(self):
         self.assertEquals(format_counters(['a', 'b']), "('a'),('b')")
-        self.assertEquals(format_counters(["\Système\Temps d’activité système"]), '(\\"\Système\Temps d’activité système\\")')
+        self.assertEquals(format_counters(["\Système\Temps d’activité système"]), "('\Système\Temps d'+[char]8217+'activité système')")
 
 
 class TestFormat_stdout(BaseTestCase):


### PR DESCRIPTION
Fixes ZPS-2298

This will allow us to always use single quotes around all counters so they
are sent in as literals and will not be expanded because of double quotes.