### PR TITLE
Use long command to get sql server databases

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
@@ -59,6 +59,8 @@ from . import send_to_debug
 # Requires that txwinrm_utils is already imported.
 from txwinrm.util import RequestError
 from txwinrm.WinRMClient import SingleCommandClient
+from txwinrm.shell import create_long_running_command, CommandResponse
+
 
 log = logging.getLogger("zen.MicrosoftWindows")
 ZENPACKID = 'ZenPacks.zenoss.Microsoft.Windows'
@@ -519,6 +521,9 @@ class PowershellMSSQLStrategy(object):
                 self.valuemap[databasename]['status'] = value.strip()
 
         for dsconf in dsconfs:
+            if dsconf.params['resource'] == 'status':
+                # no need to get status as it's handled differently
+                continue
             timestamp = int(time.mktime(time.localtime()))
             databasename = dsconf.params['contexttitle']
             try:
@@ -877,9 +882,21 @@ class ShellDataSourcePlugin(PythonDataSourcePlugin):
         else:
             command_line, script = strategy.build_command_line(counters)
 
-        command = SingleCommandClient(conn_info)
+        if dsconf0.params['strategy'] == 'powershell MSSQL':
+            command = create_long_running_command(conn_info)
+            yield command.start(command_line, ps_script=script)
+            stdout = []
+            stderr = []
+            while command._exit_code is None:
+                stdout_r, stderr_r = yield command.receive()
+                stdout += stdout_r
+                stderr += stderr_r
 
-        results = yield command.run_command(command_line, script)
+            results = CommandResponse(stdout, stderr, command._exit_code)
+            yield command.stop()
+        else:
+            command = SingleCommandClient(conn_info)
+            results = yield command.run_command(command_line, script)
 
         defer.returnValue((strategy, config.datasources, results))
 

--- a/docs/body.md
+++ b/docs/body.md
@@ -1807,6 +1807,7 @@ Changes
 -   Fix Winrs failures (powershell datasources) with "Unknown strategy" message (ZPS-2613)
 -   Fix Missing interface counters on non physical adapters (ZPS-2567)
 -   Fix WinRS: Failed collection ipaddress missing (ZPS-2645)
+-   Fix Windows ZenPack: WinMSSQL may not finish modeling when hundreds of databases exist. (ZPS-2644)
 
 2.8.2
 


### PR DESCRIPTION
Fixes ZPS-2644

Having more databases can cause our modeler to take longer to complete.
Let's convert our single command to be run via the long command so we
can wait until it finishes.  Monitoring will also be affected as we are
looping through all dbs to pull metrics