### PR TITLE
Add migration script to update AlwaysOn relations

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/migrate/UpdateAlwaysOnRelations.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/migrate/UpdateAlwaysOnRelations.py
@@ -1,0 +1,38 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2021, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+
+from Products.ZenModel.migrate.Migrate import Version
+from Products.ZenModel.ZenPack import ZenPackMigration
+from Products.Zuul.interfaces import ICatalogTool
+from ZenPacks.zenoss.Microsoft.Windows.WinSQLInstance import WinSQLInstance
+from ZenPacks.zenoss.Microsoft.Windows.OperatingSystem import OperatingSystem
+
+import logging
+log = logging.getLogger("zen.migrate")
+
+
+class UpdateAlwaysOnRelations(ZenPackMigration):
+    """
+    Update relations for Always On component.
+    """
+    version = Version(3, 0, 0)
+
+    def migrate(self, pack):
+        log.debug(
+            "Update Always On relations"
+        )
+
+        catalog = ICatalogTool(pack.dmd.Devices)
+
+        for brain in catalog.search(types=[OperatingSystem, WinSQLInstance]):
+            try:
+                brain.getObject().buildRelations()
+            except Exception:
+                pass

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # or saved.  Do not modify them directly here.
 # NB: PACKAGES is deprecated
 NAME = "ZenPacks.zenoss.Microsoft.Windows"
-VERSION = "2.10.0"
+VERSION = "3.0.0"
 AUTHOR = "Zenoss"
 LICENSE = ""
 NAMESPACE_PACKAGES = ['ZenPacks', 'ZenPacks.zenoss', 'ZenPacks.zenoss.Microsoft']


### PR DESCRIPTION
Fixes ZPS-7466.

* Add migration script to update pre 3.0.0 components which have new Always On relations: 'OperatingSystem', 'WinSQLInstance'.
* Bump ZenPack version to actual release one.