### PR TITLE
allow OperatingSystem to finish modeling

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testOperatingSystem.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testOperatingSystem.py
@@ -116,6 +116,7 @@ class TestOddWMIClasses(BaseTestCase):
         self.assertEquals(data[0].snmpSysName, 'Unknown')
 
         self.assertEquals(data[1].tag, 'Unknown')
+        self.assertEquals(data[2].setProductKey.args[0], 'Unknown - Unknown')
 
     def test_contact_none_process(self):
         # ZPS-3227 test for situation where PrimaryOwnerName

--- a/docs/body.md
+++ b/docs/body.md
@@ -1930,6 +1930,8 @@ Changes
 -   Fix Receiving 'NoneType' object has no attribute '__getitem__' when modeling Windows device (ZPS-5770)
 -   Fix Perfmon command(s) did not start: 'NoneType' object has no attribute 'getConnection' (ZPS-5822)
 -   Fix "The referenced context has expired" errors (ZPS-5797)
+-   Fix WinRM device modeler fails to model system OS info if Win32_ComputerSystem doesn't return data (ZPS-5820)
+-   Fix Windows collection attempts to use a dead connection causing a timeout (ZPS-5819)
 
 2.9.3
 


### PR DESCRIPTION
Fixes ZPS-5820

if we're not getting wmi data, then let's allow the modeler to finish with Unknown attributes