### PR TITLE
Do not monitor disabled Windows Cluster Resources

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/ClusterResource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/ClusterResource.py
@@ -1,0 +1,35 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2023, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+from . import schema
+from ZenPacks.zenoss.Microsoft.Windows.WinService import WinService
+from Products.Zuul.interfaces import ICatalogTool
+
+
+class ClusterResource(schema.ClusterResource):
+    """
+    class for Cluster Resource.
+    """
+
+    def is_winservice_disabled(self):
+        if self.zWinClusterResourcesMonitoringDisabled:
+            host_device = self.get_host_device()
+            results = ICatalogTool(host_device).search(WinService)
+            for result in results:
+                try:
+                    service = result.getObject()
+                except Exception:
+                    continue
+                if self.winservice == service.id and service.startMode == "Disabled":
+                    return True
+                if service.caption == self.title and service.startMode == "Disabled":
+                    return True
+        return False
+
+    def monitored(self):
+        return not self.is_winservice_disabled()

--- a/ZenPacks/zenoss/Microsoft/Windows/__init__.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/__init__.py
@@ -1,6 +1,6 @@
 ##############################################################################
 #
-# Copyright (C) Zenoss, Inc. 2016-2019, all rights reserved.
+# Copyright (C) Zenoss, Inc. 2016-2023, all rights reserved.
 #
 # This content is made available according to terms specified in
 # License.zenoss under the directory where your Zenoss product is installed.
@@ -178,7 +178,10 @@ class ZenPack(schema.ZenPack):
                                                      'label': 'MS SQL Database Snapshots modeling disabled'},
                             'zWinServicesGroupedByClass': {'type': 'lines',
                                                      'description': 'List of regular expressions for Windows services to model with generic Windows Service class.',
-                                                     'label': 'Regex expressions to model services with generic class'}
+                                                     'label': 'Regex expressions to model services with generic class'},
+                            'zWinClusterResourcesMonitoringDisabled': {'type': 'boolean',
+                                                                       'description': 'Set to true to disable monitoring for Windows Cluster Resources if their corresponding Windows Service startup type is "Disabled".',
+                                                                       'label': 'Windows Cluster Resource monitoring disabling according to its corresponding Windows Service startup type'}
                             }
 
     def install(self, app):

--- a/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinCluster.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/modeler/plugins/zenoss/winrm/WinCluster.py
@@ -261,7 +261,7 @@ class WinCluster(WinRMPlugin):
             if app_ownergroup in ownergroups:
                 app_title = appline[0]
                 app_om = ObjectMap()
-                app_om.id = self.prepId('res-{0}'.format(appline[0]))
+                app_om.id = self.prepId('res-{0}'.format(app_title))
                 app_om.title = app_title
                 app_om.ownernode = appline[2]
                 app_om.description = appline[4]

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testClusterDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testClusterDataSource.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 ##############################################################################
 #
-# Copyright (C) Zenoss, Inc. 2015-2018, all rights reserved.
+# Copyright (C) Zenoss, Inc. 2015-2023, all rights reserved.
 #
 # This content is made available according to terms specified in
 # License.zenoss under the directory where your Zenoss product is installed.
