### PR TITLE
eliminate duplicate impact relationships

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/tests/test_dynamicview.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/test_dynamicview.py
@@ -1,0 +1,58 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2019, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+from Products.DataCollector.plugins.DataMaps import ObjectMap, RelationshipMap
+
+try:
+    from ZenPacks.zenoss.DynamicView.tests import DynamicViewTestCase
+except ImportError:
+    import unittest
+
+    @unittest.skip("tests require DynamicView >= 1.7.0")
+    class DynamicViewTestCase(unittest.TestCase):
+        """TestCase stub if DynamicViewTestCase isn't available."""
+
+
+# TODO: Complete this sometime. Right now, something is better than nothing.
+EXPECTED_IMPACTS = """
+[windows1]->[windows1/nic1]
+[windows1]->[windows1/service1]
+"""
+
+DATAMAPS = [
+    RelationshipMap(
+        modname="ZenPacks.zenoss.Microsoft.Windows.Interface",
+        compname="os",
+        relname="interfaces",
+        objmaps=[ObjectMap({"id": "nic1"})]),
+]
+
+
+class DynamicViewTests(DynamicViewTestCase):
+    """DynamicView tests."""
+
+    # ZenPacks to initialize for testing purposes.
+    zenpacks = [
+        "ZenPacks.zenoss.Microsoft.Windows",
+    ]
+
+    # Expected impact relationships.
+    expected_impacts = EXPECTED_IMPACTS
+
+    # Devices to create.
+    device_data = {
+        "windows1": {
+            "deviceClass": "/Server/Microsoft/Windows",
+            "zPythonClass": "ZenPacks.zenoss.Microsoft.Windows.Device",
+            "dataMaps": DATAMAPS,
+        },
+    }
+
+    def test_impacts(self):
+        self.check_impacts()

--- a/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
+++ b/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
@@ -131,21 +131,6 @@ classes:
         type: boolean
         default: false
         display: false
-    impacts:
-      - all_filesystems
-      - all_processes
-      - all_ipservices
-      - all_cpus
-      - all_interfaces
-      - all_clusterservices
-      - all_clusternodes
-      - all_clusternetworks
-      - all_winservices
-      - all_hyperv
-      - all_winsqlinstances
-      - all_winrmiis
-      - all_harddisks
-    impacted_by: []
     dynamicview_views: [service_view]
     dynamicview_relations:
       impacts:
@@ -153,11 +138,9 @@ classes:
         - all_processes
         - all_ipservices
         - all_cpus
-        - all_interfaces
         - all_clusterservices
         - all_clusternodes
         - all_clusternetworks
-        - all_winservices
         - all_hyperv
         - all_winsqlinstances
         - all_winrmiis
@@ -176,21 +159,6 @@ classes:
       creatingdc:
         label: Creating DC
         default: None
-    impacts:
-      - all_filesystems
-      - all_processes
-      - all_ipservices
-      - all_cpus
-      - all_interfaces
-      - all_clusterservices
-      - all_clusternodes
-      - all_clusternetworks
-      - all_winservices
-      - all_hyperv
-      - all_winsqlinstances
-      - all_winrmiis
-      - all_harddisks
-    impacted_by: [all_clusterhosts]
     dynamicview_views: [service_view]
     dynamicview_relations:
       impacts:
@@ -198,11 +166,9 @@ classes:
         - all_processes
         - all_ipservices
         - all_cpus
-        - all_interfaces
         - all_clusterservices
         - all_clusternodes
         - all_clusternetworks
-        - all_winservices
         - all_hyperv
         - all_winsqlinstances
         - all_winrmiis
@@ -228,8 +194,6 @@ classes:
         label: Cluster
         grid_display: false
     monitoring_templates: [ClusterResource]
-    impacts: []
-    impacted_by: [device, clusterservice]
     dynamicview_views: [service_view]
     dynamicview_relations:
       impacts: []
@@ -253,8 +217,6 @@ classes:
         type: int
         default: 0
     monitoring_templates: [ClusterService]
-    impacts: [clusterresources]
-    impacted_by: [device]
     dynamicview_views: [service_view]
     dynamicview_relations:
       impacts: [clusterresources]
@@ -281,8 +243,6 @@ classes:
         grid_display: true
         order: 3
     monitoring_templates: [ClusterNode]
