### PR TITLE
allow for cluster sql instance perfmon

### DIFF
--- a/docs/body.md
+++ b/docs/body.md
@@ -1915,6 +1915,7 @@ Changes
 -   Fix Windows may connect to device with wrong zWinRMUser (ZPS-3564)
 -   Fix Microsoft.Windows - Detect .NET version better for EventLogDataSource (ZPS-5399)
 -   Fix After upgrade to 2.9.x, some/most modeler plugins fail with "'NoneType' object has no attribute 'getConnection'" (ZPS-5087)
+-   Windows Cluster - SQL Server instance metrics may not be found (ZPS-4888)
 
 2.9.2
 


### PR DESCRIPTION
fixes ZPS-4888

sql server can be active on node other than the current master.  this change will allow for contacting the correct device