### PR TITLE
Get proper Default instance original name

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinMSSQL.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinMSSQL.py
@@ -28,7 +28,8 @@ from ZenPacks.zenoss.Microsoft.Windows.utils import addLocalLibPath, \
     getSQLAssembly, filter_sql_stdout, prepare_zDBInstances, get_ao_sql_instance_id
 from ZenPacks.zenoss.Microsoft.Windows.utils import save, SqlConnection, use_sql_always_on, \
     parse_winrs_response, get_sql_instance_naming_info, recursive_mapping_update, \
-    get_console_output_from_parts, lookup_ag_quorum_state, fill_ag_om, fill_ar_om, fill_al_om, fill_adb_om
+    get_console_output_from_parts, lookup_ag_quorum_state, fill_ag_om, fill_ar_om, fill_al_om, fill_adb_om, \
+    get_sql_instance_original_name
 
 from txwinrm.WinRMClient import SingleCommandClient
 
@@ -651,8 +652,11 @@ class WinMSSQL(WinRMPlugin):
                         if replica_server_hostname and ag_owner_node_domain:
                             replica_hostname_fqdn = '{}.{}'.format(replica_server_hostname, ag_owner_node_domain)
 
-                        instance_title, sqlserver = get_sql_instance_naming_info(instance_name=replica_instance_original_name,
-                                                                                 hostname=replica_server_hostname)
+                        replica_instance_original_name = get_sql_instance_original_name(replica_instance_original_name,
+                                                                                        replica_server_hostname)
+
+                        instance_title, _ = get_sql_instance_naming_info(instance_name=replica_instance_original_name,
+                                                                         hostname=replica_server_hostname)
 
                         recursive_mapping_update(
                             results['sql_instances'][replica_server_name],

--- a/ZenPacks/zenoss/Microsoft/Windows/utils.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/utils.py
@@ -808,6 +808,32 @@ def get_sql_instance_naming_info(instance_name, is_cluster_instance=False, hostn
     return instance_title, full_sql_instance_name
 
 
+def get_sql_instance_original_name(instance_name, instance_hostname):
+    """
+    Return proper SQL Instance original name. Is useful when dealing with Default MS SQL Instances ('MSSQLSERVER').
+    In scope of local resources - Default instances retains 'MSSQLSERVER'. But when information is cross-nodes - these
+    instances are named after their hosted nodes (e.g node1, node2). This function returns 'MSSQLSERVER' when Instance
+    name is equal to its hostname.
+
+    @param instance_name: SQL Instance name.
+    @type instance_name: str
+    @param instance_hostname: SQL Instance hostname.
+    @type instance_hostname: str
+
+    @return: SQL Instance name as local resource.
+    @rtype: str
+    """
+    instance_original_name = instance_name
+
+    if not isinstance(instance_name, basestring) and not isinstance(instance_hostname, basestring):
+        return instance_original_name
+
+    if instance_name.lower().strip() == instance_hostname.lower().strip():
+        instance_original_name = 'MSSQLSERVER'
+
+    return instance_original_name
+
+
 def get_proper_sql_instance_full_name(instance_full_name, is_cluster_instance, hostname='', cluster_instance_name=''):
     """
     Get proper instance full name by filter out default SQL Instance name ('MSSQLSERVER')


### PR DESCRIPTION
Implements ZPS-7515.

Default SQL Instances are named after their Windows nodes. Need to take this
into consideration when operating with theirs original names.