### PR TITLE
send empty disk object maps to nodes to remove duplicates

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1335,6 +1335,7 @@ Installing this ZenPack will add the following items to your Zenoss system.
 * Add an error event threshold added so that we can eliminate error noise on systems with poor connections (ZPS-2068)
 * Fix Windows - No perf data, see "The process cannot access the file because it is being used by another process." in debug log (ZPS-2298)
 * Fix Microsoft Windows fails to model 2008 Server Cluster Disks (ZPS-2015)
+* Fix WinCluster plugin generates duplicate Cluster Disks (ZPS-1932)
 
 ;2.8.0
 * Added SQL Server instance performance counters

--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinCluster.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinCluster.py
@@ -280,6 +280,7 @@ class WinCluster(WinRMPlugin):
                 node_ownergroups[node_om.title] = node_om.id
 
             map_nodes_oms.append(node_om)
+            map_disks_to_node[node_om.id] = []
 
         # This section is for ClusterDisk class
         clusterdisk = results['clusterdisk']

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testWinCluster.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testWinCluster.py
@@ -25,7 +25,7 @@ class TestProcesses(BaseTestCase):
         self.results = StringAttributeObject()
         self.results['domain'] = 'domain0'
         self.results['nodes'] = ['node0', 'node1']
-        self.results['nodes_data'] = ['node0|1|1|2|state0']
+        self.results['nodes_data'] = ['node0|1|1|2|state0', 'node1|1|1|1|state0']
         self.results['clusterdisk'] = [
             '2beb|disk1|Vol{2beb}|node0|1|1|2147199|1937045|Online|service',
             'b10c641b-29df-4aff-ab26-53769e793770|CSV Disk|C:\ClusterStorage\Volume1|node0|2|1|2147199||Online|Cluster Shared Volume',
@@ -49,19 +49,21 @@ class TestProcesses(BaseTestCase):
         self.assertEquals(data[1].maps[0].domain, 'domain0')
         self.assertEquals(data[1].maps[0].ownernode, 'node0')
         self.assertEquals(data[1].maps[0].title, 'title0')
-        self.assertEquals(data[4].maps[0].id, '2beb')
-        self.assertEquals(data[4].maps[0].freespace, '1.85MB')
-        self.assertEquals(data[4].maps[0].size, '2.05MB')
-        self.assertEquals(data[4].maps[0].ownernode, 'node0')
-        self.assertEquals(data[4].maps[0].partitionnumber, '1')
-        self.assertEquals(data[4].maps[0].disknumber, '1')
-        self.assertEquals(data[4].maps[0].domain, 'domain0')
-        self.assertEquals(data[4].maps[0].title, 'disk1')
-        self.assertEquals(data[4].maps[0].volumepath, 'Vol{2beb}')
-        self.assertEquals(data[4].maps[0].assignedto, 'service')
+        self.assertEquals(len(data[4].maps), 0)
+
+        self.assertEquals(data[5].maps[0].id, '2beb')
+        self.assertEquals(data[5].maps[0].freespace, '1.85MB')
+        self.assertEquals(data[5].maps[0].size, '2.05MB')
+        self.assertEquals(data[5].maps[0].ownernode, 'node0')
+        self.assertEquals(data[5].maps[0].partitionnumber, '1')
+        self.assertEquals(data[5].maps[0].disknumber, '1')
+        self.assertEquals(data[5].maps[0].domain, 'domain0')
+        self.assertEquals(data[5].maps[0].title, 'disk1')
+        self.assertEquals(data[5].maps[0].volumepath, 'Vol{2beb}')
+        self.assertEquals(data[5].maps[0].assignedto, 'service')
 
         # Test for missing freespace ZEN-21242
-        self.assertEquals(data[4].maps[1].freespace, 'N/A')
+        self.assertEquals(data[5].maps[1].freespace, 'N/A')
 
 
 def test_suite():

--- a/docs/body.md
+++ b/docs/body.md
@@ -1827,6 +1827,7 @@ Changes
 -   Add an error event threshold added so that we can eliminate error noise on systems with poor connections (ZPS-2068)
 -   Fix Windows - No perf data, see "The process cannot access the file because it is being used by another process." in debug log (ZPS-2298)
 -   Fix Microsoft Windows fails to model 2008 Server Cluster Disks (ZPS-2015)
+-   Fix WinCluster plugin generates duplicate Cluster Disks (ZPS-1932)
 
 2.8.0
 


### PR DESCRIPTION
Fixes ZPS-1932

After a failover occurs, modeling will not remove existing disk components for a node