### PR TITLE
revert change that sends maps to zenhub from perfmon

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/BaseDevice.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/BaseDevice.py
@@ -13,7 +13,6 @@ Utilities that may cause Zope stuff to be imported.
 from . import schema
 
 from Products.ZenUtils.ZenTales import talesEvalStr
-from Products.Zuul import getFacade
 
 
 class BaseDevice(schema.BaseDevice):
@@ -84,27 +83,3 @@ class BaseDevice(schema.BaseDevice):
 
         disable_rdns = org.getProperty('zWinRMKrb5DisableRDNS') or False
         return disable_rdns
-
-    def getClearEvents(self):
-        self.clear_events()
-        return True
-
-    def setClearEvents(self, value):
-        self.clear_events()
-
-    def clear_events(self):
-        zep = getFacade('zep')
-        zep_filter = zep.createEventFilter(
-            element_identifier=(self.id),
-            severity=[4],
-            status=(0, 1),
-            event_class='/Status/OSProcess'
-        )
-        results = zep.getEventSummariesGenerator(filter=zep_filter)
-
-        component_list = [x.getObject().id for x in self.componentSearch()]
-        for res in results:
-            key = res['occurrence'][0]['actor'].get('element_sub_identifier')
-            if key and key not in component_list:
-                del_filter = zep.createEventFilter(uuid=res['uuid'])
-                zep.closeEventSummaries(eventFilter=del_filter)

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
@@ -27,7 +27,6 @@ from twisted.internet.task import LoopingCall
 from zope.component import adapts, queryUtility
 from zope.interface import implements
 
-from Products.DataCollector.plugins.DataMaps import ObjectMap
 from Products.ZenCollector.interfaces import ICollectorPreferences
 from Products.ZenEvents import ZenEventClasses
 from Products.Zuul.form import schema
@@ -375,18 +374,6 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
 
         data = yield self.get_data()
         defer.returnValue(data)
-
-    def onSuccess(self, result, config):
-        """Called only on success. After onResult, before onComplete."""
-
-        if result and 'maps' in result:
-            # Clear non-existing component events
-            result['maps'].append(ObjectMap({
-                "modname": "Clear events",
-                "setClearEvents": True,
-            }))
-
-        return result
 
     @coroutine
     def start(self):

--- a/docs/body.md
+++ b/docs/body.md
@@ -1901,6 +1901,10 @@ Monitoring Templates
 Changes
 -------
 
+2.9.2
+
+-   Fix applyDataMaps call for onSuccess method destabilizing zenhub (ZPS-4422)
+
 2.9.1
 
 -   Fix Misleading Error when parsing MSSQL status datasource on different cycle than other database datasources (ZPS-3194)


### PR DESCRIPTION
Fixes ZPS-4422

we should not be sending maps that will slow down the system this way.  perhaps a simple datasource that will perform this operation instead.

reverting this PR:  https://github.com/zenoss/ZenPacks.zenoss.Microsoft.Windows/pull/1035