### PR TITLE
Removed default event class for some datasources

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ClusterDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ClusterDataSource.py
@@ -73,7 +73,6 @@ class ClusterDataSource(PythonDataSource):
     ZENPACKID = ZENPACKID
     component = '${here/id}'
     cycletime = 300
-    eventClass = '/Status'
 
     sourcetypes = (WINRS_SOURCETYPE,)
     sourcetype = sourcetypes[0]

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
@@ -71,7 +71,6 @@ class PerfmonDataSource(PythonDataSource):
 
     sourcetype = SOURCETYPE
     sourcetypes = (SOURCETYPE,)
-    eventClass = '/Status'
 
     plugin_classname = (
         ZENPACKID + '.datasources.PerfmonDataSource.PerfmonDataSourcePlugin')

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
@@ -1064,7 +1064,6 @@ class ShellDataSourcePlugin(PythonDataSourcePlugin):
 
         # Clear previous error event
         data['events'].append(dict(
-            eventClass='/Status',
             severity=ZenEventClasses.Clear,
             eventClassKey='winrsCollectionError',
             eventKey='winrsCollection',

--- a/docs/body.md
+++ b/docs/body.md
@@ -541,6 +541,8 @@ filter will be used:
 `{time}` will be replaced by the number of milliseconds since the last
 query automatically.
 
+Note: The max age field is only used the first time that the datasource is run.  Subsequent queries will only look at events that have occurred since the last time this datasource was run.   We write a timestamp to the registry location HKCU:\\SOFTWARE\\zenoss\\logs\\<datasource name> to know when the last time the datasource was run.  If you are testing a datasource and would like to reset this time, then simply remove the string value with your datasource name in the registry hive, \\SOFTWARE\\zenoss\\logs\\, for your user under HKEY_USERS.
+
 Note: The script to search for events and return relevant data is
 approximately 3700 characters. Due to the Windows 8192 character limit
 on the shell, any XML or PowerShell queries will need to be less than
@@ -1811,6 +1813,7 @@ Changes
 -   Fix Microsoft Windows: zenpython memory increases until restart required (ZPS-2176)
 -   Fix CPU use builds over time - PythonCollector MicrosoftWindows (ZPS-2480)
 -   Fix Modelling using Kerberos generates two tickets (ZPS-2394)
+-   Fix Windows data sources are improperly setting eventClass (ZPS-3056)
 
 2.8.3
 


### PR DESCRIPTION
Fixes ZPS-3056

EventLogDataSource is correct and we will continue to send to the /Unknown event class.
Also updated event datasource section so that we explain the max age field and how it only is used once.