### PR TITLE
Revert change from previous commit

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/patches/platform.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/patches/platform.py
@@ -12,7 +12,6 @@ import twisted.web.http
 
 from Products.ZenModel.OSProcess import OSProcess
 from Products.ZenUtils.Utils import monkeypatch
-from Products.ZenModel.Device import Device
 
 
 if not hasattr(OSProcess, 'getMinProcessCount'):
@@ -115,32 +114,3 @@ def _editDetails(self, info, data):
         info.post_update()
 
     return result
-
-
-@monkeypatch('Products.Zuul.facades.devicefacade.DeviceFacade')
-def getTemplates(self, id):
-    object = self._getObject(id)
-    rrdTemplates = object.getRRDTemplates()
-
-    # used to sort the templates
-    def byTitleOrId(left, right):
-        return cmp(left.titleOrId().lower(), right.titleOrId().lower())
-
-    for rrdTemplate in sorted(rrdTemplates, byTitleOrId):
-        uid = '/'.join(rrdTemplate.getPrimaryPath())
-        # only show Bound Templates
-        zDeviceTemplates = object.zDeviceTemplates
-        if '/Server/Microsoft/' in object.getPrimaryUrlPath():
-            zDeviceTemplates.append('MSExchange2013IS')
-        if rrdTemplate.id in zDeviceTemplates:
-            path = rrdTemplate.getUIPath()
-
-            # if defined directly on the device do not show the path
-            if isinstance(object, Device) and object.titleOrId() in path:
-                path = _t('Locally Defined')
-            yield {'id': uid,
-                   'uid': uid,
-                   'path': path,
-                   'text': '%s (%s)' % (rrdTemplate.titleOrId(), path),
-                   'leaf': True
-                   }

--- a/docs/body.md
+++ b/docs/body.md
@@ -1805,7 +1805,6 @@ Changes
 -   Fix Cluster Disk state always 'Inherited' (ZPS-2416)
 -   Fix Unable to monitor MS-SQL Cluser node - see 'Message stream modified' errors (ZPS-2433)
 -   Fix Windows ZP - Missing usedFilesystemSpace__bytes alias for Filesystem utilization report (ZPS-2434)
--   Fix Not all bound monitoring templates listed on device overview page (ZPS-2187)
 
 2.8.1
 


### PR DESCRIPTION
Fixes ZPS-2421

Reverting monkeypatch of platform code as unnecessary after talking to @cluther 

"What I’m thinking is that the platform DeviceFacade.getTemplates should be fixed to only use the `in object.zDeviceTemplates` check if `not isinstance(object, Device)`. I say this because `obj.getRRDTemplates()` has a very different meaning when called on device classes vs. devices.
This way it could be fixed generically, not have to be patched in Windows, and be applicable to other ZenPacks using the same template binding strategy as Windows."