### PR TITLE
get_data should return if datasource is in STOPPED state

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
@@ -412,6 +412,8 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
     def get_data(self):
         """Wait for data to arrive if necessary, then return it."""
         data = PERSISTER.pop(self.config.id)
+        if self.state == PluginStates.STOPPED:
+            defer.returnValue(data)
         if data and data['values']:
             defer.returnValue(data)
         if data and data['events']:

--- a/docs/body.md
+++ b/docs/body.md
@@ -1809,6 +1809,7 @@ Changes
 -   Fix WinRS: Failed collection ipaddress missing (ZPS-2645)
 -   Fix Windows ZenPack: WinMSSQL may not finish modeling when hundreds of databases exist. (ZPS-2644)
 -   Fix Resmgr 5.3.3 upgrade indicates Windows alias is too long (ZPS-2611)
+-   Fix Windows: Tasks building up with a bad config (ZPS-2717)
 
 2.8.2
 


### PR DESCRIPTION
Fixes ZPS-2717

When we get an immediate error from starting the get-counter command,
we should go ahead and return.  If we do not, this is leaving the ds
in a running state and contributes to missed runs.  looks to be due to the
timing of how long it takes for the error to come back from trying to get data.
The task does eventually finish, but, in the meantime, it appears as a Running_Task
and then eventually a Missed_Run.