### PR TITLE
retaining required zProp values

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/txwinrm_utils.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/txwinrm_utils.py
@@ -85,7 +85,7 @@ def createConnectionInfo(device_proxy):
     if re.match(r'[a-zA-Z0-9][a-zA-Z0-9.]{0,14}\\[^"/\\\[\]:;|=,+*?<>]{1,104}', username):
         raise UnauthorizedError("zWinRMUser must be user@example.com, not DOMAIN\User")
 
-    password = getProxyValue('windows_password', 'zWinRMPassword')
+    password = getProxyValue(['windows_password', 'zWinRMPassword'])
     if not password:
         raise UnauthorizedError("zWinRMPassword or zWinPassword must be configured")
 
@@ -154,7 +154,7 @@ def createConnectionInfo(device_proxy):
         include_dir=include_dir,
         disable_rdns=disable_rdns,
         connect_timeout=connect_timeout,
-        connection_close_time=connection_close_time
+        connection_close_time=connection_close_time,
     )
 
 

--- a/ZenPacks/zenoss/Microsoft/Windows/txwinrm_utils.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/txwinrm_utils.py
@@ -74,8 +74,6 @@ def createConnectionInfo(device_proxy):
     if not hostname:
         raise UnauthorizedError("Attempted Windows connection to non-Windows device")
 
-    hostname = getProxyValue(['windows_servername', 'zWinRMServerName', 'manageIp'])
-
     username = getProxyValue(['windows_user', 'zWinRMUser', 'zWinUser'])
     if not username:
         raise UnauthorizedError(

--- a/ZenPacks/zenoss/Microsoft/Windows/txwinrm_utils.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/txwinrm_utils.py
@@ -85,7 +85,7 @@ def createConnectionInfo(device_proxy):
 
     password = getProxyValue(['windows_password', 'zWinRMPassword'])
     if not password:
-        raise UnauthorizedError("zWinRMPassword or zWinPassword must be configured")
+        raise UnauthorizedError("zWinRMPassword must be configured")
 
     winKDC = getProxyValue(['zWinKDC', 'zWinTrustedKDC'])
     auth_type = 'kerberos' if '@' in username else 'basic'
@@ -93,7 +93,7 @@ def createConnectionInfo(device_proxy):
         raise UnauthorizedError("zWinKDC must be configured for domain authentication")
 
     scheme = getProxyValue('zWinScheme')
-    scheme = scheme if hasattr(scheme, 'lower') else ''
+    scheme = scheme.lower() if scheme else ''
     if scheme not in ('http', 'https'):
         raise UnauthorizedError("zWinScheme must be either 'http' or 'https'")
 
@@ -104,7 +104,7 @@ def createConnectionInfo(device_proxy):
         if port not in (5985, 80) and scheme == 'http':
             raise Exception()
     except Exception:
-        raise UnauthorizedError("zWinRMPort must be 5986 or 443 if zWinScheme is https")
+        raise UnauthorizedError("zWinRMPort must be 5986 or 443 if zWinScheme is https, or 5985 or 80 for http.")
 
     trusted_realm = getProxyValue('zWinTrustedRealm')
     trusted_kdc = getProxyValue('zWinTrustedKDC')


### PR DESCRIPTION
Potential fix for ZPS-8015, (if not, then this fixed another undiscovered bug)
The Windows ZenPack tries to be fancy by using 'windows_user', 'windows_password', and 'windows_servername' instead of the zProperties.  however, because these are method-properties of the base object and not zProperties defined in the yaml, zenoss-prodbin, can get really confused and not know what values to put into a proxy device. For CZ, zenmodeler and prodbin's ZenHub/service/ModelerService.py was not providing all the required values to complete a connection.