### PR TITLE
remove unecessary check for matching name

### DIFF
--- a/docs/body.md
+++ b/docs/body.md
@@ -1932,6 +1932,7 @@ Changes
 -   Fix "The referenced context has expired" errors (ZPS-5797)
 -   Fix WinRM device modeler fails to model system OS info if Win32_ComputerSystem doesn't return data (ZPS-5820)
 -   Fix Windows collection attempts to use a dead connection causing a timeout (ZPS-5819)
+-   Fix Cluster Monitoring Doesn't Account for Different Service Names (ZPS-5835)
 
 2.9.3
 


### PR DESCRIPTION
fixes ZPS-5835

the name field may not contain cluster group or sql server.  this will send the remodel event when we see that the owner node has changed for any cluster service/role