### PR TITLE
ZPS-4927: replace a deprecated Get-WmiObject

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ClusterDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ClusterDataSource.py
@@ -173,7 +173,7 @@ class ClusterDataSourcePlugin(PythonDataSourcePlugin):
         )
 
         psClusterCommands.append(
-            "$resources = Get-WmiObject -class MSCluster_Resource -namespace root\MSCluster -filter \\\"Type='Physical Disk'\\\";"
+            "$resources = Get-Get-CimInstance -class MSCluster_Resource -namespace root\MSCluster -filter \\\"Type='Physical Disk'\\\";"
             "foreach ($resource in $resources) {{"
             "if (-Not ($csvNames -Contains $resource.Name)) {{"
             "$rsc = get-clusterresource -name $resource.Name;"

--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/Interfaces.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/Interfaces.py
@@ -117,14 +117,14 @@ class Interfaces(WinRMPlugin):
             "$_.teamname, '|'};"
         ),
         'counters2012': (
-            ' '.join('''$v = (Get-WmiObject win32_OperatingSystem).Version.split('.');
+            ' '.join('''$v = (Get-CimInstance win32_OperatingSystem).Version.split('.');
             $ver2012 = [int]$v[0] -gt 6 -or [int]$v[1] -gt 1;
             function replace_unallowed($s)
             {$s.replace('(', '[').replace(')', ']').replace('#', '_').replace('\\', '_').replace('/', '_').toLower()}
             if($ver2012){
             (Get-Counter '\Network Adapter(*)\*').CounterSamples |
                 % {$_.InstanceName} | gu | % {
-                foreach($na in (Get-WmiObject MSFT_NetAdapter -Namespace 'root/StandardCimv2')) {
+                foreach($na in (Get-CimInstance MSFT_NetAdapter -Namespace 'root/StandardCimv2')) {
                     if($_ -eq (replace_unallowed $na.InterfaceDescription) -or $_ -like 'isatap.' + "$($na.DeviceID)") {
                         $na.DeviceID, ':', $_, '|'
             }}}}'''.split())

--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinCluster.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinCluster.py
@@ -115,7 +115,7 @@ class WinCluster(WinRMPlugin):
         )
 
         clusterDiskCommand.append(
-            "$resources = Get-WmiObject -class MSCluster_Resource -namespace root\MSCluster -filter \\\"Type='Physical Disk'\\\";"
+            "$resources = Get-CimInstance -class MSCluster_Resource -namespace root\MSCluster -filter \\\"Type='Physical Disk'\\\";"
             "foreach ($resource in $resources) {{"
             "$rsc = get-clusterresource -name $resource.Name;"
             "$disks = $resource.GetRelated(\\\"MSCluster_Disk\\\");"

--- a/docs/body.md
+++ b/docs/body.md
@@ -1903,6 +1903,7 @@ Changes
 
 2.9.3
 
+-   Fix deprecated Get-WmiObject cmdlet for PowerShell Core (ZPS-4927)
 -   Windows Perfmon data collection stops for long time after device reboot (ZPS-4473)
 -   Windows - No freespace on cluster shared volumes (ZPS-4612)
 -   Fix Better handling in Perfmon datasource of "is not recognized as the name of a cmdlet" errors (ZPS-3517)


### PR DESCRIPTION
[ZPS-4927](https://jira.zenoss.com/browse/ZPS-4927)

Get-WmiObject has been deprecated in Windows PowerShell Core (6x), Replaced with Get-CimInstance that works with both Windows PowerShell and Windows PowerShell Core