### PR TITLE
Add Availability Group and Replica components

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/WinSQLAvailabilityGroup.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/WinSQLAvailabilityGroup.py
@@ -1,0 +1,23 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2020, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+from . import schema
+from .utils import lookup_ag_state
+
+
+class WinSQLAvailabilityGroup(schema.WinSQLAvailabilityGroup):
+
+    def getState(self):
+        try:
+            state = int(self.cacheRRDValue('AvailabilityGroupState_IsOnline', 0))
+        except (ValueError, Exception):
+            state = None
+
+        status_representation = lookup_ag_state(state)
+
+        return status_representation

--- a/ZenPacks/zenoss/Microsoft/Windows/WinSQLAvailabilityGroup.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/WinSQLAvailabilityGroup.py
@@ -15,7 +15,7 @@ class WinSQLAvailabilityGroup(schema.WinSQLAvailabilityGroup):
     def getState(self):
         try:
             state = int(self.cacheRRDValue('AvailabilityGroupState_IsOnline', 0))
-        except (ValueError, Exception):
+        except:
             state = None
 
         status_representation = lookup_ag_state(state)

--- a/ZenPacks/zenoss/Microsoft/Windows/WinSQLAvailabilityGroupHostedObject.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/WinSQLAvailabilityGroupHostedObject.py
@@ -1,0 +1,34 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2020, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+from . import schema
+
+
+class WinSQLAvailabilityGroupHostedObject(schema.WinSQLAvailabilityGroupHostedObject):
+    """
+    Base class for components, which are hosted on MSSQL Always On Availability Group.
+    """
+
+    def get_availability_group(self):
+        ag = None
+
+        winsqlavailabilitygroup_relation = getattr(self, 'winsqlavailabilitygroup', None)
+        if winsqlavailabilitygroup_relation:
+            ag = winsqlavailabilitygroup_relation()
+
+        return ag
+
+    @property
+    def availability_group_name(self):
+        ag_name = ''
+
+        availability_group = self.get_availability_group()
+        if availability_group:
+            ag_name = availability_group.name()
+
+        return ag_name

--- a/ZenPacks/zenoss/Microsoft/Windows/WinSQLInstanceHostedObject.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/WinSQLInstanceHostedObject.py
@@ -1,0 +1,51 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2020, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+from . import schema
+
+
+class WinSQLInstanceHostedObject(schema.WinSQLInstanceHostedObject):
+    """
+    Base class for components, which are hosted on SQL Instance.
+    """
+
+    def get_sql_instance(self):
+        """
+        Returns SQL Instance on which Availability Replicas' Primary Replica is placed. TODO: revise this
+        """
+        sql_instance = None
+
+        winsqlinstance_relation = getattr(self, 'winsqlinstance', None)
+        if winsqlinstance_relation:
+            sql_instance = winsqlinstance_relation()
+
+        return sql_instance
+
+    @property
+    def cluster_node_server(self):
+        hosted_sql_instance = self.get_sql_instance()
+        if hosted_sql_instance:
+            return getattr(hosted_sql_instance, 'cluster_node_server', '')
+
+    @property
+    def perfmon_instance(self):
+        hosted_sql_instance = self.get_sql_instance()
+        if hosted_sql_instance:
+            return getattr(hosted_sql_instance, 'perfmon_instance', '')
+
+    @property
+    def owner_node_ip(self):
+        hosted_sql_instance = self.get_sql_instance()
+        if hosted_sql_instance:
+            return getattr(hosted_sql_instance, 'owner_node_ip', '')
+
+    @property
+    def instancename(self):
+        hosted_sql_instance = self.get_sql_instance()
+        if hosted_sql_instance:
+            return getattr(hosted_sql_instance, 'instancename', '')

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
@@ -771,9 +771,9 @@ class PowershellMSSQLAlwaysOnAGStrategy(object):
 
         if result.exit_code != 0:
             log.debug(
-                'Non-zero exit code ({0}) for MSSQL AO AG for {1}'
+                'Non-zero exit code ({0}) for MSSQL AO AG on {1}'
                 .format(
-                    result.exit_code, datasources[0].device))
+                    result.exit_code, datasources[0].get('cluster_node_server')))
             return parsed_results
 
         # Parse values
@@ -792,24 +792,18 @@ class PowershellMSSQLAlwaysOnAGStrategy(object):
             return parsed_results
 
         for dsconf in datasources:
-            ag_name = dsconf.params.get('contexttitle')
-
-            if not ag_name:
-                log.debug('Empty Availability Group name for {}.'.format(datasources[0].device))
-                continue
-
+            ag_name = dsconf.params.get('contexttitle', '')
             ag_results = availability_groups_info.get(ag_name)
 
             if not isinstance(ag_results, dict):
                 log.debug('Got {} response monitoring for {}. It should be dict.'.format(type(ag_results),
                                                                                          ag_name))
-                return parsed_results
+                continue
 
             # Metrics
             ag_state_metrics = ag_results.get('ag_state')
             if isinstance(ag_state_metrics, dict):
-                datasource = dsconf.datasource
-                if datasource == 'AvailabilityGroupState':
+                if dsconf.datasource == 'AvailabilityGroupState':
                     for datapoint in dsconf.points:
                         dp_id = datapoint.id
                         dp_value = ag_state_metrics.get(dp_id)

