### PR TITLE
getHostByName will not work in ZaaS, pull from device

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
@@ -20,7 +20,6 @@ import urllib
 from urlparse import urlparse
 from traceback import format_exc
 import re
-from socket import gaierror
 
 from zope.component import adapts
 from zope.component import getGlobalSiteManager
@@ -31,7 +30,6 @@ from zope.interface import Interface
 from twisted.internet import defer
 from twisted.python.failure import Failure
 from Products.DataCollector.plugins.DataMaps import ObjectMap
-from Products.ZenUtils.IpUtil import getHostByName
 from Products.DataCollector.Plugins import getParserLoader, loadParserPlugins
 from Products.Zuul.form import schema
 from Products.Zuul.infos import ProxyProperty
@@ -749,12 +747,12 @@ class ShellDataSourcePlugin(PythonDataSourcePlugin):
             else:
                 version = 0
 
-        owner_node_ip = ''
+        owner_node_ip = None
         if hasattr(context, 'cluster_node_server'):
             owner_node, _ = context.cluster_node_server.split('//')
             try:
-                owner_node_ip = getHostByName(owner_node)
-            except gaierror:
+                owner_node_ip = context.device().clusterhostdevicesdict.get(owner_node, None)
+            except Exception:
                 pass
 
         try:

--- a/docs/body.md
+++ b/docs/body.md
@@ -1806,6 +1806,7 @@ Changes
 -   Fix Microsoft.Windows: IIS template shows in Device Templates for non-IIS Server (ZPS-2555)
 -   Fix Winrs failures (powershell datasources) with "Unknown strategy" message (ZPS-2613)
 -   Fix Missing interface counters on non physical adapters (ZPS-2567)
+-   Fix WinRS: Failed collection ipaddress missing (ZPS-2645)
 
 2.8.2
 


### PR DESCRIPTION
Fixes ZPS-2645

Should have been using this method in the first place as getHostByName
could hit dns