### PR TITLE
Add DVI relations from Windows to Cluster device

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/Device.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/Device.py
@@ -228,22 +228,14 @@ class Device(schema.Device):
                 yield obj
 
     def all_clusterdevices(self):
-        """Look up for Windows Cluster devices based on all_clusterhosts method of Cluster device"""
-        try:
-            dc = self.getDmdRoot('Devices').getOrganizer(
-                '/Server/Microsoft/Cluster'
-            )
-        except Exception:
-            return
+        """Look up for Windows Cluster devices"""
+        cluster_devices = self.getClusterMachinesList()
 
-        results = ICatalogTool(dc).search(types=(
-            'ZenPacks.zenoss.Microsoft.Windows.ClusterDevice.ClusterDevice',
-        ))
-
-        for brain in results:
-            obj = brain.getObject()
-            if self in obj.all_clusterhosts():
-                yield obj
+        if cluster_devices:
+            for cluster_device in cluster_devices:
+                # check for not a string to avoid error response from getClusterMachinesList method
+                if not isinstance(cluster_device, basestring):
+                    yield cluster_device
 
 
 class DeviceLinkProvider(object):

--- a/ZenPacks/zenoss/Microsoft/Windows/Device.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/Device.py
@@ -227,6 +227,24 @@ class Device(schema.Device):
             if obj.ip == self.id:
                 yield obj
 
+    def all_clusterdevices(self):
+        """Look up for Windows Cluster devices based on all_clusterhosts method of Cluster device"""
+        try:
+            dc = self.getDmdRoot('Devices').getOrganizer(
+                '/Server/Microsoft/Cluster'
+            )
+        except Exception:
+            return
+
+        results = ICatalogTool(dc).search(types=(
+            'ZenPacks.zenoss.Microsoft.Windows.ClusterDevice.ClusterDevice',
+        ))
+
+        for brain in results:
+            obj = brain.getObject()
+            if self in obj.all_clusterhosts():
+                yield obj
+
 
 class DeviceLinkProvider(object):
     '''

--- a/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
+++ b/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
@@ -162,6 +162,7 @@ classes:
         - all_winsqlinstances
         - all_winrmiis
         - all_harddisks
+        - all_clusterdevices
       impacted_by: []
 
   ClusterDevice:
@@ -261,7 +262,7 @@ classes:
     dynamicview_views: [service_view]
     dynamicview_relations:
       impacts: []
-      impacted_by: [clusterdisks, clusterinterfaces]
+      impacted_by: [clusterdisks, clusterinterfaces, device]
     relationships:
       DEFAULTS:
         grid_display: false


### PR DESCRIPTION
Fixes ZPS-7514.

* Add DynamicView & Impact relations from Windows node (/Server/Microsoft/Windows device) to its Cluster device.
* Add DynamicView & Impact relations from Cluster device to its Node component.