### PR TITLE
Use get-clusterresource so we can get the id/ownernode on 2008

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1324,6 +1324,9 @@ Installing this ZenPack will add the following items to your Zenoss system.
 
 == Changes ==
 
+;2.8.2
+* Fix Microsoft Windows fails to model 2008 Server Cluster Disks (ZPS-2015)
+
 ;2.8.1
 * Fix "Error in zenoss.winrm.WinMSSQL: too many values to unpack" (ZPS-2206)
 * Fix Not all bound monitoring templates listed on device overview page (ZPS-2187)

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ClusterDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ClusterDataSource.py
@@ -167,8 +167,9 @@ class ClusterDataSourcePlugin(PythonDataSourcePlugin):
 
         psClusterCommands.append(
             "$resources = Get-WmiObject -class MSCluster_Resource -namespace root\MSCluster -filter \\\"Type='Physical Disk'\\\";"
-            "foreach ($rsc in $resources) {{"
-            "$disks = $rsc.GetRelated(\\\"MSCluster_Disk\\\");"
+            "foreach ($resource in $resources) {{"
+            "$rsc = get-clusterresource -name $resource.Name;"
+            "$disks = $resource.GetRelated(\\\"MSCluster_Disk\\\");"
             "foreach ($dsk in $disks) {{"
             "$partitions = $dsk.GetRelated(\\\"MSCluster_DiskPartition\\\");"
             "foreach ($prt in $partitions) {{"

--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinCluster.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinCluster.py
@@ -114,8 +114,9 @@ class WinCluster(WinRMPlugin):
 
         clusterDiskCommand.append(
             "$resources = Get-WmiObject -class MSCluster_Resource -namespace root\MSCluster -filter \\\"Type='Physical Disk'\\\";"
-            "foreach ($rsc in $resources) {{"
-            "$disks = $rsc.GetRelated(\\\"MSCluster_Disk\\\");"
+            "foreach ($resource in $resources) {{"
+            "$rsc = get-clusterresource -name $resource.Name;"
+            "$disks = $resource.GetRelated(\\\"MSCluster_Disk\\\");"
             "foreach ($dsk in $disks) {{"
             "$partitions = $dsk.GetRelated(\\\"MSCluster_DiskPartition\\\");"
             "foreach ($prt in $partitions) {{"

--- a/docs/body.md
+++ b/docs/body.md
@@ -1815,6 +1815,10 @@ Monitoring Templates
 Changes
 -------
 
+2.8.2
+
+-   Fix Microsoft Windows fails to model 2008 Server Cluster Disks (ZPS-2015)
+
 2.8.1
 
 -   Fix "Error in zenoss.winrm.WinMSSQL: too many values to unpack" (ZPS-2206)


### PR DESCRIPTION
Fixes ZPS-2015

the MSCluster_Resource WMI class does not contain the Id and OwnerNode
attributes on 2008.  They're only on 2012, 2016+.  get-clusterresource
will return a class that does contain the required attributes.  we'll
keep our wmi loops however as this seems to be a more accepted method
of finding cluster disks and their sizes.