### PR TITLE
Account for no WMI data, but successful ps query

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/Interfaces.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/Interfaces.py
@@ -159,6 +159,10 @@ class Interfaces(WinRMPlugin):
         if broadcomresults:
             broadcomresults = ''.join(broadcomresults.stdout).split('|')
 
+        if not netInt and (broadcomresults or regresults or counter_instances):
+            log.warn("Received incomplete Interface modeling results.")
+            return
+
         # Performance Counters for Windows 2012
         counters = self.sanitize_counters(results.get('counters2012'))
 

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/data/Interfaces_process_194131.pickle
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/data/Interfaces_process_194131.pickle
@@ -1,0 +1,107 @@
+(lp0
+(dp1
+S'counters2012'
+p2
+cDateTime.DateTime
+_dt_reconstructor
+p3
+(ctxwinrm.shell
+CommandResponse
+p4
+c__builtin__
+object
+p5
+Ntp6
+Rp7
+(dp8
+S'_stderr'
+p9
+(lp10
+sS'_exit_code'
+p11
+I0
+sS'_stdout'
+p12
+(lp13
+sbsS'broadcomnic'
+p14
+g3
+(g4
+g5
+Ntp15
+Rp16
+(dp17
+g9
+(lp18
+sg11
+I0
+sg12
+(lp19
+sbsS'registry'
+p20
+g3
+(g4
+g5
+Ntp21
+Rp22
+(dp23
+g9
+(lp24
+sg11
+I0
+sg12
+(lp25
+sbsS'counters'
+p26
+g3
+(g4
+g5
+Ntp27
+Rp28
+(dp29
+g9
+(lp30
+sg11
+I0
+sg12
+(lp31
+VReadings : \u005c\u005cwin2016-kdc-01\u005cnetwork interface(intel[r] 82574l gigabit network connection)\u005cbytes received/sec :
+p32
+aV59516.9368158373
+p33
+aV\u005c\u005cwin2016-kdc-01\u005cnetwork interface(isatap.{79f1322a-1d3b-42a3-ae1e-b9b50d707f8c})\u005cbytes received/sec :
+p34
+aV0
+p35
+aV\u005c\u005cwin2016-kdc-01\u005cnetwork interface(isatap.{d2e821ce-f45a-4ff3-a6d1-d060db4eac69})\u005cbytes received/sec :
+p36
+ag35
+aV\u005c\u005cwin2016-kdc-01\u005cnetwork adapter(intel[r] 82574l gigabit network connection)\u005cbytes received/sec :
+p37
+aV59516.9368158373
+p38
+aV\u005c\u005cwin2016-kdc-01\u005cnetwork adapter(intel[r] 82574l gigabit network connection _2)\u005cbytes received/sec :
+p39
+ag35
+aV\u005c\u005cwin2016-kdc-01\u005cnetwork adapter(microsoft kernel debug network adapter)\u005cbytes received/sec :
+p40
+ag35
+aV\u005c\u005cwin2016-kdc-01\u005cnetwork adapter(local area connection* 11-wfp native mac layer lightweight filter-0000)\u005cbytes received/sec :
+p41
+ag35
+aV\u005c\u005cwin2016-kdc-01\u005cnetwork adapter(local area connection* 11-qos packet scheduler-0000)\u005cbytes received/sec :
+p42
+ag35
+aV\u005c\u005cwin2016-kdc-01\u005cnetwork adapter(local area connection* 11-wfp 802.3 mac layer lightweight filter-0000)\u005cbytes received/sec :
+p43
+ag35
+aV\u005c\u005cwin2016-kdc-01\u005cnetwork adapter(isatap.{79f1322a-1d3b-42a3-ae1e-b9b50d707f8c})\u005cbytes received/sec :
+p44
+ag35
+aV\u005c\u005cwin2016-kdc-01\u005cnetwork adapter(isatap.{d2e821ce-f45a-4ff3-a6d1-d060db4eac69})\u005cbytes received/sec :
+p45
+ag35
+aV\u005c\u005cwin2016-kdc-01\u005cnetwork adapter(local area connection* 11)\u005cbytes received/sec :
+p46
+ag35
+asbsa.

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testInterfaces.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testInterfaces.py
@@ -111,10 +111,26 @@ class TestTeamInterfaces(BaseTestCase):
         self.assertEquals(data.maps[13].perfmonInstance, "\\Network Interface(HP NC382i DP Multifunction Gigabit Server Adapter _2#1)")
 
 
+class TestNoWMI(BaseTestCase):
+    """Test case for no WMI data, but there was successful powershell collection"""
+    def setUp(self):
+        self.results = load_pickle_file(self, 'Interfaces_process_194131')[0]
+        self.device = load_pickle_file(self, 'device')
+        self.plugin = Interfaces()
+
+    def test_process(self):
+        m = Mock()
+        data = self.plugin.process(self.device, self.results, m)
+        # We should not return an empty relationship map
+        self.assertEquals(data, None)
+        self.assertTrue('Received incomplete Interface modeling results.' in str(m.mock_calls[1]))
+
+
 def test_suite():
     """Return test suite for this module."""
     from unittest import TestSuite, makeSuite
     suite = TestSuite()
+    suite.addTest(makeSuite(TestNoWMI))
     suite.addTest(makeSuite(TestInterfaces))
     suite.addTest(makeSuite(TestHelpers))
     suite.addTest(makeSuite(TestInterfacesCounters))


### PR DESCRIPTION
Fixes ZPS-3100

If no WMI data is returned, but there is powershell data, we are sending back an empty relationship map, which blows away existing model.  We should try to keep existing components, so we'll issue a warning stating incomplete modeling results and return nothing.
Added unit test to confirm