### PR TITLE
use ping to get ip address of owner node

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinMSSQL.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinMSSQL.py
@@ -86,7 +86,8 @@ class SQLCommander(object):
             | Group ClusterObject | Select
             @{Name='SQLInstance';Expression={($_.Group | select -expandproperty Value) -join '\\'}},
             @{Name='OwnerNode';Expression={($ownernode, $domain) -join '.'}},
-            @{Name='IPv4';Expression={(Test-Connection $ownernode -count 1 -erroraction ignore).IPV4Address.ipaddresstostring}}};
+            @{Name='IPv4';Expression={[regex]::match((ping -4 -a -n 1 $ownernode|
+            select-string 'Pinging').ToString(), '(\\b\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\b)').value}}};
         $cluster_instances | % {write-host \"instances:\"($_).OwnerNode\($_).IPv4\($_).SQLInstance};
     '''
 

--- a/docs/body.md
+++ b/docs/body.md
@@ -1907,6 +1907,7 @@ Changes
 -   Windows - No freespace on cluster shared volumes (ZPS-4612)
 -   Fix Better handling in Perfmon datasource of "is not recognized as the name of a cmdlet" errors (ZPS-3517)
 -   Fix 500 Operation Timeout Errors when modeling and/or monitoring SQL Server (ZPS-4638)
+-   Fix Windows Cluster - wrong ip address can be returned for sql server node (ZPS-4703)
 
 2.9.2
 


### PR DESCRIPTION
Fixes ZPS-4703

Test-Connection was not giving us the correct ip address for the ownernode.  ping will so we can regex it out of the ping results.