### PR TITLE
add owner_node_ip property to sql instance

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
@@ -740,10 +740,12 @@ class ShellDataSourcePlugin(PythonDataSourcePlugin):
         owner_node_ip = None
         if hasattr(context, 'cluster_node_server'):
             owner_node, _ = context.cluster_node_server.split('//')
-            try:
-                owner_node_ip = context.device().clusterhostdevicesdict.get(owner_node, None)
-            except Exception:
-                pass
+            owner_node_ip = getattr(context, 'owner_node_ip', None)
+            if not owner_node_ip:
+                try:
+                    owner_node_ip = context.device().clusterhostdevicesdict.get(owner_node, None)
+                except Exception:
+                    pass
 
         try:
             contextURL = context.getPrimaryUrlPath()

--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinMSSQL.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinMSSQL.py
@@ -214,6 +214,7 @@ class WinMSSQL(WinRMPlugin):
         device_om.sqlhostname = sqlhostname
         for instance, version in server_config['instances'].items():
             owner_node = ''  # Leave empty for local databases.
+            ip_address = None # Leave empty for local databases.
             # For cluster device, create a new a connection to each node,
             # which owns network instances.
             if isCluster:
@@ -262,6 +263,8 @@ class WinMSSQL(WinRMPlugin):
             om_instance.sql_server_version = version
             om_instance.cluster_node_server = '{0}//{1}'.format(
                 owner_node, sqlserver)
+            om_instance.owner_node_ip = ip_address
+
             instance_oms.append(om_instance)
 
             # Look for specific instance creds first

--- a/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
+++ b/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
@@ -782,6 +782,8 @@ classes:
         label: Cluster Node Server
       perfmon_instance:
         label: Perfmon Counter Instance Name
+      owner_node_ip:
+        display: false
     monitoring_templates: [WinDBInstance]
     impacts: [backups, databases, jobs]
     impacted_by: [device]

--- a/docs/body.md
+++ b/docs/body.md
@@ -1908,6 +1908,7 @@ Changes
 -   Fix GetWinEvent error message formatting (ZPS-3484)
 -   Fix IIS Application Pool states (ZPS-3629)
 -   Fix Better handling in Perfmon datasource of "is not recognized as the name of a cmdlet" errors (ZPS-3517)
+-   Fix Windows - error regarding missing ipaddress is generated in zenpython log for cluster device (ZPS-4184)
 -   Add support for SQL Server 2017
 
 2.9.0


### PR DESCRIPTION
Fixes ZPS-4184

Since we are grabbing the ip address of the instance, we should also store it in case we can't auto-discover the node.