### PR TITLE
make sure service id matches correctly

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ServiceDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ServiceDataSource.py
@@ -330,11 +330,12 @@ class ServicePlugin(PythonDataSourcePlugin):
         services = self.buildServicesDict(config.datasources)
         timestamp = int(time.mktime(time.localtime()))
         for index, svc_info in enumerate(serviceinfo):
-            if svc_info.Name not in services.keys():
+            svc_info_name = prepId(svc_info.Name)
+            if svc_info_name not in services.keys():
                 continue
 
             severity = ZenEventClasses.Clear
-            service = services[svc_info.Name]
+            service = services[svc_info_name]
 
             if svc_info.State not in [alertifnot.strip() for alertifnot in service['alertifnot'].split(',')]:
                 evtmsg = 'Service Alert: {0} has changed to {1} state'.format(
@@ -349,22 +350,22 @@ class ServicePlugin(PythonDataSourcePlugin):
                 )
 
             if svc_info.State.lower() == STATE_RUNNING.lower():
-                data['values'][svc_info.Name]['state'] = (0, timestamp)
+                data['values'][svc_info_name]['state'] = (0, timestamp)
             elif svc_info.State.lower() == STATE_STOPPED.lower():
-                data['values'][svc_info.Name]['state'] = (1, timestamp)
+                data['values'][svc_info_name]['state'] = (1, timestamp)
             elif svc_info.State.lower() == STATE_PAUSED.lower():
-                data['values'][svc_info.Name]['state'] = (2, timestamp)
+                data['values'][svc_info_name]['state'] = (2, timestamp)
 
             # event for the service
             data['events'].append({
-                'service_name': svc_info.Name,
+                'service_name': svc_info_name,
                 'service_state': svc_info.State,
                 'service_status': svc_info.Status,
                 'eventClass': "/Status/WinService",
                 'eventKey': "WindowsService",
                 'severity': severity,
                 'summary': evtmsg,
-                'component': prepId(svc_info.Name),
+                'component': svc_info_name,
                 'device': config.id,
             })
 

--- a/docs/body.md
+++ b/docs/body.md
@@ -1602,6 +1602,12 @@ domain should fix this problem. It is a known error from Microsoft,
 
 -   You should also ensure that the correct name is returned for lookups.
 
+-   If you see "Attempted to get ticket for HTTP@X.X.X.X" where X.X.X.X is an ip
+    address, then try using the [zWinRMServerName](#configuration-options).
+    To know the exact name by which Active Directory knows this device, you can use
+    `setspn -L <hostname>`.  This will produce a list of service principals with the
+    FQDN of the device.
+
 `Preauthentication failed while getting initial credentials.`
 
 -   This typically indicates a bad or expired password.
@@ -1914,6 +1920,7 @@ Changes
 -   Fix WinCluster plugin does not honor zCollectorClientTimeout , always times out requests after 60 seconds (ZPS-4272)
 -   Fix Teamed NIC speed not modeled on individual adapters (ZPS-4149)
 -   Fix Modeling errors caused by multiple 'zenoss.winrm.WinCluster' in zCollectorPlugins (ZPS-4300)
+-   Fix Windows services with certain characters are always in 'unknown' state. (ZPS-3424)
 -   Add support for SQL Server 2017
 
 2.9.0


### PR DESCRIPTION
Fixes ZPS-3424

need to use prepId to make sure that the service name and id match correctly.  also added a blurb to krb troubleshooting about spns.