### PR TITLE
do not restart() on receiveFail

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
@@ -705,11 +705,11 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
             generateClearAuthEvents(self.config, PERSISTER.get_events(self.unique_id))
         # Handle errors on which we should retry the receive.
         if 'OperationTimeout' in e.message:
-            retry, level, msg = (
-                True,
-                logging.DEBUG,
-                "OperationTimeout on {}.  This timeout is expected when zWinPerfmonInterval is >= 60s."
-                .format(self.config.id))
+            # do not log operation timeout message.  it implies there's some sort of problem.
+            # we expect to see this timeout during default zWinPerfmonInterval time (300)
+            # it only adds confusion to troubleshooters.  we'll just retry and return
+            self.receive()
+            defer.returnValue(None)
 
         elif isinstance(e, ConnectError):
             retry, level, msg = (
@@ -724,6 +724,15 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
             level = logging.WARN
             if send_to_debug(failure):
                 level = logging.DEBUG
+            elif isinstance(e, AttributeError) and \
+                "'NoneType' object has no attribute 'persistent'" in e.message:
+                level = logging.DEBUG
+                e = 'Attempted to receive from closed connection.  Possibly due'\
+                    'to device reboot.'
+            elif 'invalid selectors for the resource' in e.message:
+                level = logging.DEBUG
+                e = 'Attempted to use a non-existent remote shell.  Possibly due'\
+                    'to device reboot.'
             retry, msg = (
                 False,
                 "receive failure on {}: {}"
@@ -736,10 +745,9 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
         if self.network_failures >= MAX_NETWORK_FAILURES:
             yield self.stop()
             self.reset()
+            retry = False
         if retry:
             self.receive()
-        else:
-            yield self.restart()
 
         defer.returnValue(None)
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -3,26 +3,26 @@ Releases
 --------
 
 Version 2.9.0- <a class="external" href="http://wiki.zenoss.org/download/zenpacks/ZenPacks.zenoss.Microsoft.Windows/2.9.0/ZenPacks.zenoss.Microsoft.Windows-2.9.0.egg" rel="nofollow">Download</a>
-:Released on 2018/03/06
-:Requires <a href="/product/zenpacks/pythoncollector" title="ZenPack:PythonCollector">PythonCollector ZenPack</a>, <a href="/product/zenpacks/zenpacklib" title="ZenPack:ZenPackLib">ZenPackLib ZenPack</a>
-:Compatible with Zenoss Core 4.2.x, Zenoss Core 5.0.x, Zenoss Core 5.1.x, Zenoss Core 5.2.x, Zenoss Core 5.3.x, Zenoss Core 6.1.x, Zenoss Resource Manager 4.2.x, Zenoss Resource Manager 5.0.x, Zenoss Resource Manager 5.1.x, Zenoss Resource Manager 5.2.x, Zenoss Resource Manager 5.3.x, Zenoss Resource Manager 6.1.x
+:   Released on 2018/03/06
+:   Requires <a href="/product/zenpacks/pythoncollector" title="ZenPack:PythonCollector">PythonCollector ZenPack</a>, <a href="/product/zenpacks/zenpacklib" title="ZenPack:ZenPackLib">ZenPackLib ZenPack</a>
+:   Compatible with Zenoss Core 4.2.x, Zenoss Core 5.0.x, Zenoss Core 5.1.x, Zenoss Core 5.2.x, Zenoss Core 5.3.x, Zenoss Core 6.1.x, Zenoss Resource Manager 4.2.x, Zenoss Resource Manager 5.0.x, Zenoss Resource Manager 5.1.x, Zenoss Resource Manager 5.2.x, Zenoss Resource Manager 5.3.x, Zenoss Resource Manager 6.1.x
 
 Version 2.8.3- <a class="external" href="http://wiki.zenoss.org/download/zenpacks/ZenPacks.zenoss.Microsoft.Windows/2.8.3/ZenPacks.zenoss.Microsoft.Windows-2.8.3.egg" rel="nofollow">Download</a>
-:Released on 2017/12/13
-:Requires <a href="/product/zenpacks/pythoncollector" title="ZenPack:PythonCollector">PythonCollector ZenPack</a>, <a href="/product/zenpacks/zenpacklib" title="ZenPack:ZenPackLib">ZenPackLib ZenPack</a>
-:Compatible with Zenoss Core 4.2.x, Zenoss Core 5.0.x, Zenoss Core 5.1.x, Zenoss Core 5.2.x, Zenoss Core 5.3.x, Zenoss Resource Manager 4.2.x, Zenoss Resource Manager 5.0.x, Zenoss Resource Manager 5.1.x, Zenoss Resource Manager 5.2.x, Zenoss Resource Manager 5.3.x
+:   Released on 2017/12/13
+:   Requires <a href="/product/zenpacks/pythoncollector" title="ZenPack:PythonCollector">PythonCollector ZenPack</a>, <a href="/product/zenpacks/zenpacklib" title="ZenPack:ZenPackLib">ZenPackLib ZenPack</a>
+:   Compatible with Zenoss Core 4.2.x, Zenoss Core 5.0.x, Zenoss Core 5.1.x, Zenoss Core 5.2.x, Zenoss Core 5.3.x, Zenoss Resource Manager 4.2.x, Zenoss Resource Manager 5.0.x, Zenoss Resource Manager 5.1.x, Zenoss Resource Manager 5.2.x, Zenoss Resource Manager 5.3.x
 
 Version 2.7.8- <a class="external" href="http://wiki.zenoss.org/download/zenpacks/ZenPacks.zenoss.Microsoft.Windows/2.7.8/ZenPacks.zenoss.Microsoft.Windows-2.7.8.egg" rel="nofollow">Download</a>
-:Released on 2017/06/29
-:Requires <a href="/product/zenpacks/pythoncollector" title="ZenPack:PythonCollector">PythonCollector ZenPack</a>, <a href="/product/zenpacks/zenpacklib" title="ZenPack:ZenPackLib">ZenPackLib ZenPack</a>
-:Compatible with Zenoss Core 4.2.x, Zenoss Core 5.0.x, Zenoss Core 5.1.x, Zenoss Core 5.2.x, Zenoss Resource Manager 4.2.x, Zenoss Resource Manager 5.0.x, Zenoss Resource Manager 5.1.x, Zenoss Resource Manager 5.2.x
+:   Released on 2017/06/29
+:   Requires <a href="/product/zenpacks/pythoncollector" title="ZenPack:PythonCollector">PythonCollector ZenPack</a>, <a href="/product/zenpacks/zenpacklib" title="ZenPack:ZenPackLib">ZenPackLib ZenPack</a>
+:   Compatible with Zenoss Core 4.2.x, Zenoss Core 5.0.x, Zenoss Core 5.1.x, Zenoss Core 5.2.x, Zenoss Resource Manager 4.2.x, Zenoss Resource Manager 5.0.x, Zenoss Resource Manager 5.1.x, Zenoss Resource Manager 5.2.x
 
 Version 2.6.12- <a class="external" href="http://wiki.zenoss.org/download/zenpacks/ZenPacks.zenoss.Microsoft.Windows/2.6.12/ZenPacks.zenoss.Microsoft.Windows-2.6.12.egg" rel="nofollow">Download</a>
-:Released on 2017/01/31
-:Requires <a href="/product/zenpacks/pythoncollector" title="ZenPack:PythonCollector">PythonCollector ZenPack</a>
-:Compatible with Zenoss Core 4.2.x, Zenoss Core 5.0.x, Zenoss Core 5.1.x, Zenoss Core 5.2.x, Zenoss Resource Manager 4.2.x, Zenoss Resource Manager 5.0.x, Zenoss Resource Manager 5.1.x, Zenoss Resource Manager 5.2.x
+:   Released on 2017/01/31
+:   Requires <a href="/product/zenpacks/pythoncollector" title="ZenPack:PythonCollector">PythonCollector ZenPack</a>
+:   Compatible with Zenoss Core 4.2.x, Zenoss Core 5.0.x, Zenoss Core 5.1.x, Zenoss Core 5.2.x, Zenoss Resource Manager 4.2.x, Zenoss Resource Manager 5.0.x, Zenoss Resource Manager 5.1.x, Zenoss Resource Manager 5.2.x
 
 Version 2.5.13- <a class="external" href="http://wiki.zenoss.org/download/zenpacks/ZenPacks.zenoss.Microsoft.Windows/2.5.13/ZenPacks.zenoss.Microsoft.Windows-2.5.13.egg" rel="nofollow">Download</a>
-:Released on 2016/05/10
-:Requires <a href="/product/zenpacks/pythoncollector" title="ZenPack:PythonCollector">PythonCollector ZenPack</a>
-:Compatible with Zenoss Core 4.2.x, Zenoss Core 5.0.x, Zenoss Core 5.1.x, Zenoss Core 5.2.x, Zenoss Resource Manager 4.2.x, Zenoss Resource Manager 5.0.x, Zenoss Resource Manager 5.1.x, Zenoss Resource Manager 5.2.x
+:   Released on 2016/05/10
+:   Requires <a href="/product/zenpacks/pythoncollector" title="ZenPack:PythonCollector">PythonCollector ZenPack</a>
+:   Compatible with Zenoss Core 4.2.x, Zenoss Core 5.0.x, Zenoss Core 5.1.x, Zenoss Core 5.2.x, Zenoss Resource Manager 4.2.x, Zenoss Resource Manager 5.0.x, Zenoss Resource Manager 5.1.x, Zenoss Resource Manager 5.2.x


### PR DESCRIPTION
Fixes ZPS-3377

when receive fails on a device reboot, we were restarting the entire process.  this is unnecessary and the reason we see tons of error messages.  we will just wait until the next cycle to start collection over.  handling certain error messages and sending them to debug with an explanation that they are possibly due to a device reboot.

updated releases sections for proper formatting of releases