--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/ShellDataSource.py
@@ -47,11 +47,12 @@ from ..txcoroutine import coroutine
 
 from ..txwinrm_utils import ConnectionInfoProperties, createConnectionInfo
 from ZenPacks.zenoss.Microsoft.Windows.utils import filter_sql_stdout, \
-    parseDBUserNamePass, getSQLAssembly
+    parseDBUserNamePass, getSQLAssembly, parse_winrs_response
 from ..utils import (
     check_for_network_error, save, errorMsgCheck,
     generateClearAuthEvents, get_dsconf, SqlConnection,
-    lookup_databasesummary, lookup_database_status)
+    lookup_databasesummary, lookup_database_status,
+    lookup_ag_state, lookup_ag_quorum_state, fill_ag_om)
 from EventLogDataSource import string_to_lines
 from . import send_to_debug
 
@@ -69,7 +70,8 @@ AVAILABLE_STRATEGIES = [
     'powershell MSSQL',
     'DCDiag',
     'powershell MSSQL Instance',
-    'powershell MSSQL Job'
+    'powershell MSSQL Job',
+    'powershell MSSQL AO AG'
 ]
 
 BUFFER_SIZE = '$Host.UI.RawUI.BufferSize = New-Object Management.Automation.Host.Size (4096, 512);'
@@ -681,6 +683,202 @@ class PowershellMSSQLInstanceStrategy(object):
 gsm.registerUtility(PowershellMSSQLInstanceStrategy(), IStrategy, 'powershell MSSQL Instance')
 
 
