### PR TITLE
Fix ReindexWinServices job execution

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/handlers.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/handlers.py
@@ -42,7 +42,7 @@ def onServiceDataSourceMoved(ob, event):
 
         if dmd and not temporary:
             for job in dmd.JobManager.getPendingJobs():
-                if job.type == ReindexWinServices.getJobType():
+                if getattr(job, 'name') == "ZenPacks.zenoss.Microsoft.Windows.jobs.ReindexWinServices":
                     log.debug('handler: ReindexWinServices already pending')
                     return
 


### PR DESCRIPTION
Fixes ZPS-8862.

There is no "type" attr available for the job object. We will compare "name" attr with an actual name of the job.