### PR TITLE
do not monitor individual NICs in a team

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/Interfaces.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/Interfaces.py
@@ -310,6 +310,7 @@ class Interfaces(WinRMPlugin):
                 int_om.speed = int(inter.Speed)
             else:
                 int_om.speed = 0
+                int_om.monitor = False
 
             int_om.duplex = 0
             int_om.type = inter.AdapterType
@@ -329,7 +330,7 @@ class Interfaces(WinRMPlugin):
                 # Workaround for 2003 / XP
                 if inter.NetConnectionStatus in ENABLED_NC_STATUSES:
                     int_om.adminStatus = 1
-            
+
             int_om.operStatus = AVAILABILITY.get(inter.Availability, 0)
 
             try:

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testInterfaces.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testInterfaces.py
@@ -100,9 +100,18 @@ class TestTeamInterfaces(BaseTestCase):
         self.results = load_pickle_file(self, 'Interfaces_process_184038')[0]
         data = self.plugin.process(self.device, self.results, Mock())
         self.assertEquals(data.maps[7].perfmonInstance, "\\Network Interface(HP NC382i DP Multifunction Gigabit Server Adapter)")
+        self.assertFalse(data.maps[7].monitor)
+        self.assertEquals(data.maps[7].speed, 0)
         self.assertEquals(data.maps[8].perfmonInstance, "\\Network Interface(HP NC382i DP Multifunction Gigabit Server Adapter _2)")
+        self.assertFalse(data.maps[8].monitor)
+        self.assertEquals(data.maps[8].speed, 0)
+        self.assertEquals(data.maps[12].speed, 1000000000)
         self.assertEquals(data.maps[13].perfmonInstance, "\\Network Interface(HP NC382i DP Multifunction Gigabit Server Adapter#1)")
+        self.assertFalse(data.maps[13].monitor)
+        self.assertEquals(data.maps[13].speed, 0)
         self.assertEquals(data.maps[14].perfmonInstance, "\\Network Interface(HP NC382i DP Multifunction Gigabit Server Adapter _2#1)")
+        self.assertFalse(data.maps[14].monitor)
+        self.assertEquals(data.maps[14].speed, 0)
         self.results = load_pickle_file(self, 'Interfaces_process_184151')[0]
         data = self.plugin.process(self.device, self.results, Mock())
         self.assertEquals(data.maps[7].perfmonInstance, "\\Network Interface(HP NC382i DP Multifunction Gigabit Server Adapter)")

--- a/docs/body.md
+++ b/docs/body.md
@@ -1414,6 +1414,8 @@ The current release is known to have the following limitations.
     them from your Cluster device:  Interfaces/WindowsInterfaces, 
     FileSystems, Processors, Services/Windows Services, Processes.
 -   Support for team NICs is limited to Intel and Broadcom interfaces.
+-   Individual NICs in a team are not monitored and will have a speed of 0.
+    Monitoring them could cause threshold error events.
 -   The custom widget for MSSQL Server credentials is not compatible
     with Zenoss 4.1.x, therefore the *zDBInstances* property in this
     version should be set as a valid JSON list (e.g. *[{"instance":
@@ -1910,6 +1912,7 @@ Changes
 -   Fix Better handling in Perfmon datasource of "is not recognized as the name of a cmdlet" errors (ZPS-3517)
 -   Fix Windows - error regarding missing ipaddress is generated in zenpython log for cluster device (ZPS-4184)
 -   Fix WinCluster plugin does not honor zCollectorClientTimeout , always times out requests after 60 seconds (ZPS-4272)
+-   Fix Teamed NIC speed not modeled on individual adapters (ZPS-4149)
 -   Add support for SQL Server 2017
 
 2.9.0


### PR DESCRIPTION
Fixes ZPS-4149

no TeamName option was set on the adapter so we were unaware these were teamed.  if Speed is None, then we won't monitor them.  Updated unit test to account for this