### PR TITLE
Account for event logs with '-' and/or '/' in name

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/EventLogDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/EventLogDataSource.py
@@ -161,7 +161,7 @@ class EventLogInfo(InfoBase):
                 node.childNodes[0].data = filter_text
             xml_query = prettify_xml(in_filter_xml)
             # undo replacement of single quotes with double
-            xml_query = re.sub(r"(\w+)='(\w+)'", r'\1="\2"', xml_query)
+            xml_query = re.sub(r"(\w+)='(\S+)'", r'\1="\2"', xml_query)
             # remove the xml header and replace any "&amp;" with "&"
             header = '<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n'
             xml_query = xml_query.replace(header, '').replace('&amp;', '&')

--- a/docs/body.md
+++ b/docs/body.md
@@ -1805,6 +1805,7 @@ Changes
 
 -   Fix Windows - IIS 7 or higher may show Unknown site status (ZPS-2728)
 -   Fix Windows - Error: local variable 'kerberos' referenced before assignment (ZPS-2738)
+-   Fix Quote issue for polling custom event logs (ZPS-2741)
 
 2.8.3
 


### PR DESCRIPTION
Fixes ZPS-2741

Regex was not catching names with symbols, e.g. Microsoft-Windows-Backup or
Microsoft-Windows-PowerShell/Operational