### PR TITLE
raise event for possible powershell config issue

### DIFF
--- a/docs/body.md
+++ b/docs/body.md
@@ -1745,6 +1745,23 @@ example:
 winrm set winrm/config/service '@{MaxConcurrentOperationsPerUser="4294967295"}'
 ```
 
+### Troubleshooting Perfmon Collection
+
+If you see errors containing text similar to "The term 'New-Object' is not
+recognized as the name of a cmdlet, function, script file, or operable program",
+this could indicate a problem with the loading of Powershell modules. Zenoss
+uses common best practice to execute powershell scripts with the
+[-NoProfile](http://www.powertheshell.com/bp_noprofile/) option for efficency.
+Powershell will fall back on the default system PSModulePath in this case.
+You must ensure that the default PSModulePath environment variable is valid.
+
+One common problem seen is a UNC (Universal Naming Convention) path in the default
+system PSModulePath.  If there is a UNC path in the default system path, no
+modules will load due to [double-hopping](https://blogs.msdn.microsoft.com/knowledgecast/2007/01/31/the-double-hop-problem/).
+Because no modules were loaded, even the most basic powershell cmdlets will not run.
+To fix this, simply remove the UNC path from the default system PSModulePath
+environment variable.
+
 ## Zenoss Analytics
 
 This ZenPack provides additional support for Zenoss Analytics. Perform
@@ -1881,6 +1898,7 @@ Changes
 -   Fix Microsoft.Windows - wrong counter name for 2016 network interfaces (ZPS-3902)
 -   Fix WinRM monitoring not properly respecting zWinPerfmonInterval (ZPS-3581)
 -   Fix GetWinEvent error message formatting (ZPS-3484)
+-   Fix Better handling in Perfmon datasource of "is not recognized as the name of a cmdlet" errors (ZPS-3517)
 
 2.9.0
 


### PR DESCRIPTION
Fixes ZPS-3517

if the PSModulePath is wrong or contains a UNC path, powershell modules could fail to load and we'd see errors about simple powershell cmdlets not working.  this will raise an event giving user info to be sure their path is right.  also documented this in a troubleshooting section