### PR TITLE
take into account lack of get-disk/get-partition on win2008

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinCluster.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinCluster.py
@@ -96,13 +96,20 @@ class WinCluster(WinRMPlugin):
 
         clusterDiskCommand = []
         clusterDiskCommand.append(
+            "$skip = -not ([System.Environment]::OSVersion.Version.Major -le 6"
+            " -and [System.Environment]::OSVersion.Version.Minor -eq 1);"
+            "if ($skip) {{"
             "$volumeInfo = Get-Disk | Get-Partition | Select DiskNumber, @{{"
-            "Name='Volume';Expression={{Get-Volume -Partition $_ | Select -ExpandProperty ObjectId;}}}};"
+            "Name='Volume';Expression={{Get-Volume -Partition $_ | Select"
+            " -ExpandProperty ObjectId;}}}}}};"
             "$clusterSharedVolume = Get-ClusterSharedVolume;"
             "foreach ($volume in $clusterSharedVolume) {{"
             "$volumeowner = $volume.OwnerNode.Name;"
             "$csvVolume = $volume.SharedVolumeInfo.Partition.Name;"
-            "$csvdisknumber = ($volumeinfo | where {{ $_.Volume -eq $csvVolume}}).Disknumber;"
+            "if ($skip) {{"
+            "$csvdisknumber = ($volumeinfo | where {{ $_.Volume -eq "
+            "$csvVolume}}).Disknumber;}}"
+            "else {{$csvdisknumber = -1}}"
             "$csvtophysicaldisk = New-Object -TypeName PSObject -Property @{{"
             "Id = $csvVolume.substring(11, $csvVolume.length-13);"
             "Name = $volume.Name;"

--- a/docs/body.md
+++ b/docs/body.md
@@ -153,7 +153,7 @@ Cluster Disks
     Partition Number, Capacity, Free Space, State
 :   **Relationships:** Cluster Nodes
 
-Note: If a cluster disk has not been allocated, there are no partitions, so the representation of free space is invalid.  We will therefore show free space as N/A.
+Note: If a cluster disk has not been allocated, there are no partitions, so the representation of free space is invalid.  We will therefore show free space as N/A.  Disk number will not be discovered on Windows 2008 servers because the Powershell Storage Module is not available.
 
 Cluster Interfaces
 :   **Attributes:** Name, Owner Node, Network, IP
@@ -1933,6 +1933,7 @@ Changes
 -   Fix WinRM device modeler fails to model system OS info if Win32_ComputerSystem doesn't return data (ZPS-5820)
 -   Fix Windows collection attempts to use a dead connection causing a timeout (ZPS-5819)
 -   Fix Cluster Monitoring Doesn't Account for Different Service Names (ZPS-5835)
+-   Fix 'Get-Disk' is not recognized on Windows 2008 Clusters (ZPS-5822)
 
 2.9.3
 


### PR DESCRIPTION
fixes ZPS-5582

when modeling, we will skip getting the disk number for win 2008 devices.  determining a workaround with wmi objects is not a useful endeavor because there are no direct associations.  also, when monitoring, we only need to worry about getting the id, freespace, and state of the csv.  we should have also been ignoring the csvs when getting 'Physical Disk' resources.  updated doc to indicate that an no disk number will be reported for the csvs on win 2008