### PR TITLE
ZPS-8740 - Add Additional Per-User Windows Services

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/migrate/UpdatezWinServicesGroupedByClass.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/migrate/UpdatezWinServicesGroupedByClass.py
@@ -24,13 +24,16 @@ from ZenPacks.zenoss.Microsoft.Windows.Device import Device
 from ZenPacks.zenoss.Microsoft.Windows.ClusterDevice import ClusterDevice
 
 
-SERVICES_TO_ADD = ["BcastDVRUserService", "BluetoothUserService", "CaptureService", "CDPUserSvc", "DevicePickerUserSvc",
-                   "DevicesFlowUserSvc", "MessagingService", "OneSyncSvc", "PimIndexMaintenanceSvc",
-                   "PrintWorkflowUserSvc", "UnistoreSvc", "UserDataSvc", "WpnUserService"]
+SERVICES_TO_ADD = ["BcastDVRUserService", "BluetoothUserService", "CDPUserSvc"
+                   "CaptureService", "ConsentUxUserSvc",
+                   "CredentialEnrollmentManagerUserSvc", "DevicePickerUserSvc",
+                   "DevicesFlowUserSvc", "MessagingService", "OneSyncSvc", 
+                   "PimIndexMaintenanceSvc", "PrintWorkflowUserSvc", "UdkUserSvc",
+                   "UnistoreSvc", "UserDataSvc", "WpnUserService", "cbdhsvc"]
 
 
 class UpdatezWinServicesGroupedByClass(ZenPackMigration):
-    version = Version(3, 1, 0)
+    version = Version(3, 2, 0)
 
     def migrate(self, pack):
         log.info("Setting new default values %s to zWinServicesGroupedByClass", SERVICES_TO_ADD)

--- a/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
+++ b/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
@@ -94,7 +94,7 @@ zProperties:
     label: 'Regex expressions to model services with generic class'
     description: 'List of regular expressions for Windows Service classes to model services with generic Windows Service class.'
     type: lines
-    default: ['BcastDVRUserService', 'BluetoothUserService', 'CDPUserSvcCaptureService', 'ConsentUxUserSvc', 'CredentialEnrollmentManagerUserSvc', 'DevicePickerUserSvc', 'DevicesFlowUserSvc', 'MessagingService', 'OneSyncSvc', 'PimIndexMaintenanceSvc', 'PrintWorkflowUserSvc', 'UdkUserSvc', 'UnistoreSvc', 'UserDataSvc', 'WpnUserService', 'cbdhsvc']
+    default: ['BcastDVRUserService', 'BluetoothUserService', 'CaptureService', 'CDPUserSvc', 'ConsentUxUserSvc', 'CredentialEnrollmentManagerUserSvc', 'DevicePickerUserSvc', 'DevicesFlowUserSvc', 'MessagingService', 'OneSyncSvc', 'PimIndexMaintenanceSvc', 'PrintWorkflowUserSvc', 'UdkUserSvc', 'UnistoreSvc', 'UserDataSvc', 'WpnUserService', 'cbdhsvc']
   zWinClusterResourcesMonitoringDisabled:
     label: 'Windows Cluster Resource monitoring disabling according to its corresponding Windows Service startup type'
     description: 'Set to true to disable monitoring for Windows Cluster Resources if their corresponding Windows Service startup type is "Disabled".'

--- a/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
+++ b/ZenPacks/zenoss/Microsoft/Windows/zenpack.yaml
@@ -94,7 +94,7 @@ zProperties:
     label: 'Regex expressions to model services with generic class'
     description: 'List of regular expressions for Windows Service classes to model services with generic Windows Service class.'
     type: lines
-    default: ['BcastDVRUserService', 'BluetoothUserService', 'CaptureService', 'CDPUserSvc', 'DevicePickerUserSvc', 'DevicesFlowUserSvc', 'MessagingService', 'OneSyncSvc', 'PimIndexMaintenanceSvc', 'PrintWorkflowUserSvc', 'UnistoreSvc', 'UserDataSvc', 'WpnUserService']
+    default: ['BcastDVRUserService', 'BluetoothUserService', 'CDPUserSvcCaptureService', 'ConsentUxUserSvc', 'CredentialEnrollmentManagerUserSvc', 'DevicePickerUserSvc', 'DevicesFlowUserSvc', 'MessagingService', 'OneSyncSvc', 'PimIndexMaintenanceSvc', 'PrintWorkflowUserSvc', 'UdkUserSvc', 'UnistoreSvc', 'UserDataSvc', 'WpnUserService', 'cbdhsvc']
   zWinClusterResourcesMonitoringDisabled:
     label: 'Windows Cluster Resource monitoring disabling according to its corresponding Windows Service startup type'
     description: 'Set to true to disable monitoring for Windows Cluster Resources if their corresponding Windows Service startup type is "Disabled".'


### PR DESCRIPTION
Adding additional per-user Windows Services that were omitted from the Microsoft KB listing them. I'm reusing the same migration script but with a version bump.

ConsentUxUserSvc - Consent User Experience User Service.
cbdhsvc - Clipboard User Service
CredentialEnrollmentManagerUserSvc - Credential Enrollment Manager User Service in Windows.
UdkUserSvc - Undocked Dev Kit User Service