### PR TITLE
don't write invalid datapoint

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ClusterDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ClusterDataSource.py
@@ -230,7 +230,10 @@ class ClusterDataSourcePlugin(PythonDataSourcePlugin):
                 # specific for cluster disk component
                 data['values'][comp]['state'] = int(state)
                 state = cluster_disk_state_string(int(state))
-                data['values'][comp]['freespace'] = int(freespace)
+                if freespace != '-1':
+                    # don't write dp if -1.  probably means unallocated disk
+                    # and freespace would have no meaning
+                    data['values'][comp]['freespace'] = int(freespace)
             except Exception:
                 # handles all other cases
                 data['values'][comp]['state'] = cluster_state_value(state), 'N'


### PR DESCRIPTION
Fixes ZPS-3143

If freespace is -1, this means there are no partitions and freespace would have no meaning.  don't write the datapoint and it will show as N/A on a graph and won't get hit by any threshold