### PR TITLE
fix uninitialized local variable

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
@@ -393,7 +393,7 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
                 PERSISTER.add_event(self.config.id, self.config.datasources, {
                     'device': self.config.id,
                     'eventClass': '/Status/Winrm',
-                    'eventKey': 'Windows Perfmon Collection Error',
+                    'eventKey': 'WindowsPerfmonCollection',
                     'severity': ZenEventClasses.Warning,
                     'summary': errorMessage,
                     'ipAddress': self.config.manageIp})
@@ -406,18 +406,27 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
             if success:
                 self.state = PluginStates.STARTED
             else:
-                LOG.warn("%s: Perfmon command(s) did not start: %s", self.config.id, data.value)
+                errorMessage = 'Perfmon command(s) did not start'
+                LOG.warn("%s: %s: %s", self.config.id, errorMessage, data.value)
                 if not errorMsgCheck(self.config, PERSISTER.get_events(self.config.id), data.value.message):
                     PERSISTER.add_event(self.config.id, self.config.datasources, {
                         'device': self.config.id,
                         'eventClass': '/Status/Winrm',
-                        'eventKey': 'WindowsPerfmonCollection Error',
+                        'eventKey': 'WindowsPerfmonCollection',
                         'severity': ZenEventClasses.Warning,
-                        'summary': errorMessage,
+                        'summary': errorMessage + ': ' + data.value.message,
                         'ipAddress': self.config.manageIp})
 
         if self.state != PluginStates.STARTED:
             self.state = PluginStates.STOPPED
+        else:
+            PERSISTER.add_event(self.config.id, self.config.datasources, {
+                'device': self.config.id,
+                'eventClass': '/Status/Winrm',
+                'eventKey': 'WindowsPerfmonCollection',
+                'severity': ZenEventClasses.Clear,
+                'summary': 'successfully started Get-Counter command(s)',
+                'ipAddress': self.config.manageIp})
         self.collected_samples = 0
         self.collected_counters = set()
 
@@ -657,7 +666,7 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
         PERSISTER.add_event(self.config.id, self.config.datasources, {
             'device': self.config.id,
             'eventClass': '/Status/Winrm',
-            'eventKey': 'Windows Perfmon Collection Error',
+            'eventKey': 'WindowsPerfmonCollection',
             'severity': ZenEventClasses.Clear,
             'summary': 'Successful Perfmon Collection',
             'ipAddress': self.config.manageIp})

--- a/docs/body.md
+++ b/docs/body.md
@@ -1822,6 +1822,7 @@ Changes
 -   Fix MSSQL Monitoring causes thousands of logon/logoff events in windows event log (ZPS-3392)
 -   Fix Potential ticket expiry during collection causes collection issue (ZPS-3216)
 -   Fix Windows device fails to monitor performance counters, generating several log messages per second. (ZPS-3377)
+-   Fix Windows Perfmon data collection stops for long time after device reboot (ZPS-3997)
 
 2.9.0
 


### PR DESCRIPTION
Fixes ZPS-3997

errorMessage was uninitialized, causing an errback and self.state was never changed to STOPPED.  state was stuck in the STARTING state and could never be brought out of it due to this.  updated event summary and sending clear events now