@@ -70,7 +70,6 @@ RESULTS = {
     'res-SQL Server Analysis Services CEIP (CINSTANCE01)': 'Online',
     'res-SQL Server CEIP (CINSTANCE01)': 'Online',
     'res-Virtual Machine Cluster WMI': 'Failed',
-    '0f58359e-f0d9-4a96-a697-5213a4edfb9a': 'Online',
     'aa35b386-5182-4cf2-a99f-670788c11347': 'Failed',
     '109d14aa-234b-453b-b099-1a621cc59601': 'Online',
     'node-2': 'Up',
@@ -99,39 +98,79 @@ class TestClusterDataSourcePlugin(BaseTestCase):
 
     def setUp(self):
         self.plugin = ClusterDataSourcePlugin()
+        self.plugin.last_event_ts = {}
 
     @patch('ZenPacks.zenoss.Microsoft.Windows.datasources.ClusterDataSource.log', Mock())
     def test_onSuccess(self):
         config = load_pickle_file(self, 'cluster_config')
-        
+
         for datasource in config.datasources:
-            datasource.params.update({'collector_timeout':180})
-        
+            datasource.params.update({'collector_timeout': 180})
+            datasource.params.update({'disable_monitoring': False})
+
         results = CommandResponse(
             RAW_RESULTS['stdout'],
             RAW_RESULTS['stderr'],
             RAW_RESULTS['exit_code'])
         data = self.plugin.onSuccess(results, config)
-        self.assertEquals(len(data['values']), 25)
+        self.assertEquals(len(data['values']), 24)
         for comp, value in RESULTS.iteritems():
             try:
                 num = int(value)
                 value = cluster_disk_state_string(num)
                 self.assertEquals(data['values'][comp]['state'], num)
             except Exception:
-                self.assertEquals(data['values'][comp]['state'][0], cluster_state_value(value), 'found {}'.format(value))
+                self.assertEquals(data['values'][comp]['state'][0], cluster_state_value(value),
+                                  'found {}'.format(value))
         self.assertEquals(len(data['events']), 28)
         # 24989663232 is the freespace in the pickle file
         self.assertEquals(data['values']['860caaf4-595a-44e6-be70-285a9bb3733d']['freespace'], 24254611456)
 
         # test for ownerchange events
         results.stdout[11] = results.stdout[11].replace('win2016-node-01', 'win2016-node-02')
+        self.plugin.last_event_ts = {}
         data = self.plugin.onSuccess(results, config)
         self.assertEquals(len(data['events']), 29)
         results.stdout[11] = results.stdout[11].replace('win2016-node-02', 'win2016-node-01')
         results.stdout[12] = results.stdout[12].replace('win2016-node-02', 'win2016-node-01')
+        self.plugin.last_event_ts = {}
         data = self.plugin.onSuccess(results, config)
         self.assertEquals(len(data['events']), 29)
+
+    @patch('ZenPacks.zenoss.Microsoft.Windows.datasources.ClusterDataSource.log', Mock())
+    def test_onSuccess_monitor_false_all(self):
+        config = load_pickle_file(self, 'cluster_config')
+
+        for datasource in config.datasources:
+            datasource.params.update({'collector_timeout': 180})
+            datasource.params.update({'disable_monitoring': True})
+
+        results = CommandResponse(
+            RAW_RESULTS['stdout'],
+            RAW_RESULTS['stderr'],
+            RAW_RESULTS['exit_code'])
+        data = self.plugin.onSuccess(results, config)
+        self.assertEquals(len(data['events']), 4)
+        self.assertEquals(len(data['values']), 0)
+
+    @patch('ZenPacks.zenoss.Microsoft.Windows.datasources.ClusterDataSource.log', Mock())
+    def test_onSuccess_monitor_false_sample(self):
+        config = load_pickle_file(self, 'cluster_config')
+
+        i = 1
+        for datasource in config.datasources:
+            datasource.params.update({'collector_timeout': 180})
+            datasource.params.update({'disable_monitoring': True}) if i <= 10 else datasource.params.update(
+                {'disable_monitoring': False})
+            i += 1
+
+        results = CommandResponse(
+            RAW_RESULTS['stdout'],
+            RAW_RESULTS['stderr'],
+            RAW_RESULTS['exit_code'])
+        data = self.plugin.onSuccess(results, config)
+        self.assertEquals(len(data['events']), 18)
+        self.assertEquals(len(data['values']), 14)
 
     @patch('ZenPacks.zenoss.Microsoft.Windows.datasources.ClusterDataSource.log', Mock())
     def test_143596(self):
@@ -148,7 +187,8 @@ class TestClusterDataSourcePlugin(BaseTestCase):
                     'contexttitle': 'device',
                     'ownernode': 'IS-HVDRCL03-H04',
                     'cluster': 'IS-HVDRCL03.tcy.prv',
-                    'collector_timeout': 180
+                    'collector_timeout': 180,
+                    'disable_monitoring': False
                 },
                 datasource='DataSource',
                 component=component)
@@ -178,5 +218,6 @@ def test_suite():
 
 if __name__ == "__main__":
     from zope.testrunner.runner import Runner
