### PR TITLE
Strip zProperty from spaces and newlines

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/Services.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/Services.py
@@ -80,6 +80,7 @@ def validate_modeling_regex(device, log):
     model_list = create_regex_list(device, 'zWinServicesModeled', log)
     ignore_list = create_regex_list(device, 'zWinServicesNotModeled', log)
     group_list = create_regex_list(device, 'zWinServicesGroupedByClass', log)
+    group_list = [group.strip() for group in group_list if group.strip()]
     return model_list, ignore_list, group_list
 
 


### PR DESCRIPTION
Fixes ZPS-8115.

Stripped zWinServicesGroupedByClass zProperty
from spaces and newlines, etc.