### PR TITLE
use sspi in connection string for fewer logins

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinMSSQL.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinMSSQL.py
@@ -25,7 +25,7 @@ from Products.DataCollector.plugins.DataMaps \
 from ZenPacks.zenoss.Microsoft.Windows.modeler.WinRMPlugin import WinRMPlugin
 from ZenPacks.zenoss.Microsoft.Windows.utils import addLocalLibPath, \
     getSQLAssembly, filter_sql_stdout, prepare_zDBInstances
-from ZenPacks.zenoss.Microsoft.Windows.utils import save
+from ZenPacks.zenoss.Microsoft.Windows.utils import save, SqlConnection
 
 from txwinrm.WinRMClient import SingleCommandClient
 
@@ -255,8 +255,6 @@ class WinMSSQL(WinRMPlugin):
                 owner_node.strip(), sqlserver)
             instance_oms.append(om_instance)
 
-            sqlConnection = []
-
             # Look for specific instance creds first
             try:
                 sqlusername = dblogins[instance]['username']
@@ -274,27 +272,9 @@ class WinMSSQL(WinRMPlugin):
                     sqlpassword = password
                     login_as_user = True
 
-            # DB Connection Object
-            pwd = base64.b64encode(sqlpassword)
-            sqlConnection.append("$x = '{}';".format(pwd))
-            sqlConnection.append("$p = [System.Text.Encoding]::ASCII.GetString([Convert]::FromBase64String($x));")
-            sqlConnection.append("$con = new-object "
-                                 "('Microsoft.SqlServer.Management.Common.ServerConnection')"
-                                 '"{0}", "{1}", "$p";'.format(sqlserver, sqlusername))
-
-            if login_as_user:
-                # Login using windows credentials
-                sqlConnection.append("$con.LoginSecure=$true;")
-                sqlConnection.append("$con.ConnectAsUser=$true;")
-                # Omit domain part of username
-                sqlConnection.append("$con.ConnectAsUserName='{0}';".format(sqlusername.split("\\")[-1]))
-                sqlConnection.append('$con.ConnectAsUserPassword="$p";')
-            else:
-                sqlConnection.append("$con.Connect();")
-
-            # Connect to Database Server
-            sqlConnection.append("$server = new-object "
-                                 "('Microsoft.SqlServer.Management.Smo.Server') $con;")
+            sql_version = int(om_instance.sql_server_version.split('.')[0])
+            sqlConnection = SqlConnection(sqlserver, sqlusername, sqlpassword, login_as_user, sql_version).sqlConnection
+            self.log.info(''.join(sqlConnection))
 
             db_sqlConnection = []
             # Get database information

--- a/docs/body.md
+++ b/docs/body.md
@@ -1068,7 +1068,8 @@ important.
         Fill in the user and password to use SQL authentication. Leave the user
         and password blank to use Windows authentication. The default
         *MSSQLSERVER* credentials will be used for all instances not
-        specified.
+        specified.  Microsoft recommends using Windows authentication to
+        connect to SQL Server.
 
 -   zWinRMEnvelopeSize
     :   This property is used when the winrm configuration
@@ -1136,8 +1137,8 @@ Supported SQL Server versions
 Note: In order to properly monitor SQL Server, the Client Tools SDK must be installed for each version of SQL Server installed on your Windows servers.
 
 ##### Support for SQL Server and Windows Authentication: 
-*   Windows Authentication: In *zDBInstances* property specify only SQL instances names, leave user and password fields blank. 
-*   SQL Server Authentication: In *zDBInstances* property provide user name and password for each SQL instance. 
+*   Windows Authentication: In *zDBInstances* property specify only SQL instances names, leave user and password fields blank.  Microsoft prefers this authentication method.
+*   SQL Server Authentication: In *zDBInstances* property provide user name and password for each SQL instance.
 *   Specifying authentication per instance is no longer required with version 2.4.2 and above. We will use the credentials specified for the MSSQLSERVER instance by default.
 *   For instances which contain hundreds of databases, you may need to increase zCollectorClientTimeout as this process may take a few minutes or more to complete.
 


### PR DESCRIPTION
Fixes ZPS-3392

By using SSPI for Windows Authentication, we can avoid passing in the windows user password altogether.  Also it will cut down on the number of logons/logoffs when getting job/db properties.  we'll recommend using windows auth in readme because Microsoft does also.  centralize the connection part of the script because it's used in modeler plugin and shell datasource.