### PR TITLE
issue bad username/password event

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
@@ -406,7 +406,15 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
             if success:
                 self.state = PluginStates.STARTED
             else:
-                LOG.debug("%s: Perfmon command(s) did not start: %s", self.config.id, data)
+                LOG.warn("%s: Perfmon command(s) did not start: %s", self.config.id, data.value)
+                if not errorMsgCheck(self.config, PERSISTER.get_events(self.config.id), data.value.message):
+                    PERSISTER.add_event(self.config.id, self.config.datasources, {
+                        'device': self.config.id,
+                        'eventClass': '/Status/Winrm',
+                        'eventKey': 'WindowsPerfmonCollection Error',
+                        'severity': ZenEventClasses.Warning,
+                        'summary': errorMessage,
+                        'ipAddress': self.config.manageIp})
 
         if self.state != PluginStates.STARTED:
             self.state = PluginStates.STOPPED


### PR DESCRIPTION
Fixes ZPS-2712

Be sure to issue an event for bad username/password for local auth when starting the perfmon command.  Also, let's not show the traceback in the log.  could cause confusion