### PR TITLE
Fix zWinServicesGroupedByClass inappropriate usage

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/Services.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/Services.py
@@ -115,6 +115,8 @@ def truncate_service_class(group_list, service_name, service_caption):
         for group in group_list:
             if re.search(group, service_name):
                 service_class_name = re.search(group, service_name).group(0)
-                service_class_caption = re.sub("(?:.(?!_.*))+$", '', service_caption)
+                matched_caption = re.sub("(?:.(?!_.*))+$", '', service_caption)
+                if matched_caption:
+                    service_class_caption = matched_caption
                 break
     return service_class_name, service_class_caption

--- a/docs/body.md
+++ b/docs/body.md
@@ -1294,9 +1294,10 @@ important.
 
 - zWinServicesGroupedByClass
     :   List of regular expressions for Windows services to model with generic Windows Service class. Specify class names to set generic Windows Service class names for matching Windows Services.
-        This property should be used when a target Windows device has a lot of Windows Services with rotating name extension - "<service_name>_0123456789bcdef". Each of these services creates separate Windows Service class.
-        Note: The regex is not anchored to the start of the service name. So we should specify correct generic Windows Class in zProperty values for services which Windows Class name should be truncated to specified zProperty value.
-        Example: In order to model all "CDPUserSvc_*" Windows Services under one generic Windows Service class we should specify "CDPUserSvc" in zProperty values.
+        This property appropriate use case is when a target Windows device has a lot of Windows Services with rotating name extension - "<service_name>_0123456789bcdef". 
+        In this case each Windows service creates a separate Windows Service class. So we can group these services by Windows Service generic class. This grouping will create only one Windows Service CLass for each service group.
+        Note: The regex is not anchored to the start of the service name. So we have to specify the correct generic Windows Class in zProperty values for services whose Windows Class name should be truncated to specific zProperty value.
+        Example: In order to model all "CDPUserSvc_*" Windows Services under one generic Windows Service class "CDPUserSvc" we should specify "CDPUserSvc" in zProperty values.
 
 
 Note: HyperV and MicrosoftWindows ZenPacks share krb5.conf file as
@@ -2063,7 +2064,8 @@ Changes
 
 - Add zWinDBStateMonitoringIgnore configuration property to disable monitoring of MS SQL databases in specified statuses (ZPS-7867)
 - Add zWinDBSnapshotIgnore configuration property to disable monitoring of MS SQL database snapshots (ZPS-7824)
-- Add zWinServicesSetGenericClass property for Windows Service classes to model services with generic Windows Service class. (ZPS-8115)
+- Fix MSSQL Always incorrect datamaps sending which cause large number of unnecessary datamaps and invalidations (ZPS-8074)
+- Add zWinServicesGroupedByClass property for Windows Service classes to model services with generic Windows Service class. (ZPS-8115)
 
 3.0.1
 


### PR DESCRIPTION
Fixes ZPS-8244.

Fixed cases where zProperty removes services captions
when it was used inproperly