### PR TITLE
Retry two 500 error for Perfmon datasource plugin

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
@@ -879,6 +879,13 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
                     'got "Unexpected Response" during receive, '
                     'attempting to receive again'
                 )
+            elif 'Illegal operation attempted on a registry key that has been marked for deletion' in e.message or \
+                    'Class not registered' in e.message:
+                retry, level, msg = (
+                    True,
+                    logging.DEBUG,
+                    'got "{}" during receive, attempting to receive again'.format(e.message)
+                )
             elif 'invalid selectors for the resource' in e.message:
                 retry, level, msg = (
                     False,


### PR DESCRIPTION
Fixes ZPS-5967.

Retry 'Class not registered' and 'Illegal operation attempted on a registry key that has been marked for deletion' Windows errors for Perfmon datasource plugin
as these errors frequently occurs if new service account trying to use resources after previous was log off.
This may occurs for to quick shell reinitialization.
Also add unit test.