### PR TITLE
Move output to innermost loop to get all disk info

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1334,6 +1334,7 @@ Installing this ZenPack will add the following items to your Zenoss system.
 * Fix Using the exit code for Windows Shell Datasource to generate events can result in a second error. (ZPS-2252)
 * Add an error event threshold added so that we can eliminate error noise on systems with poor connections (ZPS-2068)
 * Fix Windows - No perf data, see "The process cannot access the file because it is being used by another process." in debug log (ZPS-2298)
+* Fix Microsoft Windows fails to model 2008 Server Cluster Disks (ZPS-2015)
 
 ;2.8.0
 * Added SQL Server instance performance counters

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ClusterDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ClusterDataSource.py
@@ -167,13 +167,11 @@ class ClusterDataSourcePlugin(PythonDataSourcePlugin):
 
         psClusterCommands.append(
             "$resources = Get-WmiObject -class MSCluster_Resource -namespace root\MSCluster -filter \\\"Type='Physical Disk'\\\";"
-            "$resources | foreach {{"
-            "$rsc = $_;"
+            "foreach ($rsc in $resources) {{"
             "$disks = $rsc.GetRelated(\\\"MSCluster_Disk\\\");"
-            "$disks | foreach {{"
-            "$dsk = $_;"
+            "foreach ($dsk in $disks) {{"
             "$partitions = $dsk.GetRelated(\\\"MSCluster_DiskPartition\\\");"
-            "$partitions | foreach {{"
+            "foreach ($prt in $partitions) {{"
             "$prt = $_;"
             "$physicaldisk = New-Object -TypeName PSObject -Property @{{"
             "Id = $rsc.Id;"
@@ -186,7 +184,7 @@ class ClusterDataSourcePlugin(PythonDataSourcePlugin):
             "Size = $prt.Size * 1mb;"
             "FreeSpace = $prt.FreeSpace * 1mb;"
             "State = $rsc.State;"
-            "}}; }} }} }}; $physicaldisk | foreach {{{}}}"
+            "}}; $physicaldisk | foreach {{{}}} }} }} }};"
             "".format(cluster_id_items)
         )
 

--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinCluster.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinCluster.py
@@ -27,6 +27,7 @@ from txwinrm.WinRMClient import SingleCommandClient
 addLocalLibPath()
 log = logging.getLogger("zen.MicrosoftCluster")
 
+
 class ClusterCommander(object):
     def __init__(self, conn_info):
         self.winrs = SingleCommandClient(conn_info)
@@ -113,15 +114,12 @@ class WinCluster(WinRMPlugin):
 
         clusterDiskCommand.append(
             "$resources = Get-WmiObject -class MSCluster_Resource -namespace root\MSCluster -filter \\\"Type='Physical Disk'\\\";"
-            "$resources | foreach {"
-            "$rsc = $_;"
+            "foreach ($rsc in $resources) {{"
             "$disks = $rsc.GetRelated(\\\"MSCluster_Disk\\\");"
-            "$disks | foreach {"
-            "$dsk = $_;"
+            "foreach ($dsk in $disks) {{"
             "$partitions = $dsk.GetRelated(\\\"MSCluster_DiskPartition\\\");"
-            "$partitions | foreach {"
-            "$prt = $_;"
-            "$physicaldisk = New-Object -TypeName PSObject -Property @{"
+            "foreach ($prt in $partitions) {{"
+            "$physicaldisk = New-Object -TypeName PSObject -Property @{{"
             "Id = $rsc.Id;"
             "OwnerNode = $rsc.OwnerNode;"
             "OwnerGroup = $rsc.OwnerGroup;"
@@ -132,8 +130,8 @@ class WinCluster(WinRMPlugin):
             "Size = $prt.TotalSize * 1mb;"
             "FreeSpace = $prt.FreeSpace * 1mb;"
             "State = $rsc.State;"
-            "}}}}; $physicaldisk | foreach { %s }" % pipejoin(
-                '$_.Id $_.Name $_.VolumePath $_.OwnerNode $_.DiskNumber $_.PartitionNumber $_.Size $_.FreeSpace $_.State $_.OwnerGroup')
+            "}}; $physicaldisk | foreach {{{}}} }}}}}};".format(pipejoin(
+                '$_.Id $_.Name $_.VolumePath $_.OwnerNode $_.DiskNumber $_.PartitionNumber $_.Size $_.FreeSpace $_.State $_.OwnerGroup'))
         )
 
         clusterdisk = yield cmd.run_command("".join(clusterDiskCommand))

--- a/docs/body.md
+++ b/docs/body.md
@@ -1826,6 +1826,7 @@ Changes
 -   Fix Using the exit code for Windows Shell Datasource to generate events can result in a second error. (ZPS-2252)
 -   Add an error event threshold added so that we can eliminate error noise on systems with poor connections (ZPS-2068)
 -   Fix Windows - No perf data, see "The process cannot access the file because it is being used by another process." in debug log (ZPS-2298)
+-   Fix Microsoft Windows fails to model 2008 Server Cluster Disks (ZPS-2015)
 
 2.8.0
 


### PR DESCRIPTION
Fixes ZPS-2015

the output of each disk object was being overwritten until the very last one.
need to print out each object as we build it