### PR TITLE
Apply simple obfuscation of sql password in queries

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
@@ -46,7 +46,6 @@ from ZenPacks.zenoss.PythonCollector.datasources.PythonDataSource \
 
 from ..txcoroutine import coroutine
 
-from ..twisted_utils import add_timeout
 from ..txwinrm_utils import ConnectionInfoProperties, createConnectionInfo
 from ZenPacks.zenoss.Microsoft.Windows.utils import filter_sql_stdout, \
     parseDBUserNamePass, getSQLAssembly
@@ -61,7 +60,6 @@ from . import send_to_debug
 # Requires that txwinrm_utils is already imported.
 from txwinrm.util import RequestError
 from txwinrm.WinRMClient import SingleCommandClient
-from txwinrm.shell import create_long_running_command, CommandResponse
 
 
 log = logging.getLogger("zen.MicrosoftWindows")
@@ -441,7 +439,7 @@ class SqlConnection(object):
         self.sqlConnection.append("$p = [System.Text.Encoding]::ASCII.GetString([Convert]::FromBase64String($x));")
         self.sqlConnection.append("$con = new-object "
                                   "('Microsoft.SqlServer.Management.Common.ServerConnection')"
-                                  '"{}", "{}", "$p";'.format(instance, sqlusername, sqlpassword))
+                                  '"{}", "{}", "$p";'.format(instance, sqlusername))
 
         if login_as_user:
             # Login using windows credentials

--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinMSSQL.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinMSSQL.py
@@ -280,7 +280,7 @@ class WinMSSQL(WinRMPlugin):
             sqlConnection.append("$p = [System.Text.Encoding]::ASCII.GetString([Convert]::FromBase64String($x));")
             sqlConnection.append("$con = new-object "
                                  "('Microsoft.SqlServer.Management.Common.ServerConnection')"
-                                 '"{0}", "{1}", "$p";'.format(sqlserver, sqlusername, pwd))
+                                 '"{0}", "{1}", "$p";'.format(sqlserver, sqlusername))
 
             if login_as_user:
                 # Login using windows credentials

--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinMSSQL.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinMSSQL.py
@@ -15,6 +15,7 @@ available in WMI.
 
 """
 import json
+import base64
 
 from twisted.internet import defer
 
@@ -274,9 +275,12 @@ class WinMSSQL(WinRMPlugin):
                     login_as_user = True
 
             # DB Connection Object
+            pwd = base64.b64encode(sqlpassword)
+            sqlConnection.append("$x = '{}';".format(pwd))
+            sqlConnection.append("$p = [System.Text.Encoding]::ASCII.GetString([Convert]::FromBase64String($x));")
             sqlConnection.append("$con = new-object "
                                  "('Microsoft.SqlServer.Management.Common.ServerConnection')"
-                                 "'{0}', '{1}', '{2}';".format(sqlserver, sqlusername, sqlpassword))
+                                 '"{0}", "{1}", "$p";'.format(sqlserver, sqlusername, pwd))
 
             if login_as_user:
                 # Login using windows credentials
@@ -284,7 +288,7 @@ class WinMSSQL(WinRMPlugin):
                 sqlConnection.append("$con.ConnectAsUser=$true;")
                 # Omit domain part of username
                 sqlConnection.append("$con.ConnectAsUserName='{0}';".format(sqlusername.split("\\")[-1]))
-                sqlConnection.append("$con.ConnectAsUserPassword='{0}';".format(sqlpassword))
+                sqlConnection.append('$con.ConnectAsUserPassword="$p";')
             else:
                 sqlConnection.append("$con.Connect();")
 

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testShellDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testShellDataSource.py
@@ -142,7 +142,7 @@ class TestShellDataSourcePlugin(BaseTestCase):
 
     def test_sqlConnection(self):
         sq = SqlConnection('instance', 'sqlusername@domain.com', 'sqlpassword', True, 11)
-        self.assertTrue('sqlpassword' not in ' '.join(sq.sqlConnection), sq.sqlConnection)
+        self.assertNotIn('sqlpassword', ' '.join(sq.sqlConnection), sq.sqlConnection)
 
 def test_suite():
     """Return test suite for this module."""

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testShellDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testShellDataSource.py
@@ -18,7 +18,7 @@ from ZenPacks.zenoss.Microsoft.Windows.tests.utils import load_pickle, load_pick
 from ZenPacks.zenoss.Microsoft.Windows.tests.mock import sentinel, patch, Mock
 
 from ZenPacks.zenoss.Microsoft.Windows.datasources.ShellDataSource import (
-    ShellDataSourcePlugin, DCDiagStrategy
+    ShellDataSourcePlugin, DCDiagStrategy, SqlConnection
 )
 
 
@@ -140,6 +140,9 @@ class TestShellDataSourcePlugin(BaseTestCase):
                 'Error parsing data in powershell MSSQL strategy for "ActiveTransactions" datasource',
                 data['events'][x]['summary'])
 
+    def test_sqlConnection(self):
+        sq = SqlConnection('instance', 'sqlusername@domain.com', 'sqlpassword', True, 11)
+        self.assertTrue('sqlpassword' not in ' '.join(sq.sqlConnection), sq.sqlConnection)
 
 def test_suite():
     """Return test suite for this module."""

--- a/docs/body.md
+++ b/docs/body.md
@@ -1817,6 +1817,7 @@ Changes
 -   Fix Misleading Error when parsing MSSQL status datasource on different cycle than other database datasources (ZPS-3194)
 -   Fix Undefined PrimaryOwnerName or RegisteredUser causes traceback in OperatingSystem plugin (ZPS-3227)
 -   Fix ShellDataSource slow to gather data when hundreds of databases exist.
+-   Fix MSSQL password can be logged in the Windows Event Log as plaintext during query failure (ZPS-3302)
 
 2.9.0
 


### PR DESCRIPTION
Fixes ZPS-3302

For now, apply a simple b64 encoding to obfuscate the password sent into the sql scripts for modeling/monitoring.