-    impacts: []
-    impacted_by: [clusterdisks, clusterinterfaces]
     dynamicview_views: [service_view]
     dynamicview_relations:
       impacts: []
@@ -327,8 +287,6 @@ classes:
         grid_display: true
         order: 2
     monitoring_templates: [ClusterDisk]
-    impacts: [clusternode]
-    impacted_by: []
     dynamicview_views: [service_view]
     dynamicview_relations:
       impacts: [clusternode]
@@ -352,8 +310,6 @@ classes:
         grid_display: true
         order: 2
     monitoring_templates: [ClusterNetwork]
-    impacts: []
-    impacted_by: [device]
     dynamicview_views: [service_view]
     dynamicview_relations:
       impacts: []
@@ -393,8 +349,6 @@ classes:
         label: Adapter
         grid_display: false
     monitoring_templates: [ClusterInterface]
-    impacts: [clusternode]
-    impacted_by: []
     dynamicview_views: [service_view]
     dynamicview_relations:
       impacts: [clusternode]
@@ -424,8 +378,6 @@ classes:
         label: L3 Cache Size
         grid_display: true
     monitoring_templates: [CPU]
-    impacts: []
-    impacted_by: [device]
     dynamicview_views: [service_view]
     dynamicview_relations:
       impacts: []
@@ -483,8 +435,6 @@ classes:
         api_only: true
         api_backendtype: method
 
-    impacts: []
-    impacted_by: [device]
     dynamicview_views: [service_view]
     dynamicview_relations:
       impacts: [filesystems]
@@ -517,8 +467,6 @@ classes:
       instance_name:
         label: Instance Name
     monitoring_templates: [FileSystem]
-    impacts: []
-    impacted_by: [device]
     dynamicview_views: [service_view]
     dynamicview_relations:
       impacts: []
@@ -532,12 +480,10 @@ classes:
         grid_display: false
         details_display: false
     monitoring_templates: [ethernetCsmacd]
-    impacts: []
-    impacted_by: [device]
     dynamicview_views: [service_view]
     dynamicview_relations:
       impacts: []
-      impacted_by: [device]
+      impacted_by: []
     relationships:
       DEFAULTS:
         grid_display: true
@@ -553,8 +499,6 @@ classes:
         label: Supports Private Working Set
         type: boolean
         default: False
-    impacts: []
-    impacted_by: [device]
     dynamicview_views: [service_view]
     dynamicview_relations:
       impacts: []
@@ -576,8 +520,6 @@ classes:
         default: 0
         api_only: true
         api_backendtype: method
-    impacts: []
-    impacted_by: [device]
     dynamicview_views: [service_view]
     dynamicview_relations:
       impacts: []
@@ -671,8 +613,6 @@ classes:
         type: string
         grid_display: true
     monitoring_templates: [IISSites]
-    impacts: []
-    impacted_by: [device]
     dynamicview_views: [service_view]
     dynamicview_relations:
       impacts: []
@@ -702,8 +642,6 @@ classes:
       status:
         label: Status
     monitoring_templates: [WinBackupDevice]
-    impacts: []
-    impacted_by:  [winsqlinstance]
     dynamicview_views: [service_view]
     dynamicview_relations:
       impacts: []
@@ -753,8 +691,6 @@ classes:
       cluster_node_server:
         label: Cluster Node Server
     monitoring_templates: [WinDatabase]
-    impacts: []
-    impacted_by: [winsqlinstance]
     dynamicview_views: [service_view]
     dynamicview_relations:
       impacts: []
@@ -785,8 +721,6 @@ classes:
       owner_node_ip:
         display: false
     monitoring_templates: [WinDBInstance]
-    impacts: [backups, databases, jobs]
-    impacted_by: [device]
     dynamicview_views: [service_view]
     dynamicview_relations:
       impacts: [backups, databases, jobs]
@@ -822,8 +756,6 @@ classes:
       cluster_node_server:
         label: Cluster Node Server
     monitoring_templates: [WinSQLJob]
-    impacts: []
-    impacted_by: [winsqlinstance]
     dynamicview_views: [service_view]
     dynamicview_relations:
       impacts: []


### PR DESCRIPTION
Specifying impact relationships under the impacts/impacted_by fields and
the dynamicview_relations field results in Impact having to execute the
relationship-finding code twice. It's only necessary to use
dynamicview_relations to get the relationships into Dynamic View and
into Impact.

Fixes ZPS-5778.