+class PowershellMSSQLAlwaysOnAGStrategy(object):
+    implements(IStrategy)
+
+    key = 'MSSQLAlwaysOnAG'
+
+    @staticmethod
+    def build_command_line(sql_connection, ag_names):
+        ps_command = "powershell -NoLogo -NonInteractive " \
+            "-OutputFormat TEXT -Command "
+
+        ps_ao_ag_script = \
+            ("$res = New-Object 'system.collections.generic.dictionary[string, object]';"
+
+             "$def_fields = $server.GetDefaultInitFields([Microsoft.SqlServer.Management.Smo.AvailabilityGroup]);"
+             "$server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.AvailabilityGroup], $def_fields);"
+             "$dbmaster = $server.Databases['master'];"
+             "$is_clustered = $server.IsClustered;"
+
+             '$cluster_query = \\"SELECT quorum_state FROM sys.dm_hadr_cluster;\\";'
+             "   try {"
+             "       $cl_qry_res = $dbmaster.ExecuteWithResults($cluster_query);"
+             "       if ($cl_qry_res.tables[0].rows.Count -gt 0) {"
+             "          $cl_quorum_state = $cl_qry_res.tables[0].rows[0].quorum_state;"
+             "       } else {$cl_quorum_state = '';}"
+             "   }"
+             "   catch {"
+             "       $cl_quorum_state = '';"
+             "   }"
+             "$ag_names = @(ag_names_placeholder);"
+             "foreach ($ag_name in $ag_names) {"
+             "   $ag = New-Object 'Microsoft.SqlServer.Management.Smo.AvailabilityGroup' $server, $ag_name;"
+
+             "   $ag.Refresh();"
+             "   $ag_result = New-Object 'system.collections.generic.dictionary[string, object]';"
+             ""
+             "   $ag_info = New-Object 'system.collections.generic.dictionary[string, object]';"
+             "   $ag_info['primary_replica_server_name'] = $ag.PrimaryReplicaServerName;"
+             "   $ag_info['health_check_timeout'] = $ag.HealthCheckTimeout;"
+             "   $ag_info['automated_backup_preference'] = $ag.AutomatedBackupPreference;"
+             "   $ag_info['is_clustered_instance'] = $is_clustered;"
+             "   $ag_uid = $ag.UniqueId;"
+             '   $ag_health_query = \\"SELECT ag_states.synchronization_health AS synchronization_health, '
+             "   ag_states.primary_recovery_health AS primary_recovery_health"
+             "   FROM sys.dm_hadr_availability_group_states AS ag_states"
+             '   WHERE ag_states.group_id = \'$ag_uid\';\\";'
+             "   try {"
+             "       $ag_st_res = $dbmaster.ExecuteWithResults($ag_health_query);"
+             "       $ag_info['synchronization_health'] = $ag_st_res.tables[0].rows[0].synchronization_health;"
+             "       $ag_info['primary_recovery_health'] = $ag_st_res.tables[0].rows[0].primary_recovery_health;"
+             "   }"
+             "   catch {"
+             "       $ag_info['synchronization_health'] = '';"
+             "       $ag_info['primary_recovery_health'] = '';"
+             "   }"
+             "   $ag_result['ag_info'] = $ag_info;"
+             ""
+             "   $ag_state = New-Object 'Microsoft.SqlServer.Management.Smo.AvailabilityGroupState' $ag;"
+             "   $ag_result['ag_state'] = $ag_state;"
+             "   $ag_result['cl_quorum_state'] = $cl_quorum_state;"
+             ""
+             "   $res[$ag_name] = $ag_result;"
+             "}"
+             "$result_in_json = ConvertTo-Json $res;"
+             "Write-Host $result_in_json;").replace('ag_names_placeholder',
+                                                    ','.join(("'{}'".format(ag_name) for ag_name in ag_names)))
+        script = "\"& {{{}}}\"".format(
+            ''.join([BUFFER_SIZE] +
+                    getSQLAssembly(sql_connection.version) +
+                    sql_connection.sqlConnection +
+                    [ps_ao_ag_script]))
+
+        log.debug('Powershell MSSQL Always On AG Strategy script: {}'.format(script))
+
+        return ps_command, script
+
+    @staticmethod
+    def parse_result(config, result):
+
+        datasources = config.datasources
+
+        parsed_results = PythonDataSourcePlugin.new_data()
+
+        if result.stderr:
+            log.debug('MSSQL AO AG error: {0}'.format('\n'.join(result.stderr)))
+        log.debug('MSSQL AO AG results: {}'.format('\n'.join(result.stdout)))
+
+        if result.exit_code != 0:
+            log.debug(
+                'Non-zero exit code ({0}) for MSSQL AO AG for {1}'
+                .format(
+                    result.exit_code, datasources[0].device))
+            return parsed_results
+
+        # Parse values
+        ag_info_stdout = filter_sql_stdout(result.stdout)
+        availability_groups_info, passing_error = parse_winrs_response(ag_info_stdout, 'json')
+
+        if not availability_groups_info and passing_error:
+            log.debug('Error during parsing Availability Groups State counters')
+            return parsed_results
+
+        log.debug('Availability Groups monitoring response: {}'.format(availability_groups_info))
+
+        if not isinstance(availability_groups_info, dict):
+            log.debug('Availability group monitoring response should be dict, got {}.'.format(
+                type(availability_groups_info)))
+            return parsed_results
+
+        for dsconf in datasources:
+            ag_name = dsconf.params.get('contexttitle')
+
+            if not ag_name:
+                log.debug('Empty Availability Group name for {}.'.format(datasources[0].device))
+                continue
+
+            ag_results = availability_groups_info.get(ag_name)
+
+            if not isinstance(ag_results, dict):
+                log.debug('Got {} response monitoring for {}. It should be dict.'.format(type(ag_results),
+                                                                                         ag_name))
+                return parsed_results
+
+            # Metrics
+            ag_state_metrics = ag_results.get('ag_state')
+            if isinstance(ag_state_metrics, dict):
+                datasource = dsconf.datasource
+                if datasource == 'AvailabilityGroupState':
+                    for datapoint in dsconf.points:
+                        dp_id = datapoint.id
+                        dp_value = ag_state_metrics.get(dp_id)
+                        if dp_value is not None:
+                            parsed_results['values'][dsconf.component][dp_id] = dp_value, 'N'
+            # Maps:
+            ag_om = None
+            ag_info_maps = ag_results.get('ag_info')
+            if isinstance(ag_info_maps, dict):
+                ag_om = ObjectMap()
+                ag_om.id = dsconf.params['instanceid']
+                ag_om.title = dsconf.params['contexttitle']
+                ag_om.compname = dsconf.params['contextcompname']
+                ag_om.modname = dsconf.params['contextmodname']
+                ag_om.relname = dsconf.params['contextrelname']
+                sql_instance_data = {
+                    'quorum_state': lookup_ag_quorum_state(
+                        ag_results.get('cl_quorum_state'))
+                }
+                ag_om = fill_ag_om(ag_om, ag_info_maps, prepId, sql_instance_data)
+                parsed_results['maps'].append(ag_om)
+            # Events:
+            # 1. check whether Primary replica SQL Instance has changed. If yes - create an event.
+            if ag_om:
+                primary_repliaca_sql_instance_id = getattr(ag_om, 'set_winsqlinstance', None)
+                if primary_repliaca_sql_instance_id and \
+                        dsconf.params['winsqlinstance_id'] and \
+                        primary_repliaca_sql_instance_id != dsconf.params['winsqlinstance_id']:
+
+                    parsed_results['events'].append(dict(
+                        eventClassKey='alwaysOnPrimaryReplicaInstanceChange',
+                        eventKey='winrsCollection',
+                        severity=ZenEventClasses.Info,
+                        summary='Primary replica SQL Instance for Availability Group {} changed to {}'.format(
+                                    dsconf.params['contexttitle'],
+                                    ag_info_maps.get('primary_replica_server_name'), ''),
+                        device=config.id,
+                        component=dsconf.component
+                    ))
+            # 2. IsOnline event
+            is_online = None
+            if isinstance(ag_state_metrics, dict):
+                is_online = ag_state_metrics.get('IsOnline')
+                try:
+                    is_online = int(is_online)
+                except TypeError:
+                    pass
+            state_representation = lookup_ag_state(is_online)
+            severity = ZenEventClasses.Clear if is_online else ZenEventClasses.Critical
+
+            parsed_results['events'].append(dict(
+                eventClass=dsconf.eventClass or "/Status",
+                eventClassKey='alwaysOnAvailabilityGroupStatus',
+                eventKey=dsconf.eventKey,
+                severity=severity,
+                summary='Last state of Availability Group {} was {}'.format(
+                    dsconf.params['contexttitle'], state_representation),
+                device=config.id,
+                component=dsconf.component
+            ))
+
+        log.debug('MSSQL Availability Group monitoring parsed results: {}'.format(parsed_results))
+
+        return parsed_results
+
+
+gsm.registerUtility(PowershellMSSQLAlwaysOnAGStrategy(), IStrategy, 'powershell MSSQL AO AG')
+
+
 class ShellDataSourcePlugin(PythonDataSourcePlugin):
 
     proxy_attributes = ConnectionInfoProperties + (
@@ -707,6 +905,17 @@ class ShellDataSourcePlugin(PythonDataSourcePlugin):
                     datasource.getCycleTime(context),
                     datasource.strategy,
                     getattr(context, 'instancename', ''))