+
     runner = Runner(found_suites=[test_suite()])
     runner.run()

--- a/ZenPacks/zenoss/Microsoft/Windows/tests/testWinCluster.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/tests/testWinCluster.py
@@ -2,7 +2,7 @@
 
 ##############################################################################
 #
-# Copyright (C) Zenoss, Inc. 2014-2018, all rights reserved.
+# Copyright (C) Zenoss, Inc. 2014-2023, all rights reserved.
 #
 # This content is made available according to terms specified in
 # License.zenoss under the directory where your Zenoss product is installed.
@@ -40,6 +40,7 @@ class TestProcesses(BaseTestCase):
             "====",
             "title0|title0|node0|state0|description0|cluster1"
         ]
+        self.results['generic_services'] = []
 
     def test_process(self):
         data = self.plugin.process(self.device, self.results, Mock())

--- a/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
+++ b/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
@@ -95,6 +95,11 @@ zProperties:
     description: 'List of regular expressions for Windows Service classes to model services with generic Windows Service class.'
     type: lines
     default: ['BcastDVRUserService', 'BluetoothUserService', 'CaptureService', 'CDPUserSvc', 'DevicePickerUserSvc', 'DevicesFlowUserSvc', 'MessagingService', 'OneSyncSvc', 'PimIndexMaintenanceSvc', 'PrintWorkflowUserSvc', 'UnistoreSvc', 'UserDataSvc', 'WpnUserService']
+  zWinClusterResourcesMonitoringDisabled:
+    label: 'Windows Cluster Resource monitoring disabling according to its corresponding Windows Service startup type'
+    description: 'Set to true to disable monitoring for Windows Cluster Resources if their corresponding Windows Service startup type is "Disabled".'
+    type: boolean
+    default: false
 
 
 class_relationships:
@@ -239,6 +244,14 @@ classes:
       cluster:
         label: Cluster
         grid_display: false
+      is_winservice_disabled:
+        type: boolean
+        label: Is WinService Disabled
+        grid_display: false
+        api_only: true
+        api_backendtype: method
+      winservice:
+        display: False
     monitoring_templates: [ClusterResource]
     dynamicview_views: [service_view]
     dynamicview_relations:

--- a/docs/body.md
+++ b/docs/body.md
@@ -1305,6 +1305,11 @@ important.
         Note: The regex is not anchored to the start of the service name. So we have to specify the correct generic Windows Class in zProperty values for services whose Windows Class name should be truncated to specific zProperty value.
         Example: In order to model all "CDPUserSvc_*" Windows Services under one generic Windows Service class "CDPUserSvc" we should specify "CDPUserSvc" in zProperty values.
 
+- zWinClusterResourcesMonitoringDisabled
+    :   Windows Cluster Resource monitoring disabling according to its corresponding Windows Service startup type.
+        Set to true to disable monitoring for Windows Cluster Resources if their corresponding Windows Service startup type is "Disabled".
+        To resume monitoring for these Windows Cluster Resource set the value to false and remodel the device manually or wait for the next remodeling cycle.
+
 
 Note: HyperV and MicrosoftWindows ZenPacks share krb5.conf file as
 well as tools for sending/receiving data. Therefore if either HyperV or
@@ -2017,6 +2022,7 @@ Configuration Properties
 :   zWinDBStateMonitoringIgnore
 :   zWinDBSnapshotIgnore
 :   zWinServicesGroupedByClass
+:   zWinClusterResourcesMonitoringDisabled
 
 Modeler Plugins 
 :   zenoss.winrm.CPUs 


### PR DESCRIPTION
Implements ZPS-8412.

Added new zProperty zWinClusterResourcesMonitoringDisabled which is responsible for Windows Cluster Resource monitoring disabling according to its corresponding Windows Service startup type. Added is_winservice_disabled attribute for Cluster Resource component to determine whether the corresponding WinService is disabled. It finds the specific WinService by its name or by new winservice attribute that stores the value of the corresponding WinService ID if the Cluster Resource type is "Generic Service". Added and fixed unit tests.
Added documentation.