### PR TITLE
If no site info found, set is_iis to False

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/IISSiteDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/IISSiteDataSource.py
@@ -214,7 +214,12 @@ class IISSiteDataSourcePlugin(PythonDataSourcePlugin):
                 if match:
                     app_pool = match.group(1)
             else:
-                app_pool_statuses[app_pool] = int(line)
+                try:
+                    app_pool_statuses[app_pool] = int(line)
+                except ValueError:
+                    # make sure we have an int as the status
+                    # we're catching exception below to default to Unknown
+                    pass
                 app_pool = None
 
         for ds in config.datasources:

--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/IIS.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/IIS.py
@@ -119,10 +119,11 @@ class IIS(WinRMPlugin):
             self.name(), device.id)
 
         device_om = ObjectMap()
-        device_om.is_iis = True
+        device_om.is_iis = False
         maps = [device_om]
         rm = self.relMap()
         if results.get('IIsWebServerSetting'):
+            device_om.is_iis = True
             for iisSite in results.get('IIsWebServerSetting', ()):
                 om = self.objectMap()
                 om.id = self.prepId(iisSite.Name)
@@ -136,7 +137,8 @@ class IIS(WinRMPlugin):
                         om.apppool = iisVirt.AppPoolId
 
                 rm.append(om)
-        else:
+        elif results.get('IIs7Site', False):
+            device_om.is_iis = True
             for iisSite in results.get('IIs7Site', ()):
                 try:
                     om = self.objectMap()

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testIIS.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testIIS.py
@@ -1,18 +1,21 @@
+#!/usr/bin/env python
 ##############################################################################
 #
-# Copyright (C) Zenoss, Inc. 2014, all rights reserved.
+# Copyright (C) Zenoss, Inc. 2014-2017, all rights reserved.
 #
 # This content is made available according to terms specified in
 # License.zenoss under the directory where your Zenoss product is installed.
 #
 ##############################################################################
 
+import Globals
 from mock import Mock
 
 from Products.ZenTestCase.BaseTestCase import BaseTestCase
 from ZenPacks.zenoss.Microsoft.Windows.tests.utils import StringAttributeObject
 
 from ZenPacks.zenoss.Microsoft.Windows.modeler.plugins.zenoss.winrm.IIS import IIS
+from ZenPacks.zenoss.Microsoft.Windows.lib.txwinrm.shell import CommandResponse
 
 
 class TestIIS(BaseTestCase):
@@ -28,3 +31,22 @@ class TestIIS(BaseTestCase):
         self.assertEquals(data[1].maps[0].sitename, "ServerComment")
         self.assertEquals(data[1].maps[0].statusname, "Name")
         self.assertEquals(data[1].maps[0].title, "ServerComment")
+
+        # test if no iis sites returned, probably means iis not installed
+        # and we need to set is_iis to False so IIS template is not used
+        data = self.plugin.process(StringAttributeObject(), {'version': CommandResponse([], [], 0)}, Mock())
+        self.assertFalse(data[0].is_iis)
+
+
+def test_suite():
+    """Return test suite for this module."""
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    suite.addTest(makeSuite(TestIIS))
+    return suite
+
+
+if __name__ == "__main__":
+    from zope.testrunner.runner import Runner
+    runner = Runner(found_suites=[test_suite()])
+    runner.run()

--- a/docs/body.md
+++ b/docs/body.md
@@ -1798,6 +1798,9 @@ Monitoring Templates
 Changes
 -------
 
+2.8.3
+-   Fix Microsoft.Windows: IIS template shows in Device Templates for non-IIS Server (ZPS-2555)
+
 2.8.2
 
 -   Fix Microsoft Windows fails to model 2008 Server Cluster Disks (ZPS-2015)


### PR DESCRIPTION
Fixes ZPS-2555

We were setting is_iis to True no matter what.  We should only set it
to True if we find IIS sites.  Also need to catch an exception that
could occur in the IISSiteDataSource