### PR TITLE
Change Device label so it's not confusing

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
+++ b/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
@@ -101,7 +101,7 @@ classes:
         label: Owner Node
         grid_display: false
       get_host_device:
-        label: Device
+        label: Windows Device
         grid_display: true
         api_only: true
         api_backendtype: method


### PR DESCRIPTION
Fixes ZPS-3123

Change ClusterNodeObject from Device to Windows Device so that it is differentiated from the cluster device.