### PR TITLE
powershell 2 does not support get-ciminstance

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinCluster.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinCluster.py
@@ -65,7 +65,10 @@ class WinCluster(WinRMPlugin):
         conn_info = conn_info._replace(timeout=device.zCollectorClientTimeout - 5)
         cmd = ClusterCommander(conn_info)
 
-        domain = yield cmd.run_command("(gwmi WIN32_ComputerSystem).Domain;")
+        domain = yield cmd.run_command(
+            "$use_cim = $PSVersionTable.PSVersion.Major -gt 2;"
+            "if ($use_cim) { (Get-CimInstance WIN32_ComputerSystem).Domain; }"
+            " else { (gwmi WIN32_ComputerSystem).Domain;}")
         domain = domain.stdout[0] if domain.stdout else ''
 
         resourceCommand = []
@@ -115,16 +118,24 @@ class WinCluster(WinRMPlugin):
         )
 
         clusterDiskCommand.append(
+            "$use_cim = $PSVersionTable.PSVersion.Major -gt 2;"
+            "if ($use_cim) {{"
             "$resources = Get-CimInstance -namespace"
             " 'root\MSCluster' -class 'MSCluster_Resource' "
             " | ? {{$_.Type -eq 'Physical Disk'}};"
+            "}} else {{$resources = Get-WmiObject -class MSCluster_Resource "
+            "-namespace root\MSCluster -filter \\\"Type='Physical Disk'\\\";}}"
             "foreach ($resource in $resources) {{"
             "$rsc = get-clusterresource -name $resource.Name;"
+            "if ($use_cim) {{"
             "$disks = Get-CimAssociatedInstance $resource -ResultClassName "
-            '"MSCluster_Disk";'
+            "'MSCluster_Disk'; }} else {{ "
+            "$disks = $resource.GetRelated('MSCluster_Disk');}}"
             "foreach ($dsk in $disks) {{"
+            "if ($use_cim) {{"
             "$partitions = Get-CimAssociatedInstance $dsk -ResultClassName "
-            '"MSCluster_DiskPartition";'
+            '"MSCluster_DiskPartition";}} else {{'
+            "$partitions = $dsk.GetRelated('MSCluster_DiskPartition');}}"
             "if ($partitions -ne $null) {{"
             "foreach ($prt in $partitions) {{"
             "$physicaldisk = New-Object -TypeName PSObject -Property @{{"
@@ -138,7 +149,8 @@ class WinCluster(WinRMPlugin):
             "OwnerGroup = $rsc.OwnerGroup;Name = $rsc.Name;DiskNumber = $dsk.Number;"
             "State = $rsc.State;Size = $dsk.Size;VolumePath = 'No Volume';"
             "PartitionNumber = 'No Partitions';FreeSpace = 'N/A'}};"
-            "$physicaldisk | foreach {{{}}};}}}}}};".format(disk_properties, disk_properties)
+            "$physicaldisk | foreach {{{}}};}}}}}};".format(disk_properties,
+                                                            disk_properties)
         )
 
         clusterdisk = yield cmd.run_command("".join(clusterDiskCommand))

--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinMSSQL.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinMSSQL.py
@@ -77,7 +77,13 @@ class SQLCommander(object):
     '''
 
     CLUSTER_INSTANCES_PS_SCRIPT = '''
-        $domain = (gwmi WIN32_ComputerSystem).Domain;
+        $use_cim = $PSVersionTable.PSVersion.Major -gt 2;
+        if ($use_cim) {
+            $domain = (get-ciminstance WIN32_ComputerSystem).Domain;
+        }
+        else {
+            $domain = (gwmi WIN32_ComputerSystem).Domain;
+        }
         Import-Module FailoverClusters;
         $cluster_instances = Get-ClusterResource
             | ? {$_.ResourceType -like 'SQL Server'}

--- a/docs/body.md
+++ b/docs/body.md
@@ -1916,6 +1916,7 @@ Changes
 
 -   Fix Traceback seen for zenoss.winrm.Processes modeler plugin (ZPS-5676)
 -   Fix Windows ZP: After upgrade to 2.9.3, seeing "caught returnValue being used in a non-generator" errors (ZPS-5727)
+-   Fix Windows - cluster disks may not be modeled or monitored on 2008 cluster when using Powershell v2.0 (ZPS-5755)
 
 2.9.3
 


### PR DESCRIPTION
Fixes ZPS-5755

get-ciminstance only available in powershell v3+.  we need to account for that until support for windows 2008 is EOL.  2012 and up will default to using newer versions.