### PR TITLE
Pull cluster disk state from wmi class

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1327,6 +1327,7 @@ Installing this ZenPack will add the following items to your Zenoss system.
 ;2.8.2
 * Fix Microsoft Windows fails to model 2008 Server Cluster Disks (ZPS-2015)
 * Fix Windows - traceback when no data returned for wmi class win32_computersystem (ZPS-2384)
+* Fix Cluster Disk state always 'Inherited' (ZPS-2416)
 
 ;2.8.1
 * Fix "Error in zenoss.winrm.WinMSSQL: too many values to unpack" (ZPS-2206)

--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinCluster.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinCluster.py
@@ -76,7 +76,7 @@ class WinCluster(WinRMPlugin):
         )
         resourceCommand.append('write-host "====";')
         resourceCommand.append(
-            'get-clusterresource | foreach {%s};' % pipejoin(
+            "get-clusterresource | where { $_.ResourceType.name -ne 'Physical Disk'} | foreach {%s};" % pipejoin(
                 '$_.Name $_.OwnerGroup $_.OwnerNode $_.State $_.Description'
             )
         )

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testClusterDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testClusterDataSource.py
@@ -50,6 +50,7 @@ def is_empty(struct):
     else:
         return True
 
+
 class TestClusterDataSourcePlugin(BaseTestCase):
 
     def setUp(self):

--- a/docs/body.md
+++ b/docs/body.md
@@ -1819,6 +1819,7 @@ Changes
 
 -   Fix Microsoft Windows fails to model 2008 Server Cluster Disks (ZPS-2015)
 -   Fix Windows - traceback when no data returned for wmi class win32_computersystem (ZPS-2384)
+-   Fix Cluster Disk state always 'Inherited' (ZPS-2416)
 
 2.8.1
 


### PR DESCRIPTION
Fixes ZPS-2416

Need to be sure to pull the state from the wmi class because we're using
it to determine state, not get-clusterresource.  Also, it's redundant to
model disks in the resources.