+        elif datasource.strategy == 'powershell MSSQL AO AG':
+            # TODO: single out 'powershell MSSQL AO ...' into separate config key, as 'cluster_node_server' value
+            #  should be included as well. It is also true for 'powershell MSSQL' and 'powershell MSSQL Job' strategies.
+            #  As a result, when 'cluster_node_server' will be included to theirs config key - this particular block
+            #  should be removed and 'powershell MSSQL AO ...' strategies name should
+            #  be added to the previous elif block.
+            return (context.device().id,
+                    datasource.getCycleTime(context),
+                    datasource.strategy,
+                    getattr(context, 'instancename', ''),
+                    getattr(context, 'cluster_node_server', ''))
         elif datasource.strategy == 'powershell MSSQL Instance':
             return (context.device().id,
                     datasource.getCycleTime(context),
@@ -726,7 +935,8 @@ class ShellDataSourcePlugin(PythonDataSourcePlugin):
                                         'Custom Command',
                                         'DCDiag',
                                         'powershell MSSQL Instance',
-                                        'powershell MSSQL Job'):
+                                        'powershell MSSQL Job,'
+                                        'powershell MSSQL AO AG'):
             resource = '\\' + resource
         if safe_hasattr(context, 'perfmonInstance') and context.perfmonInstance is not None:
             resource = context.perfmonInstance + resource
@@ -778,6 +988,14 @@ class ShellDataSourcePlugin(PythonDataSourcePlugin):
 
         script = get_script(datasource, context)
 
+        # Always On params:
+        # SQL Instance ID from relation.
+        get_winsqlinstance = getattr(context, 'get_winsqlinstance', None)
+        if get_winsqlinstance:
+            winsqlinstance_id = get_winsqlinstance()
+        else:
+            winsqlinstance_id = None
+
         return dict(resource=resource,
                     strategy=datasource.strategy,
                     instancename=instancename,
@@ -791,7 +1009,8 @@ class ShellDataSourcePlugin(PythonDataSourcePlugin):
                     contextmodname=contextmodname,
                     contexttitle=contexttitle,
                     version=version,
-                    owner_node_ip=owner_node_ip)
+                    owner_node_ip=owner_node_ip,
+                    winsqlinstance_id=winsqlinstance_id)
 
     def getSQLConnection(self, dsconf, conn_info):
         dbinstances = dsconf.zDBInstances
@@ -861,11 +1080,18 @@ class ShellDataSourcePlugin(PythonDataSourcePlugin):
                 if len(server.split('\\')) < 2:
                     cmd_line_input = 'MSSQLSERVER'
                 else:
-                    cmd_line_input = dsconf0.params['instanceid']
+                    cmd_line_input = dsconf0.params['instancename']  # instancename represents native SQL Instance name.
             if dsconf.params['strategy'] == 'powershell MSSQL' or\
                     dsconf.params['strategy'] == 'powershell MSSQL Job':
                 conn_info = conn_info._replace(timeout=dsconf0.cycletime - 5)
-            command_line, script = strategy.build_command_line(cmd_line_input)
+            if dsconf0.params['strategy'] == 'powershell MSSQL AO AG':
+                # For Always On Availability groups, Availability Group names are needed:
+                ag_nemes = [dsconf.params['contexttitle']
+                            for dsconf in config.datasources
+                            if dsconf.params['contexttitle']]
+                command_line, script = strategy.build_command_line(cmd_line_input, ag_nemes)
+            else:
+                command_line, script = strategy.build_command_line(cmd_line_input)
         elif dsconf0.params['strategy'] == 'Custom Command':
             check_datasource(dsconf0)
             script = dsconf0.params['script']
@@ -919,6 +1145,11 @@ class ShellDataSourcePlugin(PythonDataSourcePlugin):
             diagResult = strategy.parse_result(dsconfs, result)
             dsconf = dsconfs[0]
             data['events'] = diagResult.events
