### PR TITLE
Restore usedFilesytemSpace__bytes alias

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/device_classes.yaml
+++ b/ZenPacks/zenoss/Microsoft/Windows/device_classes.yaml
@@ -1938,7 +1938,8 @@ device_classes:
             datapoints:
               FreeMegabytes:
                 rrdtype: GAUGE
-                aliases: {usedfilesystemspace__bytes: '1024,*,1024,*,${here/totalBytes},EXC,-'}
+                aliases: {usedFilesystemSpace__bytes: '1024,*,1024,*,${here/totalBytes},EXC,-',
+                          usedfilesystemspace__bytes: '1024,*,1024,*,${here/totalBytes},EXC,-'}
             counter: \Free Megabytes
         graphs:
           Utilization:
@@ -2008,7 +2009,7 @@ device_classes:
             datapoints:
               MemoryAvailableBytes:
                 rrdtype: GAUGE
-                aliases: {memoryavailable__bytes: null}
+                aliases: {memoryAvailable__bytes: null, memoryavailable__bytes: null}
             counter: \Memory\Available bytes
           ProcessorTotalProcessorTime:
             type: Windows Perfmon
@@ -3144,7 +3145,7 @@ device_classes:
             datapoints:
               bytesSentSec:
                 rrdtype: GAUGE
-                aliases: {outputoctets__bytes: null}
+                aliases: {outputOctets__bytes: null, outputoctets__bytes: null}
             counter: \Bytes Sent/sec
           packetsReceivedErrors:
             type: Windows Perfmon
@@ -3169,7 +3170,7 @@ device_classes:
             datapoints:
               bytesReceivedSec:
                 rrdtype: GAUGE
-                aliases: {inputoctets__bytes: null}
+                aliases: {inputOctets__bytes: null, inputoctets__bytes: null}
             counter: \Bytes Received/sec
           packetsSentErrors:
             type: Windows Perfmon

--- a/docs/body.md
+++ b/docs/body.md
@@ -1804,6 +1804,7 @@ Changes
 -   Fix Windows - traceback when no data returned for wmi class win32_computersystem (ZPS-2384)
 -   Fix Cluster Disk state always 'Inherited' (ZPS-2416)
 -   Fix Unable to monitor MS-SQL Cluser node - see 'Message stream modified' errors (ZPS-2433)
+-   Fix Windows ZP - Missing usedFilesystemSpace__bytes alias for Filesystem utilization report (ZPS-2434)
 
 2.8.1
 


### PR DESCRIPTION
Fixes ZPS-2434

add usedFilesystemSpace__bytes alias, along with inputOctets__bytes, outputOctets__bytes, memoryAvailable__bytes for platform based reports