### PR TITLE
Send onError events to '/Status' for datasources

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ClusterDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ClusterDataSource.py
@@ -262,8 +262,14 @@ class ClusterDataSourcePlugin(PythonDataSourcePlugin):
 
         data['events'].append(dict(
             severity=ZenEventClasses.Clear,
-            eventClassKey='clusterCollectionSuccess',
+            eventClass='/Status',
             eventKey='clusterCollection',
+            summary='cluster: successful collection',
+            device=config.id))
+        data['events'].append(dict(
+            severity=ZenEventClasses.Clear,
+            eventClass='/Status',
+            eventKey='datasourceWarning_{0}'.format(config.datasources[0].datasource),
             summary='cluster: successful collection',
             device=config.id))
         generateClearAuthEvents(config, data['events'])
@@ -278,7 +284,6 @@ class ClusterDataSourcePlugin(PythonDataSourcePlugin):
             if isinstance(result.value, RequestError):
                 args = result.value.args
                 msg = args[0] if args else format_exc(result.value)
-                event_class = '/Status'
             elif send_to_debug(result):
                 logg = log.debug
             else:
@@ -295,9 +300,8 @@ class ClusterDataSourcePlugin(PythonDataSourcePlugin):
         data = self.new_data()
         if not errorMsgCheck(config, data['events'], result.value.message):
             data['events'].append(dict(
-                eventClass=event_class,
+                eventClass='/Status',
                 severity=ZenEventClasses.Warning,
-                eventClassKey='clusterCollectionError',
                 eventKey=eventKey,
                 summary='Cluster: ' + msg,
                 device=config.id))

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/EventLogDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/EventLogDataSource.py
@@ -351,6 +351,7 @@ class EventLogPlugin(PythonDataSourcePlugin):
 
         data['events'].append({
             'device': config.id,
+            'eventClass': '/Status',
             'summary': 'Windows EventLog: successful event collection',
             'severity': ZenEventClasses.Clear,
             'eventKey': 'WindowsEventCollection: {}'.format(ds0.params.get('eventid', '')),
@@ -390,11 +391,10 @@ class EventLogPlugin(PythonDataSourcePlugin):
             for ds in config.datasources:
                 data['events'].append({
                     'severity': severity,
-                    'eventClassKey': 'WindowsEventCollectionError',
+                    'eventClass': '/Status',
                     'eventKey': 'WindowsEventCollection: {}'.format(ds.params.get('eventid', '')),
                     'summary': msg,
                     'message': msg,
-                    'eventClass': ds.eventClass,
                     'device': config.id
                 })
         return data

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/IISSiteDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/IISSiteDataSource.py
@@ -289,7 +289,6 @@ class IISSiteDataSourcePlugin(PythonDataSourcePlugin):
         # Clear previous error event
         data['events'].append({
             'eventClass': '/Status',
-            'eventClassKey': 'IISSiteStatusError',
             'eventKey': 'IISSite',
             'severity': ZenEventClasses.Clear,
             'summary': 'Monitoring ok',
@@ -311,9 +310,8 @@ class IISSiteDataSourcePlugin(PythonDataSourcePlugin):
         if not errorMsgCheck(config, data['events'], result.value.message):
             # only need the one event
             data['events'].append({
-                'eventClass': event_class,
                 'severity': ZenEventClasses.Warning,
-                'eventClassKey': 'IISSiteStatusError',
+                'eventClass': '/Status',
                 'eventKey': 'IISSite',
                 'summary': 'IISSite: ' + msg,
                 'device': config.id})

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/PortCheckDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/PortCheckDataSource.py
@@ -168,21 +168,25 @@ class PortCheckDataSourcePlugin(PythonDataSourcePlugin):
             # no ports listening
             pass
         # send clear events
+        data['events'].append({
+            'eventClass': '/Status',
+            'severity': ZenEventClasses.Clear,
+            'eventClassKey': 'WindowsPortCheckStatus',
+            'eventKey': 'WindowsPortCheckError',
+            'summary': 'Port Check Successful',
+            'device': config.id})
         return data
 
     def onError(self, results, config):
         data = self.new_data()
-        dsconf0 = config.datasources[0]
 
         # send error event
-        eventClass = dsconf0.eventClass if dsconf0.eventClass else "/Status"
-        eventkey = 'WindowsPortCheckError'
         msg = 'Error running port check tests.  {}'.format(results)
         data['events'].append({
-            'eventClass': eventClass,
+            'eventClass': '/Status',
             'severity': ZenEventClasses.Error,
             'eventClassKey': 'WindowsPortCheckStatus',
-            'eventKey': eventkey,
+            'eventKey': 'WindowsPortCheckError',
             'summary': msg,
             'device': config.id})
         return data

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ServiceDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ServiceDataSource.py
@@ -319,7 +319,6 @@ class ServicePlugin(PythonDataSourcePlugin):
             serviceinfo = results[results.keys()[0]]
         except Exception:
             data['events'].append({
-                'eventClass': "/Status/WinService",
                 'severity': ZenEventClasses.Error,
                 'eventClassKey': 'WindowsServiceCollectionStatus',
                 'eventKey': 'WindowsServiceCollection',
@@ -362,7 +361,6 @@ class ServicePlugin(PythonDataSourcePlugin):
                 'service_state': svc_info.State,
                 'service_status': svc_info.Status,
                 'eventClass': "/Status/WinService",
-                'eventClassKey': 'WindowsServiceLog',
                 'eventKey': "WindowsService",
                 'severity': severity,
                 'summary': evtmsg,
@@ -372,12 +370,10 @@ class ServicePlugin(PythonDataSourcePlugin):
 
         # Event to provide notification that check has completed
         data['events'].append({
-            'eventClass': "/Status/WinService",
             'device': config.id,
             'summary': 'Windows Service Check: successful service collection',
             'severity': ZenEventClasses.Clear,
             'eventKey': 'WindowsServiceCollection',
-            'eventClassKey': 'WindowsServiceCollectionStatus',
         })
 
         generateClearAuthEvents(config, data['events'])
@@ -399,9 +395,8 @@ class ServicePlugin(PythonDataSourcePlugin):
         data = self.new_data()
         if not errorMsgCheck(config, data['events'], result.message):
             data['events'].append({
-                'eventClass': "/Status/WinService",
                 'severity': ZenEventClasses.Error,
-                'eventClassKey': 'WindowsServiceCollectionStatus',
+                'eventClass': '/Status',
                 'eventKey': 'WindowsServiceCollection',
                 'summary': msg,
                 'device': config.id})

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
@@ -1065,7 +1065,7 @@ class ShellDataSourcePlugin(PythonDataSourcePlugin):
         # Clear previous error event
         data['events'].append(dict(
             severity=ZenEventClasses.Clear,
-            eventClassKey='winrsCollectionError',
+            eventClass='/Status',
             eventKey='winrsCollection',
             summary='Monitoring ok',
             device=config.id))
@@ -1099,7 +1099,7 @@ class ShellDataSourcePlugin(PythonDataSourcePlugin):
         if not errorMsgCheck(config, data['events'], result.value.message):
             data['events'].append(dict(
                 severity=ZenEventClasses.Warning,
-                eventClassKey='winrsCollectionError',
+                eventClass='/Status',
                 eventKey=eventKey,
                 summary='WinRS: ' + msg,
                 device=config.id))

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testClusterDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testClusterDataSource.py
@@ -74,7 +74,7 @@ class TestClusterDataSourcePlugin(BaseTestCase):
                 self.assertEquals(data['values'][comp]['state'], num)
             except Exception:
                 self.assertEquals(data['values'][comp]['state'][0], cluster_state_value(value), 'found {}'.format(value))
-        self.assertEquals(len(data['events']), 26)
+        self.assertEquals(len(data['events']), 27)
 
 
 def test_suite():

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testIISSiteDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testIISSiteDataSource.py
@@ -68,7 +68,7 @@ class TestIISSiteDataSourcePlugin(BaseTestCase):
 
         for err in winrm_errors:
             data = self.plugin.onError(Failure(err), config)
-            self.assertEquals(data['events'][0]['eventClass'], '/Status/IIS')
+            self.assertEquals(data['events'][0]['eventClass'], '/Status')
 
         for err in kerberos_errors:
             data = self.plugin.onError(Failure(err), config)

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testPortCheckDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testPortCheckDataSource.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 ##############################################################################
 #
 # Copyright (C) Zenoss, Inc. 2015, all rights reserved.
@@ -6,6 +7,8 @@
 # License.zenoss under the directory where your Zenoss product is installed.
 #
 ##############################################################################
+
+import Globals
 
 from Products.ZenTestCase.BaseTestCase import BaseTestCase
 from ZenPacks.zenoss.Microsoft.Windows.tests.mock import MagicMock, sentinel
@@ -31,9 +34,9 @@ class TestPortCheckDataSourcePlugin(BaseTestCase):
         self.plugin.scanner.getSuccesses = MagicMock(return_value={sentinel.manageIp: [1]})
         self.plugin.scanner.getFailures = MagicMock(return_value={sentinel.manageIp: [[2]]})
         data = self.plugin.onSuccess(MagicMock, self.config)
-        self.assertEquals(len(data['events']), 2)
+        self.assertEquals(len(data['events']), 3)
         self.assertItemsEqual(
-            ['Port 2 is not listening.  Desc', 'Port 1 is listening.  Desc'],
+            ['Port 2 is not listening.  Desc', 'Port 1 is listening.  Desc', 'Port Check Successful'],
             [e['summary'] for e in data['events']]
         )
 
@@ -41,3 +44,18 @@ class TestPortCheckDataSourcePlugin(BaseTestCase):
         data = self.plugin.onError(MagicMock, self.config)
         self.assertEquals(len(data['events']), 1)
         self.assertEquals(data['events'][0]['eventKey'], "WindowsPortCheckError")
+        self.assertEquals(data['events'][0]['eventClass'], '/Status')
+
+
+def test_suite():
+    """Return test suite for this module."""
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    suite.addTest(makeSuite(TestPortCheckDataSourcePlugin))
+    return suite
+
+
+if __name__ == "__main__":
+    from zope.testrunner.runner import Runner
+    runner = Runner(found_suites=[test_suite()])
+    runner.run()

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testShellDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testShellDataSource.py
@@ -55,8 +55,7 @@ class TestShellDataSourcePlugin(BaseTestCase):
 
         for err in winrm_errors:
             data = self.plugin.onError(Failure(err), self.config)
-            self.assertEquals(data['events'][0]['eventClassKey'], 'winrsCollectionError')
-            self.assertTrue('eventClass' not in data['events'][0])
+            self.assertEquals(data['events'][0]['eventClass'], '/Status')
 
         for err in kerberos_errors:
             data = self.plugin.onError(Failure(err), self.config)


### PR DESCRIPTION
Fixes ZPS-3056

Send onError type events to /Status.  no need to eventClassKeys or using datasource eventclass
