### PR TITLE
No need to replace $ with `$ in counter

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
@@ -293,9 +293,8 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
         self.ps_counter_map = {}
         for dsconf in self.config.datasources:
             counter = dsconf.params['counter'].decode('utf-8').lower()
-            ps_counter = counter.replace('$', '`$')
             self.counter_map[counter] = (dsconf.component, dsconf.datasource, dsconf.eventClass)
-            self.ps_counter_map[ps_counter] = (dsconf.component, dsconf.datasource)
+            self.ps_counter_map[counter] = (dsconf.component, dsconf.datasource)
 
         self._build_commandlines()
 


### PR DESCRIPTION
Fixes ZPS-2376

When $ is inside single quotes it's taken as a literal instead of powershell
trying to expand it as a variable