+        elif strategy.key == 'MSSQLAlwaysOnAG':
+            ao_result = strategy.parse_result(config, result)
+            data['values'] = ao_result.get('values', {})
+            data['maps'] = ao_result.get('maps', [])
+            data['events'] = ao_result.get('events', [])
         elif strategy.key == 'MSSQLInstance':
             for dsconf, value in strategy.parse_result(dsconfs, result):
                 currentstate = {

--- a/ZenPacks/zenoss/Microsoft/Windows/device_classes.yaml
+++ b/ZenPacks/zenoss/Microsoft/Windows/device_classes.yaml
@@ -2143,7 +2143,67 @@ device_classes:
             component: ${here/id}
             datapoints:
               state: GAUGE
-
+      WinAvailabilityGroup:
+        description: Microsoft SQL Server per-availability group monitoring.
+        targetPythonClass: ZenPacks.zenoss.Microsoft.Windows.WinSQLAvailabilityGroup
+        datasources:
+          AvailabilityGroupState:
+            type: Windows Shell
+            strategy: powershell MSSQL AO AG
+            component: ${here/id}
+            resource: AvailabilityGroupState
+            cycletime: ${here/zWinPerfmonInterval}
+            datapoints:
+              IsOnline:
+                rrdtype: GAUGE
+                rrdmin: 0
+                rrdmax: 1
+                description: Used to monitor the availability of the Availability Group.
+              NumberOfDisconnectedReplicas:
+                rrdtype: GAUGE
+                rrdmin: 0
+                aliases: {ag_state_disc_rpl__count: null}
+              NumberOfNotSynchronizedReplicas:
+                rrdtype: GAUGE
+                rrdmin: 0
+                aliases: {ag_state_n_synced_rpl__count: null}
+              NumberOfNotSynchronizingReplicas:
+                rrdtype: GAUGE
+                rrdmin: 0
+                aliases: {ag_state_n_syncing_rpl__count: null}
+              NumberOfReplicasWithUnhealthyRole:
+                rrdtype: GAUGE
+                rrdmin: 0
+                aliases: {ag_state_unh_role_rpl__count: null}
+              NumberOfSynchronizedSecondaryReplicas:
+                rrdtype: GAUGE
+                rrdmin: 0
+                aliases: {ag_state_sync_secd_rpl__count: null}
+        graphs:
+          State Indicators:
+            units: replicas
+            miny: 0
+            graphpoints:
+              Disconnected:
+                dpName: AvailabilityGroupState_NumberOfDisconnectedReplicas
+                format: '%7.0lf'
+                color: 'CC0000' # Red
+              Not Synchronized:
+                dpName: AvailabilityGroupState_NumberOfNotSynchronizedReplicas
+                format: '%7.0lf'
+                color: '990033' # Dark red
+              Not Synchronizing:
+                dpName: AvailabilityGroupState_NumberOfNotSynchronizingReplicas
+                format: '%7.0lf'
+                color: 'FFCC66' # Light orange
+              With Unhealthy Role:
+                dpName: AvailabilityGroupState_NumberOfReplicasWithUnhealthyRole
+                format: '%7.0lf'
+                color: 'FF9933' # Orange
+              Synchronized Secondary:
+                dpName: AvailabilityGroupState_NumberOfSynchronizedSecondaryReplicas
+                format: '%7.0lf'
+                color: '006633' # Green
 
       Active Directory:
         description: Microsoft Active Directory

--- a/ZenPacks/zenoss/Microsoft/Windows/event_classes.yaml
+++ b/ZenPacks/zenoss/Microsoft/Windows/event_classes.yaml
@@ -17,6 +17,11 @@ event_classes:
         transform: "if device:\n\
           \    from ZenPacks.zenoss.Microsoft.Windows.actions import schedule_remodel\n\
           \    schedule_remodel(device, evt)"
+      AlwaysOnPrimaryReplicaInstanceChange:
+        eventClassKey: alwaysOnPrimaryReplicaInstanceChange
+        sequence: 10
+        remove: true
+        example: Primary replica SQL Instance for Availability Group AG1 changed to sql_instance_2
   /Status/IIS:
     remove: true
   /Status/Kerberos:

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testWinMSSQL.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testWinMSSQL.py
@@ -307,7 +307,7 @@ class TestProcesses(BaseTestCase):
 
     def test_process(self):
         data = self.plugin.process(self.device, RESULTS, Mock())
-        self.assertEquals(len(data), 5)
+        self.assertEquals(len(data), 6)  # Hostname, SQLInstance, SQLBackup, SQLJob, SQLDatabase, SQLAvailabilityGroup
         self.assertEquals(data[0].sqlhostname, 'dbhost0')
 
         self.assertEquals(data[1].maps[0].title, 'RTC')
@@ -344,6 +344,9 @@ class TestProcesses(BaseTestCase):
         self.assertEquals(data[4].maps[0].systemobject, 'False')
         self.assertEquals(data[4].maps[0].title, 'db0')
         self.assertEquals(data[4].maps[0].version, '706')
+
+        # Always On components are disabled by default, so there must be empty object map
+        self.assertEquals(data[5].maps, [])
 
         # if empty jobs, backups, or databases we need to send empty list of object maps
         RESULTS['jobs'] = []

--- a/ZenPacks/zenoss/Microsoft/Windows/utils.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/utils.py
@@ -13,6 +13,7 @@ Basic utilities that doesn't cause any Zope stuff to be imported.
 
 import json
 import base64
+import collections
 from Products.AdvancedQuery import In
 from Products.Zuul.interfaces import ICatalogTool
 
@@ -760,13 +761,10 @@ def get_sql_instance_naming_info(instance_name, is_cluster_instance=False, hostn
 
     @param instance_name: SQL Instance name.
     @type instance_name: str
-
     @param is_cluster_instance: Whether it is Cluster SQL Instance. Default is False
     @type is_cluster_instance: bool
-
     @param hostname: Non-cluster SQL Instance hostname. Default is empty string.
     @type hostname: str
-
     @param cluster_instance_name: Name of Cluster SQL Instance. Default is empty string.
     @type cluster_instance_name: str
 
@@ -789,6 +787,24 @@ def get_sql_instance_naming_info(instance_name, is_cluster_instance=False, hostn
     return instance_title, full_sql_instance_name
 
 
+def get_proper_sql_instance_full_name(instance_full_name, is_cluster_instance, hostname='', cluster_instance_name=''):
+    """
+    Get proper instance full name by filter out default SQL Instance name ('MSSQLSERVER')
+    :param instnace_name:
+    :return:
+    """
+    proper_sql_instance_full_name = instance_full_name
+
+    if is_cluster_instance:
+        if instance_full_name == 'MSSQLSERVER':
+            proper_sql_instance_full_name = cluster_instance_name
+    else:
+        if instance_full_name == 'MSSQLSERVER':
+            proper_sql_instance_full_name = hostname
+
+    return proper_sql_instance_full_name
+
+
 def use_sql_always_on(device):
     """
     Determines whether to use SQL Always On functionality based on information taken from provided Device proxy.
@@ -805,3 +821,276 @@ def use_sql_always_on(device):
     device_class_name = getattr(device, 'getDeviceClassName', '')
 
     return sql_always_on_enabled and 'Microsoft/Cluster' in device_class_name
+
+
+def get_ao_sql_instance_id(prep_id_method, instance_name='', is_cluster_sql_instnace=False, instance_hostnmane='',
+                           sql_server_instance_full_name=''):
+    """
+    Returns SQL Instance ID to be use in Zenoss component path. If valid sql_server_instance_full_name is provided - it
+    will used straightaway (with prep_id_method processing)
+    """
+
+    # If sql_server_instance_full_name is provided - use it straightaway
+    if isinstance(sql_server_instance_full_name, basestring) and sql_server_instance_full_name:
+        return prep_id_method(sql_server_instance_full_name)
+
+    if not isinstance(is_cluster_sql_instnace, bool) or \
+            not prep_id_method or \
+            not instance_name:
+        return None
+
+    if not is_cluster_sql_instnace and not instance_hostnmane:
+        return None
+
+    if is_cluster_sql_instnace:
+        name_for_id = instance_name
+    else:
+        name_for_id = '{}_{}'.format(instance_hostnmane, instance_name)
+
+    return prep_id_method(name_for_id)
+
+
+def lookup_cluster_member_state(value):
+    return {
+        0: 'Offline',
+        1: 'Online',
+        2: 'Partially Online',
+        3: 'Unknown',
+    }.get(value, 'unknown')
+
+
+def lookup_ag_state(value):
+    return {
+        0: 'Offline',
+        1: 'Online',
+    }.get(value, 'unknown')
+
+
+def lookup_ag_synchronization_health(value):
+    return {
+        0: 'Not healthy',
+        1: 'Partially healthy',
+        2: 'Healthy',
+    }.get(value, 'unknown')
+
+
+def lookup_ag_automated_backup_preference(value):
+    return {
+        0: 'Primary',
+        1: 'Secondary only',
+        2: 'Prefer Secondary',
+        3: 'Any Replica',
+    }.get(value, 'unknown')
+
+
+def lookup_ag_primary_recovery_health(value):
+    return {
+        0: 'In progress',
+        1: 'Online',
+    }.get(value, 'unknown')
+
+
+def lookup_ag_failure_condition_level(value):
+    return {
+        1: 'OnServerDown',
+        2: 'OnServerUnresponsive',
+        3: 'OnCriticalServerErrors',
+        4: 'OnModerateServerErrors',
+        5: 'OnAnyQualifiedFailureCondition',
+        6: 'Unknown',
+    }.get(value, 'unknown')
+
+
+def lookup_ag_cluster_type(value):
+    return {
+        0: 'WSFC',
+        1: 'None',
+        2: 'External',
+    }.get(value, 'unknown')
+
+
+def lookup_ag_quorum_state(value):
+    return {
+        0: 'Unknown quorum state',
+        1: 'Normal quorum',
+        2: 'Forced quorum',
+    }.get(value, 'unknown')
+
+
+def fill_ag_om(ag_om, ag_data, prep_id_method, sql_instance_data):
+    """
+    Fill ObjectMaps for Always On Availability Group.
+    """
+    for key, value in ag_data.iteritems():
+        if key == 'id':
+            setattr(ag_om, 'unigue_id', value)
+            continue  # Do not use AG internal SQL id as in case of all SQL Instance outage - AG will be deleted.
+            # use AG Cluster resource id instead:
+        if key == 'ag_res_id':
+            setattr(ag_om, 'id', prep_id_method(value))
+        if key == 'name':
+            setattr(ag_om, 'title', value)
+        if key == 'synchronization_health':
+            value = lookup_ag_synchronization_health(value)
+        if key == 'automated_backup_preference':
+            value = lookup_ag_automated_backup_preference(value)
+        if key == 'primary_recovery_health':
+            value = lookup_ag_primary_recovery_health(value)
+        if key == 'failure_condition_level':
+            value = lookup_ag_failure_condition_level(value)
+        if key == 'cluster_type':
+            value = lookup_ag_cluster_type(value)
+        if key == 'primary_replica_server_name':
+            continue  # relation to SQL Instance is set below.
+        setattr(ag_om, key, value)
+
+    sql_server_instance_full_name = sql_instance_data.get('sql_server_fullname') \
+                                    or ag_data.get('primary_replica_server_name')
+    sql_instance_name = sql_instance_data.get('sql_instance_name') or ag_data.get('sql_instance_name')
+    is_clustered_instance = sql_instance_data.get('is_clustered_instance') or ag_data.get('is_clustered_instance') \
+                            or False
+    sql_hostname = sql_instance_data.get('sql_hostname') or ag_data.get('sql_hostname')
+
+    sql_instance_id = get_ao_sql_instance_id(prep_id_method,
+                                             sql_instance_name,
+                                             is_clustered_instance,
+                                             sql_hostname,
+                                             sql_server_instance_full_name)
+    if sql_instance_id:
+        setattr(ag_om, 'set_winsqlinstance', sql_instance_id)
+
+    quorum_state = sql_instance_data.get('quorum_state')
+    if quorum_state:
+        setattr(ag_om, 'quorum_state', quorum_state)
+
+    return ag_om
+
+
+def lookup_ar_role(value):
+    return {
+        0: 'Resolving',
+        1: 'Primary',
+        2: 'Secondary',
+        3: 'Unknown'
+    }.get(value, 'unknown')
+
+
+def lookup_ar_operational_state(value):
+    return {
+        0: 'Pending failover',
+        1: 'Pending',
+        2: 'Online',
+        3: 'Offline',
+        4: 'Failed',
+        5: 'Failed no Quorum',
+        6: 'Unknown'
+    }.get(value, 'unknown')
+
+
+def lookup_ar_availability_mode(value):
+    return {
+        0: 'Asynchronous commit',
+        1: 'Synchronous commit',
+        2: 'Unknown',
+        4: 'Configuration only'
+    }.get(value, 'unknown')
+
+
+def lookup_ar_connection_state(value):
+    return {
+        0: 'Disconnected',
+        1: 'Connected',
+        2: 'Unknown'
+    }.get(value, 'unknown')
+
+
+def lookup_ar_synchronization_state(value):
+    return {
+        0: 'Not synchronizing',
+        1: 'Synchronizing',
+        2: 'Synchronized',
+        3: 'Unknown'
+    }.get(value, 'unknown')
+
+
+def lookup_ar_failover_mode(value):
+    return {
+        0: 'Automatic',
+        1: 'Manual',
+        2: 'External',
+        3: 'Unknown'
+    }.get(value, 'unknown')
+
+
+def lookup_ar_synchronization_health(value):
+    return {
+        0: 'Not healthy',
+        1: 'Partially healthy',
+        2: 'Healthy'
+    }.get(value, 'unknown')
+
+
+def fill_ar_om(om, data, prep_id_method, sql_instance_data):
+    """
+    Fill ObjectMaps for Always On Availability Replica.
+    """
+    for key, value in data.iteritems():
+        if key == 'id':
+            setattr(om, 'unigue_id', value)
+            value = prep_id_method(value)
+        if key == 'name':
+            setattr(om, 'title', value)
+        if key == 'role':
+            value = lookup_ar_role(value)
+        if key == 'state':
+            value = lookup_cluster_member_state(value)
+        if key == 'operational_state':
+            value = lookup_ar_operational_state(value)
+        if key == 'availability_mode':
+            value = lookup_ar_availability_mode(value)
+        if key == 'connection_state':
+            value = lookup_ar_connection_state(value)
+        if key == 'synchronization_state':
+            value = lookup_ar_synchronization_state(value)
+        if key == 'failover_mode':
+            value = lookup_ar_failover_mode(value)
+        if key == 'synchronization_health':
+            value = lookup_ar_synchronization_health(value)
+        setattr(om, key, value)
+
+    sql_server_instance_full_name = sql_instance_data.get('sql_server_fullname') \
+                                    or data.get('replica_server_name')
+    sql_instance_name = sql_instance_data.get('sql_instance_name') or data.get('sql_instance_name')
+    is_clustered_instance = sql_instance_data.get('is_clustered_instance') or data.get('is_clustered_instance') \
+                            or False
+    sql_hostname = sql_instance_data.get('sql_hostname') or data.get('sql_hostname')
+
+    sql_instance_id = get_ao_sql_instance_id(prep_id_method,
+                                             sql_instance_name,
+                                             is_clustered_instance,
+                                             sql_hostname,
+                                             sql_server_instance_full_name)
+    if sql_instance_id:
+        setattr(om, 'set_winsqlinstance', sql_instance_id)
+
+    return om
+
+
+def recursive_mapping_update(update_destination, update_source):
+    """
+    Similar to update() method of mapping, but perform it recursively.
+    """
+
+    if not all((isinstance(update_destination, collections.Mapping),
+               isinstance(update_source, collections.Mapping))):
+        return
+
+    def _recursive_mapping_update(_update_destination, _update_source):
+        for key, value in _update_source.items():
+            if isinstance(value, collections.Mapping):
+                _update_destination[key] = _recursive_mapping_update(_update_destination.get(key, {}), value)
+            else:
+                _update_destination[key] = value
+        return _update_destination
+
+    _recursive_mapping_update(update_destination, update_source)

--- a/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
+++ b/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
@@ -68,12 +68,16 @@ class_relationships:
   - ZenPacks.zenoss.Microsoft.Windows.OperatingSystem.OperatingSystem(clusterservices) 1:MC (os)ClusterService
   - ZenPacks.zenoss.Microsoft.Windows.OperatingSystem.OperatingSystem(clusternetworks) 1:MC (os)ClusterNetwork
   - ZenPacks.zenoss.Microsoft.Windows.OperatingSystem.OperatingSystem(clusternodes) 1:MC (os)ClusterNode
+  - ZenPacks.zenoss.Microsoft.Windows.OperatingSystem.OperatingSystem(winsqlavailabilitygroups) 1:MC (os)WinSQLAvailabilityGroup
   - ClusterService(clusterresources) 1:MC (clusterservice)ClusterResource
   - ClusterNode(clusterdisks) 1:MC (clusternode)ClusterDisk
   - ClusterNode(clusterinterfaces) 1:MC (clusternode)ClusterInterface
   - WinSQLInstance(backups) 1:MC (winsqlinstance)WinSQLBackup
   - WinSQLInstance(databases) 1:MC (winsqlinstance)WinSQLDatabase
   - WinSQLInstance(jobs) 1:MC (winsqlinstance)WinSQLJob
+  - WinSQLInstance(winsqlavailabilitygroups) 1:M (winsqlinstance)WinSQLAvailabilityGroup
+  - WinSQLAvailabilityGroup(winsqlavailabilityreplicas) 1:MC (winsqlavailabilitygroup)WinSQLAvailabilityReplica
+  - WinSQLInstance(winsqlavailabilityreplicas) 1:M (winsqlinstance)WinSQLAvailabilityReplica
   - TeamInterface(teaminterfaces) 1:M (teaminterface)Interface
 
 
@@ -757,3 +761,126 @@ classes:
     dynamicview_relations:
       impacts: []
       impacted_by: [winsqlinstance]
+
+  WinSQLInstanceHostedObject:
+    base: [zenpacklib.OSComponent]
+    properties:
+      DEFAULTS:
+        grid_display: false
+        default: None
+      cluster_node_server:
+        label: Cluster Node Server
+        api_backendtype: method
+        api_only: true
+      perfmon_instance:
+        label: Perfmon Counter Instance Name
+        api_backendtype: method
+        api_only: true
+      instancename:
+        label: Instance Name
+        api_backendtype: method
+        api_only: true
+      owner_node_ip:
+        label: Owner Node IP
+        api_backendtype: method
+        api_only: true
+
+  WinSQLAvailabilityGroup:
+    label: SQL Availability Group
+    base: [WinSQLInstanceHostedObject]
+    order: 14
+    properties:
+      DEFAULTS:
+        grid_display: false
+        default: None
+      getState:
+        label: State
+        api_only: true
+        api_backendtype: method
+        grid_display: true
+      unigue_id:
+        label: Unique ID
+      failover_type:
+        label: Failover Type
+      cluster_state:
+        label: Cluster State
+      cluster_type:
+        label: Cluster Type
+      synchronization_health:
+        label: Synchronization Health
+        grid_display: true
+      primary_recovery_health:
+        label: Primary Recovery Health
+        grid_display: true
+      health_check_timeout:
+        type: int
+        label: Health Check Timeout
+        grid_display: true
+      automated_backup_preference:
+        label: Automated Backup Preference
+        grid_display: true
+      failure_condition_level:
+        label: Failure condition level
+      quorum_state:
+        label: Quorum State
+        grid_display: true
+      db_level_health_detection:
+        type: boolean
+        label: Database Level Health Detection
+        grid_display: true
+      is_distributed:
+        type: boolean
+        label: Is distributed
+        grid_display: true
+    monitoring_templates: [WinAvailabilityGroup]
+
+  WinSQLAvailabilityGroupHostedObject:
+    base: [zenpacklib.OSComponent]
+    properties:
+      DEFAULTS:
+        grid_display: false
+        default: None
+      availability_group_name:
+        label: Availability Group Name
+        display: false
+        api_backendtype: method
+        api_only: true
+
+  WinSQLAvailabilityReplica:
+    label: SQL Availability Replica
+    base: [WinSQLInstanceHostedObject, WinSQLAvailabilityGroupHostedObject]
+    order: 15
+    properties:
+      DEFAULTS:
+        grid_display: false
+        default: None
+      state:
+        label: State
+        grid_display: true
+      unigue_id:
+        label: Unique ID
+      role:
+        label: Role
+        grid_display: true
+      failover_mode:
+        label: Failover Mode
+        grid_display: true
+      operational_state:
+        label: Operational State
+        grid_display: true
+      availability_mode:
+        label: Availability Mode
+        grid_display: true
+      synchronization_health:
+        label: Synchronization Health
+        grid_display: true
+      synchronization_state:
+        label: Synchronization State
+        grid_display: true
+      connection_state:
+        label: Connection State
+        grid_display: true
+      endpoint_url:
+        label: Endpoint Url
+    monitoring_templates: []
+


### PR DESCRIPTION
Implements ZPS-7435.

* Add Availability group component.
* Add monitoring, incremental modeling and events for Availability group component.
* Add WinSQLInstance(winsqlavailabilitygroups) 1:M (winsqlinstance)WinSQLAvailabilityGroup relation.
* Add Availability replica component.
* Add non-containing realtion to WinSQLInstance and containing relation to WinSQLAvailabilityGroup.

What were done described more detailed in Jira comments:
* [Availability group component](https://jira.zenoss.com/browse/ZPS-7363?focusedCommentId=183051&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-183051)
* [Availability replica component](https://jira.zenoss.com/browse/ZPS-7435?focusedCommentId=183521&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-183521)