### PR TITLE
fix for zps-8015, adding support for method values in dsconf

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
@@ -263,6 +263,9 @@ class ComplexLongRunningCommand(object):
             # Some components, like Failover SQL Instances and MS SQL Availability Replicas may be placed not
             # on particular this device (node), but at another. So need to change connection info accordingly.
             # Also use zWinRMLongRunningCommandOperationTimeout for LongCommandClient
+            if not self.dsconf.zWinRMLongRunningCommandOperationTimeout:
+                self.dsconf.zWinRMLongRunningCommandOperationTimeout = 310
+                LOG.warn("Undefined value for PerfMon ds.conf zWinRMLongRunningCommandOperationTimeout, using default")
             additional_fields_to_replace = {'timeout': self.dsconf.zWinRMLongRunningCommandOperationTimeout}
             conn_info = modify_connection_info(conn_info, self.dsconf, additional_fields_to_replace)
             for _ in xrange(num_commands):

--- a/ZenPacks/zenoss/Microsoft/Windows/txwinrm_utils.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/txwinrm_utils.py
@@ -58,6 +58,8 @@ def createConnectionInfo(device_proxy):
     found to be invalid.
 
     """
+    update_dsconf(device_proxy)
+
     def getProxyValue(props):
         if not isinstance(props, list):
             props = [props]
@@ -189,6 +191,22 @@ def modify_connection_info(connection_info, datasource_config, data_to_reset=Non
 
     # Set fields which were provided additionally
     if isinstance(data_to_reset, dict):
+        for k, v in data_to_reset.iteritems():
+            if not v:
+                log.warn("Updating connection_info.%s to empty value.", k)
         connection_info = connection_info._replace(**data_to_reset)
 
     return connection_info
+
+def update_dsconf(dsconf):
+    if not dsconf:
+        return
+
+    if not getattr(dsconf, 'windows_user', None):
+        setattr(dsconf, 'windows_user', getattr(dsconf, 'zWinRMUser', ''))
+
+    if not getattr(dsconf, 'windows_password', None):
+        setattr(dsconf, 'windows_password', getattr(dsconf, 'zWinRMPassword', ''))
+
+    if not getattr(dsconf, 'windows_servername', None):
+        setattr(dsconf, 'windows_servername', getattr(dsconf, 'zWinRMServerName', ''))


### PR DESCRIPTION
updating winzenpack for handling method parameters values for zen modeler and zenpython.
fix for zps-8015