### PR TITLE
Pick the right node for Replicas performance counters

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/WinSQLAvailabilityGroup.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/WinSQLAvailabilityGroup.py
@@ -15,7 +15,7 @@ class WinSQLAvailabilityGroup(schema.WinSQLAvailabilityGroup):
     def getState(self):
         try:
             state = int(self.cacheRRDValue('AvailabilityGroupState_IsOnline', 0))
-        except:
+        except Exception:
             state = None
 
         status_representation = lookup_ag_state(state)

--- a/ZenPacks/zenoss/Microsoft/Windows/WinSQLAvailabilityReplica.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/WinSQLAvailabilityReplica.py
@@ -24,7 +24,7 @@ class WinSQLAvailabilityReplica(object, schema.WinSQLAvailabilityReplica):
         result = ''
 
         def local_node():
-            return '\\'
+            return ''
 
         def separate_node():
             perfdata_node = ''
@@ -59,7 +59,7 @@ class WinSQLAvailabilityReplica(object, schema.WinSQLAvailabilityReplica):
             if len(fullname_parts) == 2:
                 ar_owner_node = fullname_parts[0]
                 if ar_owner_node:
-                    perfdata_node = '\\\\{}\\'.format(ar_owner_node)
+                    perfdata_node = ar_owner_node
 
             return perfdata_node
 
@@ -81,3 +81,15 @@ class WinSQLAvailabilityReplica(object, schema.WinSQLAvailabilityReplica):
             result = node_location_mapping.get('default')()
 
         return result
+
+    def get_replica_perfdata_node_ip(self):
+        node_ip = ''
+
+        node = self.replica_perfdata_node
+        if node:
+            try:
+                node_ip = self.device().clusterhostdevicesdict.get(node)
+            except Exception as e:
+                pass
+
+        return node_ip

--- a/ZenPacks/zenoss/Microsoft/Windows/device_classes.yaml
+++ b/ZenPacks/zenoss/Microsoft/Windows/device_classes.yaml
@@ -2227,7 +2227,7 @@ device_classes:
                 rrdtype: GAUGE
                 rrdmin: 0
                 aliases: {bytes_rec_fr_repl__bytessec: null}
-            counter: ${here/replica_perfdata_node}${here/perfmon_instance}:Availability Replica(${here/availability_group_name}:${here/name})\Bytes Received from Replica/sec
+            counter: \${here/perfmon_instance}:Availability Replica(${here/availability_group_name}:${here/name})\Bytes Received from Replica/sec
           BytesSentToReplica:
             type: Windows Perfmon
             component: ${here/id}
@@ -2236,7 +2236,7 @@ device_classes:
                 rrdtype: GAUGE
                 rrdmin: 0
                 aliases: {bytes_snt_to_repl__bytessec: null}
-            counter: ${here/replica_perfdata_node}${here/perfmon_instance}:Availability Replica(${here/availability_group_name}:${here/name})\Bytes Sent to Replica/sec
+            counter: \${here/perfmon_instance}:Availability Replica(${here/availability_group_name}:${here/name})\Bytes Sent to Replica/sec
           BytesSentToTransport:
             type: Windows Perfmon
             component: ${here/id}
@@ -2245,7 +2245,7 @@ device_classes:
                 rrdtype: GAUGE
                 rrdmin: 0
                 aliases: {bytes_snt_to_trnsp__bytessec: null}
-            counter: ${here/replica_perfdata_node}${here/perfmon_instance}:Availability Replica(${here/availability_group_name}:${here/name})\Bytes Sent to Transport/sec
+            counter: \${here/perfmon_instance}:Availability Replica(${here/availability_group_name}:${here/name})\Bytes Sent to Transport/sec
           FlowControlTime:
             type: Windows Perfmon
             component: ${here/id}
@@ -2254,7 +2254,7 @@ device_classes:
                 rrdtype: GAUGE
                 rrdmin: 0
                 aliases: {flow_control_time__msecs: null}
-            counter: ${here/replica_perfdata_node}${here/perfmon_instance}:Availability Replica(${here/availability_group_name}:${here/name})\Flow Control Time (ms/sec)
+            counter: \${here/perfmon_instance}:Availability Replica(${here/availability_group_name}:${here/name})\Flow Control Time (ms/sec)
           FlowControl:
             type: Windows Perfmon
             component: ${here/id}
@@ -2263,7 +2263,7 @@ device_classes:
                 rrdtype: GAUGE
                 rrdmin: 0
                 aliases: {flow_control__persec: null}
-            counter: ${here/replica_perfdata_node}${here/perfmon_instance}:Availability Replica(${here/availability_group_name}:${here/name})\Flow Control/sec
+            counter: \${here/perfmon_instance}:Availability Replica(${here/availability_group_name}:${here/name})\Flow Control/sec
           ReceivesFromReplica:
             type: Windows Perfmon
             component: ${here/id}
@@ -2272,7 +2272,7 @@ device_classes:
                 rrdtype: GAUGE
                 rrdmin: 0
                 aliases: {receive_from_replica__persec: null}
-            counter: ${here/replica_perfdata_node}${here/perfmon_instance}:Availability Replica(${here/availability_group_name}:${here/name})\Receives from Replica/sec
+            counter: \${here/perfmon_instance}:Availability Replica(${here/availability_group_name}:${here/name})\Receives from Replica/sec
           ResentMessages:
             type: Windows Perfmon
             component: ${here/id}
@@ -2281,7 +2281,7 @@ device_classes:
                 rrdtype: GAUGE
                 rrdmin: 0
                 aliases: {resent_messages__persec: null}
-            counter: ${here/replica_perfdata_node}${here/perfmon_instance}:Availability Replica(${here/availability_group_name}:${here/name})\Resent Messages/sec
+            counter: \${here/perfmon_instance}:Availability Replica(${here/availability_group_name}:${here/name})\Resent Messages/sec
           SendsToReplica:
             type: Windows Perfmon
             component: ${here/id}
@@ -2290,7 +2290,7 @@ device_classes:
                 rrdtype: GAUGE
                 rrdmin: 0
                 aliases: {sends_to_replica__persec: null}
-            counter: ${here/replica_perfdata_node}${here/perfmon_instance}:Availability Replica(${here/availability_group_name}:${here/name})\Sends to Replica/sec
+            counter: \${here/perfmon_instance}:Availability Replica(${here/availability_group_name}:${here/name})\Sends to Replica/sec
           SendsToTransport:
             type: Windows Perfmon
             component: ${here/id}
@@ -2299,7 +2299,7 @@ device_classes:
                 rrdtype: GAUGE
                 rrdmin: 0
                 aliases: {sends_to_transport__persec: null}
-            counter: ${here/replica_perfdata_node}${here/perfmon_instance}:Availability Replica(${here/availability_group_name}:${here/name})\Sends to Transport/sec
+            counter: \${here/perfmon_instance}:Availability Replica(${here/availability_group_name}:${here/name})\Sends to Transport/sec
         graphs:
           Inter-Replicas Communication (bytes):
             units: bytes/sec

--- a/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
+++ b/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
@@ -946,6 +946,11 @@ classes:
         grid_display: true
       endpoint_url:
         label: Endpoint Url
+      replica_perfdata_node:
+        label: Replica Perfdata Node
+        display: false
+        api_backendtype: method
+        api_only: true
     monitoring_templates: [WinAvailabilityReplica]
     dynamicview_views: [service_view]
     dynamicview_relations:


### PR DESCRIPTION
Implements ZPS-7655.

AO Replicas performance counters are placed on other nodes unlike other counters. Need to pick up right Windows node for this type of counters.