### PR TITLE
ZPS-6861: better handling of "invalid selectors"

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
@@ -862,6 +862,13 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
                     'got "Unexpected Response" during receive, '
                     'attempting to receive again'
                 )
+            elif 'invalid selectors for the resource' in e.message:
+                retry, level, msg = (
+                    False,
+                    logging.DEBUG,
+                    'Attempted to use a non-existent remote shell.  Possibly '
+                    'due to device reboot.'
+                )
             else:
                 retry, level, msg = (
                     True,
@@ -887,10 +894,6 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
                     "'NoneType' object has no attribute 'persistent'" in e.message:
                 level = logging.DEBUG
                 e = 'Attempted to receive from closed connection.  Possibly '\
-                    'due to device reboot.'
-            elif 'invalid selectors for the resource' in e.message:
-                level = logging.DEBUG
-                e = 'Attempted to use a non-existent remote shell.  Possibly '\
                     'due to device reboot.'
             retry, msg = (
                 False,


### PR DESCRIPTION
Per ZPS-6861: this PR is for better handling of "invalid selectors" error:
- move it up into "elif '500' in e.message:" block
- set retry=False (this message indicates loss of connection to the device possibly due to reboot or restart of the WinRM service)
This should avoid a retry loop where we make thousands of connections to a single device when we hit the "invalid selectors" 500 error.