### PR TITLE
Add a log message for misconfigured counter

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/datasources/PerfmonDataSource.py
@@ -375,6 +375,10 @@ class PerfmonDataSourcePlugin(PythonDataSourcePlugin):
                     self.ps_counter_map[counter] = []
                 self.counter_map[counter].append((dsconf.component, dsconf.datasource, dsconf.eventClass))
                 self.ps_counter_map[counter].append((dsconf.component, dsconf.datasource))
+            else:
+                LOG.warn("Error during extraction counter from a datasource - {} for the component - {}. "
+                         "Check counter configuration on the device - {}.".format(dsconf.datasource, dsconf.component,
+                                                                                  self.config.id))
 
         self._build_commandlines()
 


### PR DESCRIPTION
Implements ZPS-8666.

Added a log message when misconfigured counter is
in the Perfmon datasource collection.