### PR TITLE
Check for missing wmi data

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ProcessDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ProcessDataSource.py
@@ -316,7 +316,12 @@ class ProcessDataSourcePlugin(PythonDataSourcePlugin):
             key=lambda x: x.params.get('sequence', 0))
 
         # Win32_Process: Counts and correlation to performance table.
-        process_key = [x for x in results if 'Win32_Process' in x.wql][0]
+        LOG.debug('ProcessDataSource results: {}'.format(results))
+        try:
+            process_key = [x for x in results if 'Win32_Process' in x.wql][0]
+        except IndexError:
+            # incomplete results
+            raise Exception('Received no results for Win32_Process WMI query.')
         for item in results[process_key]:
             processText = get_processText(item)
 
@@ -418,7 +423,7 @@ class ProcessDataSourcePlugin(PythonDataSourcePlugin):
                 'eventGroup': 'Process',
                 'summary': summary,
                 'severity': severity,
-                })
+            })
 
         # Prepare for next cycle's restart check by merging current
         # process PIDs with previous. This is to catch restarts that

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testProcessDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testProcessDataSource.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 ##############################################################################
 #
 # Copyright (C) Zenoss, Inc. 2015, all rights reserved.
@@ -7,6 +8,7 @@
 #
 ##############################################################################
 
+import Globals
 from twisted.python.failure import Failure
 from Products.ZenTestCase.BaseTestCase import BaseTestCase
 
@@ -44,3 +46,21 @@ class TestProcessDataSourcePlugin(BaseTestCase):
                 'Authentication Successful', 'No Kerberos failures'
             )
         )
+        self.success.pop(self.success.keys()[0])
+        try:
+            self.plugin.onSuccess(self.success, self.config)
+        except Exception as e:
+            self.assertEquals(e.message, 'Received no results for Win32_Process WMI query.')
+
+
+def test_suite():
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    suite.addTest(makeSuite(TestProcessDataSourcePlugin))
+    return suite
+
+
+if __name__ == "__main__":
+    from zope.testrunner.runner import Runner
+    runner = Runner(found_suites=[test_suite()])
+    runner.run()

--- a/docs/body.md
+++ b/docs/body.md
@@ -1820,6 +1820,7 @@ Changes
 -   Fix Modelling using Kerberos generates two tickets (ZPS-2394)
 -   Fix Windows data sources are improperly setting eventClass (ZPS-3056)
 -   Fix Windows Event Log Datasource Does not Map Critical Events (ZPS-3109)
+-   Fix Windows - an error 'process scan error: list index out of range' is generated for OS Processes component (ZPS-3116)
 
 2.8.3
 


### PR DESCRIPTION
Fixes ZPS-3116

If we're missing wmi data, raise exception.  added unit test