### PR TITLE
future proof counters2012 query

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/Interfaces.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/Interfaces.py
@@ -117,7 +117,8 @@ class Interfaces(WinRMPlugin):
             "$_.teamname, '|'};"
         ),
         'counters2012': (
-            ' '.join('''$ver2012 = (Get-WmiObject win32_OperatingSystem).Name -like '*2012*';
+            ' '.join('''$v = (Get-WmiObject win32_OperatingSystem).Version.split('.');
+            $ver2012 = [int]$v[0] -gt 6 -or [int]$v[1] -gt 1;
             function replace_unallowed($s)
             {$s.replace('(', '[').replace(')', ']').replace('#', '_').replace('\\', '_').replace('/', '_').toLower()}
             if($ver2012){


### PR DESCRIPTION
Fixes ZPS-3902

we should look at the version info, not just the name.  we now have server 2016.  next will be 2020, etc.