### PR TITLE
Fix issue with Sysname property on device level

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/OperatingSystem.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/OperatingSystem.py
@@ -79,7 +79,7 @@ class OperatingSystem(WinRMPlugin):
         # Device Map
         device_om = ObjectMap()
         # safely get name, contact, desc
-        sys_name = getattr(computerSystem, 'Name', None) or getattr(operatingSystem, 'CSName', None) or 'Unknown'
+        sys_name = getattr(computerSystem, 'Name', None) or getattr(operatingSystem, 'CSName', None) or device.snmpSysName or 'Unknown'
         device_om.snmpSysName = sys_name.strip()
         contact = getattr(computerSystem, 'PrimaryOwnerName', None) or getattr(operatingSystem, 'RegisteredUser', None) or 'Unknown'
         device_om.snmpContact = contact.strip()

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testOperatingSystem.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testOperatingSystem.py
@@ -48,11 +48,57 @@ class TestOperatingSystem(BaseTestCase):
         self.assertEquals(data[1].totalMemory, 1024)
         self.assertEquals(data[2].totalSwap, 1024)
 
+    def test_process_sys_name_from_device(self):
+        device = Mock()
+        device.id = 'win_device'
+        device.snmpSysName = 'device_sys_name'
+        device.manageIp = '8.8.8.8'
+        data = self.plugin.process(device, {}, Mock())
+        self.assertEquals(data[0].snmpSysName, 'device_sys_name')
+
+    def test_process_sys_name_from_comp_system(self):
+        device = Mock()
+        device.id = 'win_device'
+        device.snmpSysName = 'device_sys_name'
+        device.manageIp = '8.8.8.8'
+        computer_system = Mock()
+        computer_system.Name = 'computer_sys_name'
+        results = {
+            'Win32_ComputerSystem': [computer_system]
+        }
+        data = self.plugin.process(device, results, Mock())
+        self.assertEquals(data[0].snmpSysName, 'computer_sys_name')
+
+    def test_process_sys_name_from_os_system(self):
+        device = Mock()
+        device.id = 'win_device'
+        device.snmpSysName = 'device_sys_name'
+        device.manageIp = '8.8.8.8'
+        os_system = Mock()
+        os_system.CSName = 'os_sys_name'
+        os_system.TotalVisibleMemorySize = 1024
+        os_system.TotalVirtualMemorySize = 1024
+        os_system.Caption = 'Caption'
+        results = {
+            'Win32_OperatingSystem': [os_system]
+        }
+        data = self.plugin.process(device, results, Mock())
+        self.assertEquals(data[0].snmpSysName, 'os_sys_name')
+
+    def test_process_sys_name_unknown(self):
+        device = Mock()
+        device.id = 'win_device'
+        device.snmpSysName = ''
+        device.manageIp = '8.8.8.8'
+        data = self.plugin.process(device, {}, Mock())
+        self.assertEquals(data[0].snmpSysName, 'Unknown')
+
 
 class TestDomainController(BaseTestCase):
     '''
     Test if a device is a domain controller
     '''
+
     def setUp(self):
         self.plugin = OperatingSystem()
         self.device = load_pickle(self, 'device')
@@ -113,7 +159,7 @@ class TestOddWMIClasses(BaseTestCase):
         data = self.plugin.process(self.device, self.results, Mock())
         self.assertEquals(data[0].snmpDescr, 'Unknown')
         self.assertEquals(data[0].snmpContact, 'Unknown')
-        self.assertEquals(data[0].snmpSysName, 'Unknown')
+        self.assertEquals(data[0].snmpSysName, 'snmpSysName')
 
         self.assertEquals(data[1].tag, 'Unknown')
         self.assertEquals(data[2].setProductKey.args[0], 'Unknown - Unknown')
@@ -150,7 +196,7 @@ class TestOddWMIClasses(BaseTestCase):
         data = self.plugin.process(self.device, self.results, Mock())
         self.assertEquals(data[0].snmpDescr, 'Unknown')
         self.assertEquals(data[0].snmpContact, 'Unknown')
-        self.assertEquals(data[0].snmpSysName, 'Unknown')
+        self.assertEquals(data[0].snmpSysName, 'snmpSysName')
 
 
 def test_suite():

--- a/ZenPacks/zenoss/Microsoft/Windows/txwinrm_utils.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/txwinrm_utils.py
@@ -42,7 +42,8 @@ ConnectionInfoProperties = (
     'kerberos_rdns',
     'zWinRMConnectTimeout',
     'zWinServicesModeled',
-    'zWinServicesNotModeled'
+    'zWinServicesNotModeled',
+    'snmpSysName',
 )
 
 


### PR DESCRIPTION
Fixes ZPS-6244

When we had an insufficient responce from server,
original value of `snmpSysName` might be replaced with
'Unknown' string. So we check if we have anything from
the previous modeling.