### PR TITLE
Fix display of state, freespace

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/ClusterDisk.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/ClusterDisk.py
@@ -18,7 +18,7 @@ class ClusterDisk(schema.ClusterDisk):
     def getState(self):
         status = 'None'
         try:
-            state = int(self.cacheRRDValue('state', None))
+            state = int(self.cacheRRDValue('state_state', None))
             status = cluster_disk_state_string(state)
         except Exception:
             status = 'Error Encountered'

--- a/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
+++ b/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
@@ -318,6 +318,7 @@ classes:
         api_backendtype: method
       freespace:
         label: Free Space
+        renderer: Zenoss.render.bytesString
         grid_display: true
         order: 6
         datapoint: state_freespace


### PR DESCRIPTION
Fixes ZPS-3149

Use bytesString as renderer for freespace and be sure to pull the state_state datapoint for disk state