### PR TITLE
allow cluster datasource to run longer

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinCluster.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinCluster.py
@@ -20,7 +20,7 @@ from Products.DataCollector.plugins.DataMaps import ObjectMap, RelationshipMap
 from ZenPacks.zenoss.Microsoft.Windows.modeler.WinRMPlugin import WinRMPlugin
 from ZenPacks.zenoss.Microsoft.Windows.utils import addLocalLibPath
 from Products.ZenUtils.IpUtil import asyncIpLookup
-from ZenPacks.zenoss.Microsoft.Windows.utils import sizeof_fmt, pipejoin, save
+from ZenPacks.zenoss.Microsoft.Windows.utils import pipejoin, save
 
 from txwinrm.WinRMClient import SingleCommandClient
 
@@ -62,6 +62,7 @@ class WinCluster(WinRMPlugin):
         maps = {}
 
         conn_info = self.conn_info(device)
+        conn_info = conn_info._replace(timeout=device.zCollectorClientTimeout - 5)
         cmd = ClusterCommander(conn_info)
 
         domain = yield cmd.run_command("(gwmi WIN32_ComputerSystem).Domain;")

--- a/docs/body.md
+++ b/docs/body.md
@@ -1909,6 +1909,7 @@ Changes
 -   Fix IIS Application Pool states (ZPS-3629)
 -   Fix Better handling in Perfmon datasource of "is not recognized as the name of a cmdlet" errors (ZPS-3517)
 -   Fix Windows - error regarding missing ipaddress is generated in zenpython log for cluster device (ZPS-4184)
+-   Fix WinCluster plugin does not honor zCollectorClientTimeout , always times out requests after 60 seconds (ZPS-4272)
 -   Add support for SQL Server 2017
 
 2.9.0


### PR DESCRIPTION
Fixes ZPS-4272

customer cluster modeling was taking longer than 60s so allow the timeout to be increased