### PR TITLE
remove unnecessary append

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/Device.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/Device.py
@@ -63,7 +63,6 @@ class Device(schema.Device):
                 cluster.title = clusterdnsname
                 cluster.setPerformanceMonitor(self.getPerformanceServerName())
                 # Transfer settings to newly created cluster device
-                cluster.zCollectorPlugins.append('zenoss.winrm.WinCluster')
                 cluster.setZenProperty('zWinRMUser', self.zWinRMUser)
                 cluster.setZenProperty('zWinRMPassword', self.zWinRMPassword)
                 cluster.setZenProperty('zWinRMPort', self.zWinRMPort)

--- a/ZenPacks/zenoss/Microsoft/Windows/migrate/RemoveExtraClusterPlugins.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/migrate/RemoveExtraClusterPlugins.py
@@ -1,0 +1,42 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2018, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+import logging
+from Products.ZenModel.ZenPack import ZenPackMigration
+from Products.ZenModel.migrate.Migrate import Version
+
+log = logging.getLogger('zen.Microsoft.Windows')
+
+
+class RemoveExtraClusterPlugins(ZenPackMigration):
+    # Main class that contains the migrate() method.
+    # Note version setting.
+    version = Version(2, 9, 1)
+
+    def get_objects(self, dmd):
+        for ob in dmd.Devices.Server.Microsoft.Cluster.getSubOrganizers() +\
+                dmd.Devices.Server.Microsoft.Cluster.getSubDevices():
+            yield ob
+
+    def migrate(self, dmd):
+        for ob in self.get_objects(dmd):
+            self.remove_extra(ob)
+
+    def remove_extra(self, thing):
+        """Removes extra occurrences of WinCluster in zCollectorPlugins"""
+
+        if not hasattr(thing, 'zCollectorPlugins'):
+            return
+
+        if not thing.isLocal('zCollectorPlugins'):
+            return
+
+        zCollectorPlugins = thing.zCollectorPlugins
+        if zCollectorPlugins.count('zenoss.winrm.WinCluster') > 1:
+            thing.setZenProperty('zCollectorPlugins', list(set(zCollectorPlugins)))

--- a/docs/body.md
+++ b/docs/body.md
@@ -1913,6 +1913,7 @@ Changes
 -   Fix Windows - error regarding missing ipaddress is generated in zenpython log for cluster device (ZPS-4184)
 -   Fix WinCluster plugin does not honor zCollectorClientTimeout , always times out requests after 60 seconds (ZPS-4272)
 -   Fix Teamed NIC speed not modeled on individual adapters (ZPS-4149)
+-   Fix Modeling errors caused by multiple 'zenoss.winrm.WinCluster' in zCollectorPlugins (ZPS-4300)
 -   Add support for SQL Server 2017
 
 2.9.0


### PR DESCRIPTION
Fixes ZPS-4300

Remove the unnecessary append of the WinCluster plugin to the zCollectorPlugins property.  Devices in the cluster class already will be using this plugin.  added a migrate script to remove extra ones already added.