### PR TITLE
Stop monitoring databases in specific statuses

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
+++ b/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
@@ -77,6 +77,11 @@ zProperties:
     type: lines
   zWinServicesNotModeled:
     type: lines
+  zWinDBStateMonitoringIgnore:
+    type: lines
+    default:
+      - Restoring
+      - Standby
 
 class_relationships:
   - ZenPacks.zenoss.Microsoft.Windows.OperatingSystem.OperatingSystem(winservices) 1:MC (os)WinService

--- a/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
+++ b/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
@@ -79,9 +79,6 @@ zProperties:
     type: lines
   zWinDBStateMonitoringIgnore:
     type: lines
-    default:
-      - Restoring
-      - Standby
 
 class_relationships:
   - ZenPacks.zenoss.Microsoft.Windows.OperatingSystem.OperatingSystem(winservices) 1:MC (os)WinService


### PR DESCRIPTION
Fixes ZPS-7867.

Add a zProperty in order to stop monitoring MSSQL databases
in STANDBY and RESTORING statuses.