### PR TITLE
attempt to stop and reset on receive failures

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
@@ -748,6 +748,9 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
             retry = False
         if retry:
             self.receive()
+        else:
+            yield self.stop()
+            self.reset()
 
         defer.returnValue(None)
 

--- a/docs/body.md
+++ b/docs/body.md
@@ -1901,6 +1901,9 @@ Monitoring Templates
 Changes
 -------
 
+2.9.3
+
+-   Windows Perfmon data collection stops for long time after device reboot (ZPS-4473)
 2.9.2
 
 -   Fix applyDataMaps call for onSuccess method destabilizing zenhub (ZPS-4422)


### PR DESCRIPTION
Fixes ZPS-4473

if we are failing to receive, this can be due to many factors.  could be a simple OperationTimeout, which means counters have not reported, so we will retry.  on a timeout error we should retry to receive.  anything else we will try to stop the command and reset ourselves into a better state.