### PR TITLE
allow same device to have multiple cycletimes for counters

### DIFF
--- a/docs/body.md
+++ b/docs/body.md
@@ -1824,6 +1824,7 @@ Changes
 -   Fix Windows device fails to monitor performance counters, generating several log messages per second. (ZPS-3377)
 -   Fix Windows Perfmon data collection stops for long time after device reboot (ZPS-3997)
 -   Fix Microsoft.Windows - wrong counter name for 2016 network interfaces (ZPS-3902)
+-   Fix WinRM monitoring not properly respecting zWinPerfmonInterval (ZPS-3581)
 
 2.9.0
 


### PR DESCRIPTION
Fixes ZPS-3581

for any given device or device class, if zWinPerfmonInterval is different for one or more perfmon datasources, then data is popped off the persister before it's ready and will not populate the db correctly.  we can create a unique id to store data using the device id and cycle time so that all the data is returned correctly