### PR TITLE
Remove ‘Software’ modeler plugin from the defaults

### DIFF
--- a/ZenPacks/zenoss/Microsoft/Windows/device_classes.yaml
+++ b/ZenPacks/zenoss/Microsoft/Windows/device_classes.yaml
@@ -7,7 +7,7 @@ device_classes:
     protocol: WinRM
     zProperties:
       zPythonClass: ZenPacks.zenoss.Microsoft.Windows.Device
-      zCollectorPlugins: [zenoss.winrm.OperatingSystem, zenoss.winrm.CPUs, zenoss.winrm.FileSystems, zenoss.winrm.Interfaces, zenoss.winrm.Services, zenoss.winrm.Processes, zenoss.winrm.Software, zenoss.winrm.HardDisks]
+      zCollectorPlugins: [zenoss.winrm.OperatingSystem, zenoss.winrm.CPUs, zenoss.winrm.FileSystems, zenoss.winrm.Interfaces, zenoss.winrm.Services, zenoss.winrm.Processes, zenoss.winrm.HardDisks]
       zDeviceTemplates: [Device, Active Directory, IIS, MSExchange2010IS]
   /Server/Microsoft/Cluster:
     remove: true

--- a/ZenPacks/zenoss/Microsoft/Windows/migrate/RemoveSoftwareModelerPluginFromDefaults.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/migrate/RemoveSoftwareModelerPluginFromDefaults.py
@@ -1,0 +1,39 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2024, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+import logging
+from Products.ZenModel.ZenPack import ZenPackMigration
+from Products.ZenModel.migrate.Migrate import Version
+
+log = logging.getLogger("zen.migrate")
+
+
+class RemoveSoftwareModelerPluginFromDefaults(ZenPackMigration):
+    # Main class that contains the migrate() method.
+    # Note version setting.
+    version = Version(3, 1, 1)
+
+    def get_objects(self, pack):
+        objects = []
+        dcObject = pack.dmd.Devices.getOrganizer('/Server/Microsoft/Windows')
+        objects.append(dcObject)
+        objects.extend(dcObject.getOverriddenObjects("zCollectorPlugins", showDevices=True))
+        for ob in objects:
+            yield ob
+
+    def migrate(self, pack):
+        try:
+            for ob in self.get_objects(pack.dmd):
+                zCollectorPlugins = getattr(ob, "zCollectorPlugins", [])
+                if 'zenoss.winrm.Software' in zCollectorPlugins:
+                    zCollectorPlugins.remove('zenoss.winrm.Software')
+                    ob.setZenProperty('zCollectorPlugins', zCollectorPlugins)
+            log.info("Successfully removed ‘zenoss.winrm.Software’ modeler plugin from the defaults.")
+        except Exception as e:
+            log.warning("Failed to remove ‘zenoss.winrm.Software’ modeler plugin with a message - {}".format(e))

--- a/ZenPacks/zenoss/Microsoft/Windows/migrate/RemoveSoftwareModelerPluginFromDefaults.py
+++ b/ZenPacks/zenoss/Microsoft/Windows/migrate/RemoveSoftwareModelerPluginFromDefaults.py
@@ -19,9 +19,9 @@ class RemoveSoftwareModelerPluginFromDefaults(ZenPackMigration):
     # Note version setting.
     version = Version(3, 1, 1)
 
-    def get_objects(self, pack):
+    def get_objects(self, dmd):
         objects = []
-        dcObject = pack.dmd.Devices.getOrganizer('/Server/Microsoft/Windows')
+        dcObject = dmd.Devices.getOrganizer('/Server/Microsoft/Windows')
         objects.append(dcObject)
         objects.extend(dcObject.getOverriddenObjects("zCollectorPlugins", showDevices=True))
         for ob in objects:


### PR DESCRIPTION
Implements ZPS-8911.

Removed the 'Software' modeler plugin from the '/Server/Microsoft/Windows' device class defaults. Added a migration to delete the plugin for the already created devices.