### PR TITLE
"Time" graph for File Systems and Hard Disks is confusing

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/device_classes.yaml
+++ b/ZenPacks/zenoss/Microsoft/Windows/device_classes.yaml
@@ -1985,7 +1985,7 @@ device_classes:
               Write:
                 dpName: DiskWriteBytesSec_DiskWriteBytesSec
                 format: '%7.2lf%s'
-          Time:
+          Average Disk Queue Length Percentage:
             units: percent
             miny: 0
             graphpoints:
@@ -3337,7 +3337,7 @@ device_classes:
               Write:
                 dpName: DiskWriteBytesSec_DiskWriteBytesSec
                 format: '%7.2lf%s'
-          Time:
+          Average Disk Queue Length Percentage:
             units: percent
             miny: 0
             graphpoints:


### PR DESCRIPTION
[ZPS-2152](https://jira.zenoss.com/browse/ZPS-2152?filter=-1&jql=resolution%20%3D%20Unresolved%20AND%20assignee%20in%20(currentUser())%20order%20by%20updated%20DESC)

**Issue:** Windows - "Time" graph for File Systems and Hard Disks is confusing

**Comment:** Works for me after reinstalling the zenpack

![screenshot at aug 08 18-44-29](https://user-images.githubusercontent.com/40885776/43848196-1cbdae7a-9b3b-11e8-96fd-3c6aae592ca4.png)

