### PR TITLE
test for empty Win32_SystemEnclosure results

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/OperatingSystem.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/OperatingSystem.py
@@ -56,7 +56,12 @@ class OperatingSystem(WinRMPlugin):
             "Modeler %s processing data for device %s",
             self.name(), device.id)
 
-        sysEnclosure = results.get('Win32_SystemEnclosure', (None,))[0]
+        try:
+            # assume valid results returned
+            sysEnclosure = results.get('Win32_SystemEnclosure', None)[0]
+        except IndexError:
+            # results contains Win32_SystemEnclosure as a key, but it's empty
+            sysEnclosure = None
         computerSystem = results.get('Win32_ComputerSystem', (None,))[0]
         operatingSystem = results.get('Win32_OperatingSystem', (None,))[0]
         clusterInformation = results.get('MSCluster', ())

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testOperatingSystem.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testOperatingSystem.py
@@ -91,6 +91,18 @@ class TestOddWMIClasses(BaseTestCase):
         self.plugin = OperatingSystem()
         self.device = StringAttributeObject()
 
+    def test_empty_sysenclosure_process(self):
+        acc = ItemsAccumulator()
+        acc.new_item()
+        self.results = {'Win32_SystemEnclosure': [],
+                        'Win32_ComputerSystem': acc.items,
+                        'Win32_OperatingSystem': acc.items,
+                        'exchange_version': Mock(stdout=['15'])}
+        try:
+            self.plugin.process(self.device, self.results, Mock())
+        except IndexError:
+            self.fail('Failed to detect empty Win32_SystemEnclosure results.')
+
     def test_empty_wmi_process(self):
         acc = ItemsAccumulator()
         acc.new_item()

--- a/docs/body.md
+++ b/docs/body.md
@@ -1919,6 +1919,7 @@ Changes
 -   Fix Windows Cluster - clusterOwnerChange may not be in zWindowsRemodelEventClassKeys after install/upgrade (ZPS-4887)
 -   Fix Windows Cluster - SQL Server instance metrics may not be found (ZPS-4888)
 -   Fix WindowsServiceLog "The referenced context has expired" error (ZPS-3216)
+-   Fix Add ERROR handling for empty win32_SystemEnclsoure data (ZPS-5253)
 
 2.9.2
 


### PR DESCRIPTION
fixes ZPS-5253

on openstack, a windows vm may not contain any info on the system enclosure.  we will end up with an empty result and can cause and IndexError trying to get the results out.  added unit test to account for this